### PR TITLE
Add public init functions to command block types

### DIFF
--- a/Sources/Valkey/Commands/BitmapCommands.swift
+++ b/Sources/Valkey/Commands/BitmapCommands.swift
@@ -41,6 +41,13 @@ public struct BITCOUNT: RESPCommand {
         @usableFromInline let end: Int
         @usableFromInline let unit: RangeUnit?
 
+
+        @inlinable public init(start: Int, end: Int, unit: RangeUnit? = nil) {
+            self.start = start
+            self.end = end
+            self.unit = unit
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -71,6 +78,12 @@ public struct BITFIELD: RESPCommand {
         @usableFromInline let encoding: String
         @usableFromInline let offset: Int
 
+
+        @inlinable public init(encoding: String, offset: Int) {
+            self.encoding = encoding
+            self.offset = offset
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -98,6 +111,13 @@ public struct BITFIELD: RESPCommand {
         @usableFromInline let offset: Int
         @usableFromInline let value: Int
 
+
+        @inlinable public init(encoding: String, offset: Int, value: Int) {
+            self.encoding = encoding
+            self.offset = offset
+            self.value = value
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -111,6 +131,13 @@ public struct BITFIELD: RESPCommand {
         @usableFromInline let encoding: String
         @usableFromInline let offset: Int
         @usableFromInline let increment: Int
+
+
+        @inlinable public init(encoding: String, offset: Int, increment: Int) {
+            self.encoding = encoding
+            self.offset = offset
+            self.increment = increment
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
@@ -136,6 +163,12 @@ public struct BITFIELD: RESPCommand {
     public struct OperationWrite: RESPRenderable {
         @usableFromInline let overflowBlock: OperationWriteOverflowBlock?
         @usableFromInline let writeOperation: OperationWriteWriteOperation
+
+
+        @inlinable public init(overflowBlock: OperationWriteOverflowBlock? = nil, writeOperation: OperationWriteWriteOperation) {
+            self.overflowBlock = overflowBlock
+            self.writeOperation = writeOperation
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
@@ -177,6 +210,12 @@ public struct BITFIELDRO: RESPCommand {
     public struct GetBlock: RESPRenderable {
         @usableFromInline let encoding: String
         @usableFromInline let offset: Int
+
+
+        @inlinable public init(encoding: String, offset: Int) {
+            self.encoding = encoding
+            self.offset = offset
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
@@ -254,6 +293,12 @@ public struct BITPOS: RESPCommand {
         @usableFromInline let end: Int
         @usableFromInline let unit: RangeEndUnitBlockUnit?
 
+
+        @inlinable public init(end: Int, unit: RangeEndUnitBlockUnit? = nil) {
+            self.end = end
+            self.unit = unit
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -265,6 +310,12 @@ public struct BITPOS: RESPCommand {
     public struct Range: RESPRenderable {
         @usableFromInline let start: Int
         @usableFromInline let endUnitBlock: RangeEndUnitBlock?
+
+
+        @inlinable public init(start: Int, endUnitBlock: RangeEndUnitBlock? = nil) {
+            self.start = start
+            self.endUnitBlock = endUnitBlock
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {

--- a/Sources/Valkey/Commands/ClusterCommands.swift
+++ b/Sources/Valkey/Commands/ClusterCommands.swift
@@ -45,6 +45,12 @@ public enum CLUSTER {
             @usableFromInline let startSlot: Int
             @usableFromInline let endSlot: Int
 
+
+            @inlinable public init(startSlot: Int, endSlot: Int) {
+                self.startSlot = startSlot
+                self.endSlot = endSlot
+            }
+
             @inlinable
             public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
                 var count = 0
@@ -129,6 +135,12 @@ public enum CLUSTER {
         public struct Range: RESPRenderable {
             @usableFromInline let startSlot: Int
             @usableFromInline let endSlot: Int
+
+
+            @inlinable public init(startSlot: Int, endSlot: Int) {
+                self.startSlot = startSlot
+                self.endSlot = endSlot
+            }
 
             @inlinable
             public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {

--- a/Sources/Valkey/Commands/ConnectionCommands.swift
+++ b/Sources/Valkey/Commands/ConnectionCommands.swift
@@ -514,6 +514,12 @@ public struct HELLO: RESPCommand {
         @usableFromInline let username: String
         @usableFromInline let password: String
 
+
+        @inlinable public init(username: String, password: String) {
+            self.username = username
+            self.password = password
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -526,6 +532,13 @@ public struct HELLO: RESPCommand {
         @usableFromInline let protover: Int
         @usableFromInline let auth: ArgumentsAuth?
         @usableFromInline let clientname: String?
+
+
+        @inlinable public init(protover: Int, auth: ArgumentsAuth? = nil, clientname: String? = nil) {
+            self.protover = protover
+            self.auth = auth
+            self.clientname = clientname
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {

--- a/Sources/Valkey/Commands/GenericCommands.swift
+++ b/Sources/Valkey/Commands/GenericCommands.swift
@@ -283,6 +283,12 @@ public struct MIGRATE: RESPCommand {
         @usableFromInline let username: String
         @usableFromInline let password: String
 
+
+        @inlinable public init(username: String, password: String) {
+            self.username = username
+            self.password = password
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -565,6 +571,12 @@ public struct SORT: RESPCommand {
         @usableFromInline let offset: Int
         @usableFromInline let count: Int
 
+
+        @inlinable public init(offset: Int, count: Int) {
+            self.offset = offset
+            self.count = count
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -615,6 +627,12 @@ public struct SORTRO: RESPCommand {
     public struct Limit: RESPRenderable {
         @usableFromInline let offset: Int
         @usableFromInline let count: Int
+
+
+        @inlinable public init(offset: Int, count: Int) {
+            self.offset = offset
+            self.count = count
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {

--- a/Sources/Valkey/Commands/GeoCommands.swift
+++ b/Sources/Valkey/Commands/GeoCommands.swift
@@ -41,6 +41,13 @@ public struct GEOADD: RESPCommand {
         @usableFromInline let latitude: Double
         @usableFromInline let member: String
 
+
+        @inlinable public init(longitude: Double, latitude: Double, member: String) {
+            self.longitude = longitude
+            self.latitude = latitude
+            self.member = member
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -162,6 +169,12 @@ public struct GEORADIUS: RESPCommand {
         @usableFromInline let count: Int
         @usableFromInline let any: Bool
 
+
+        @inlinable public init(count: Int, any: Bool = false) {
+            self.count = count
+            self.any = any
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -249,6 +262,12 @@ public struct GEORADIUSBYMEMBER: RESPCommand {
         @usableFromInline let count: Int
         @usableFromInline let any: Bool
 
+
+        @inlinable public init(count: Int, any: Bool = false) {
+            self.count = count
+            self.any = any
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -334,6 +353,12 @@ public struct GEORADIUSBYMEMBERRO: RESPCommand {
         @usableFromInline let count: Int
         @usableFromInline let any: Bool
 
+
+        @inlinable public init(count: Int, any: Bool = false) {
+            self.count = count
+            self.any = any
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -405,6 +430,12 @@ public struct GEORADIUSRO: RESPCommand {
         @usableFromInline let count: Int
         @usableFromInline let any: Bool
 
+
+        @inlinable public init(count: Int, any: Bool = false) {
+            self.count = count
+            self.any = any
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -462,6 +493,12 @@ public struct GEOSEARCH: RESPCommand {
         @usableFromInline let longitude: Double
         @usableFromInline let latitude: Double
 
+
+        @inlinable public init(longitude: Double, latitude: Double) {
+            self.longitude = longitude
+            self.latitude = latitude
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -502,6 +539,12 @@ public struct GEOSEARCH: RESPCommand {
         @usableFromInline let radius: Double
         @usableFromInline let unit: ByCircleUnit
 
+
+        @inlinable public init(radius: Double, unit: ByCircleUnit) {
+            self.radius = radius
+            self.unit = unit
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -530,6 +573,13 @@ public struct GEOSEARCH: RESPCommand {
         @usableFromInline let width: Double
         @usableFromInline let height: Double
         @usableFromInline let unit: ByBoxUnit
+
+
+        @inlinable public init(width: Double, height: Double, unit: ByBoxUnit) {
+            self.width = width
+            self.height = height
+            self.unit = unit
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
@@ -567,6 +617,12 @@ public struct GEOSEARCH: RESPCommand {
     public struct CountBlock: RESPRenderable {
         @usableFromInline let count: Int
         @usableFromInline let any: Bool
+
+
+        @inlinable public init(count: Int, any: Bool = false) {
+            self.count = count
+            self.any = any
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
@@ -609,6 +665,12 @@ public struct GEOSEARCHSTORE: RESPCommand {
         @usableFromInline let longitude: Double
         @usableFromInline let latitude: Double
 
+
+        @inlinable public init(longitude: Double, latitude: Double) {
+            self.longitude = longitude
+            self.latitude = latitude
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -649,6 +711,12 @@ public struct GEOSEARCHSTORE: RESPCommand {
         @usableFromInline let radius: Double
         @usableFromInline let unit: ByCircleUnit
 
+
+        @inlinable public init(radius: Double, unit: ByCircleUnit) {
+            self.radius = radius
+            self.unit = unit
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -677,6 +745,13 @@ public struct GEOSEARCHSTORE: RESPCommand {
         @usableFromInline let width: Double
         @usableFromInline let height: Double
         @usableFromInline let unit: ByBoxUnit
+
+
+        @inlinable public init(width: Double, height: Double, unit: ByBoxUnit) {
+            self.width = width
+            self.height = height
+            self.unit = unit
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
@@ -714,6 +789,12 @@ public struct GEOSEARCHSTORE: RESPCommand {
     public struct CountBlock: RESPRenderable {
         @usableFromInline let count: Int
         @usableFromInline let any: Bool
+
+
+        @inlinable public init(count: Int, any: Bool = false) {
+            self.count = count
+            self.any = any
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {

--- a/Sources/Valkey/Commands/HashCommands.swift
+++ b/Sources/Valkey/Commands/HashCommands.swift
@@ -179,6 +179,12 @@ public struct HMSET: RESPCommand {
         @usableFromInline let field: String
         @usableFromInline let value: String
 
+
+        @inlinable public init(field: String, value: String) {
+            self.field = field
+            self.value = value
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -207,6 +213,12 @@ public struct HRANDFIELD: RESPCommand {
     public struct Options: RESPRenderable {
         @usableFromInline let count: Int
         @usableFromInline let withvalues: Bool
+
+
+        @inlinable public init(count: Int, withvalues: Bool = false) {
+            self.count = count
+            self.withvalues = withvalues
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
@@ -257,6 +269,12 @@ public struct HSET: RESPCommand {
     public struct Data: RESPRenderable {
         @usableFromInline let field: String
         @usableFromInline let value: String
+
+
+        @inlinable public init(field: String, value: String) {
+            self.field = field
+            self.value = value
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {

--- a/Sources/Valkey/Commands/ServerCommands.swift
+++ b/Sources/Valkey/Commands/ServerCommands.swift
@@ -411,6 +411,12 @@ public enum CONFIG {
             @usableFromInline let parameter: String
             @usableFromInline let value: String
 
+
+            @inlinable public init(parameter: String, value: String) {
+                self.parameter = parameter
+                self.value = value
+            }
+
             @inlinable
             public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
                 var count = 0
@@ -674,6 +680,12 @@ public enum MODULE {
             @usableFromInline let name: String
             @usableFromInline let value: String
 
+
+            @inlinable public init(name: String, value: String) {
+                self.name = name
+                self.value = value
+            }
+
             @inlinable
             public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
                 var count = 0
@@ -834,6 +846,13 @@ public struct FAILOVER: RESPCommand {
         @usableFromInline let host: String
         @usableFromInline let port: Int
         @usableFromInline let force: Bool
+
+
+        @inlinable public init(host: String, port: Int, force: Bool = false) {
+            self.host = host
+            self.port = port
+            self.force = force
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
@@ -1007,6 +1026,12 @@ public struct REPLICAOF: RESPCommand {
         @usableFromInline let host: String
         @usableFromInline let port: Int
 
+
+        @inlinable public init(host: String, port: Int) {
+            self.host = host
+            self.port = port
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -1018,6 +1043,12 @@ public struct REPLICAOF: RESPCommand {
     public struct ArgsNoOne: RESPRenderable {
         @usableFromInline let no: Bool
         @usableFromInline let one: Bool
+
+
+        @inlinable public init(no: Bool = false, one: Bool = false) {
+            self.no = no
+            self.one = one
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
@@ -1144,6 +1175,12 @@ public struct SLAVEOF: RESPCommand {
         @usableFromInline let host: String
         @usableFromInline let port: Int
 
+
+        @inlinable public init(host: String, port: Int) {
+            self.host = host
+            self.port = port
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -1155,6 +1192,12 @@ public struct SLAVEOF: RESPCommand {
     public struct ArgsNoOne: RESPRenderable {
         @usableFromInline let no: Bool
         @usableFromInline let one: Bool
+
+
+        @inlinable public init(no: Bool = false, one: Bool = false) {
+            self.no = no
+            self.one = one
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {

--- a/Sources/Valkey/Commands/SortedSetCommands.swift
+++ b/Sources/Valkey/Commands/SortedSetCommands.swift
@@ -119,6 +119,12 @@ public struct ZADD: RESPCommand {
         @usableFromInline let score: Double
         @usableFromInline let member: String
 
+
+        @inlinable public init(score: Double, member: String) {
+            self.score = score
+            self.member = member
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -431,6 +437,12 @@ public struct ZRANDMEMBER: RESPCommand {
         @usableFromInline let count: Int
         @usableFromInline let withscores: Bool
 
+
+        @inlinable public init(count: Int, withscores: Bool = false) {
+            self.count = count
+            self.withscores = withscores
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -472,6 +484,12 @@ public struct ZRANGE: RESPCommand {
         @usableFromInline let offset: Int
         @usableFromInline let count: Int
 
+
+        @inlinable public init(offset: Int, count: Int) {
+            self.offset = offset
+            self.count = count
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -511,6 +529,12 @@ public struct ZRANGEBYLEX: RESPCommand {
         @usableFromInline let offset: Int
         @usableFromInline let count: Int
 
+
+        @inlinable public init(offset: Int, count: Int) {
+            self.offset = offset
+            self.count = count
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -543,6 +567,12 @@ public struct ZRANGEBYSCORE: RESPCommand {
     public struct Limit: RESPRenderable {
         @usableFromInline let offset: Int
         @usableFromInline let count: Int
+
+
+        @inlinable public init(offset: Int, count: Int) {
+            self.offset = offset
+            self.count = count
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
@@ -590,6 +620,12 @@ public struct ZRANGESTORE: RESPCommand {
     public struct Limit: RESPRenderable {
         @usableFromInline let offset: Int
         @usableFromInline let count: Int
+
+
+        @inlinable public init(offset: Int, count: Int) {
+            self.offset = offset
+            self.count = count
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
@@ -744,6 +780,12 @@ public struct ZREVRANGEBYLEX: RESPCommand {
         @usableFromInline let offset: Int
         @usableFromInline let count: Int
 
+
+        @inlinable public init(offset: Int, count: Int) {
+            self.offset = offset
+            self.count = count
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -776,6 +818,12 @@ public struct ZREVRANGEBYSCORE: RESPCommand {
     public struct Limit: RESPRenderable {
         @usableFromInline let offset: Int
         @usableFromInline let count: Int
+
+
+        @inlinable public init(offset: Int, count: Int) {
+            self.offset = offset
+            self.count = count
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {

--- a/Sources/Valkey/Commands/StreamCommands.swift
+++ b/Sources/Valkey/Commands/StreamCommands.swift
@@ -215,6 +215,12 @@ public enum XINFO {
             @usableFromInline let full: Bool
             @usableFromInline let count: Int?
 
+
+            @inlinable public init(full: Bool = false, count: Int? = nil) {
+                self.full = full
+                self.count = count
+            }
+
             @inlinable
             public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
                 var count = 0
@@ -291,6 +297,14 @@ public struct XADD: RESPCommand {
         @usableFromInline let threshold: String
         @usableFromInline let count: Int?
 
+
+        @inlinable public init(strategy: TrimStrategy, `operator`: TrimOperator? = nil, threshold: String, count: Int? = nil) {
+            self.strategy = strategy
+            self.`operator` = `operator`
+            self.threshold = threshold
+            self.count = count
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -316,6 +330,12 @@ public struct XADD: RESPCommand {
     public struct Data: RESPRenderable {
         @usableFromInline let field: String
         @usableFromInline let value: String
+
+
+        @inlinable public init(field: String, value: String) {
+            self.field = field
+            self.value = value
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
@@ -449,6 +469,15 @@ public struct XPENDING: RESPCommand {
         @usableFromInline let count: Int
         @usableFromInline let consumer: String?
 
+
+        @inlinable public init(minIdleTime: Int? = nil, start: String, end: String, count: Int, consumer: String? = nil) {
+            self.minIdleTime = minIdleTime
+            self.start = start
+            self.end = end
+            self.count = count
+            self.consumer = consumer
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -504,6 +533,12 @@ public struct XREAD: RESPCommand {
         @usableFromInline let key: [RESPKey]
         @usableFromInline let id: [String]
 
+
+        @inlinable public init(key: [RESPKey], id: [String]) {
+            self.key = key
+            self.id = id
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -535,6 +570,12 @@ public struct XREADGROUP: RESPCommand {
         @usableFromInline let group: String
         @usableFromInline let consumer: String
 
+
+        @inlinable public init(group: String, consumer: String) {
+            self.group = group
+            self.consumer = consumer
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -546,6 +587,12 @@ public struct XREADGROUP: RESPCommand {
     public struct Streams: RESPRenderable {
         @usableFromInline let key: [RESPKey]
         @usableFromInline let id: [String]
+
+
+        @inlinable public init(key: [RESPKey], id: [String]) {
+            self.key = key
+            self.id = id
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
@@ -649,6 +696,14 @@ public struct XTRIM: RESPCommand {
         @usableFromInline let `operator`: TrimOperator?
         @usableFromInline let threshold: String
         @usableFromInline let count: Int?
+
+
+        @inlinable public init(strategy: TrimStrategy, `operator`: TrimOperator? = nil, threshold: String, count: Int? = nil) {
+            self.strategy = strategy
+            self.`operator` = `operator`
+            self.threshold = threshold
+            self.count = count
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {

--- a/Sources/Valkey/Commands/StringCommands.swift
+++ b/Sources/Valkey/Commands/StringCommands.swift
@@ -267,6 +267,12 @@ public struct MSET: RESPCommand {
         @usableFromInline let key: RESPKey
         @usableFromInline let value: String
 
+
+        @inlinable public init(key: RESPKey, value: String) {
+            self.key = key
+            self.value = value
+        }
+
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
             var count = 0
@@ -293,6 +299,12 @@ public struct MSETNX: RESPCommand {
     public struct Data: RESPRenderable {
         @usableFromInline let key: RESPKey
         @usableFromInline let value: String
+
+
+        @inlinable public init(key: RESPKey, value: String) {
+            self.key = key
+            self.value = value
+        }
 
         @inlinable
         public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {

--- a/Sources/ValkeyCommandsBuilder/ValkeyCommandsRender.swift
+++ b/Sources/ValkeyCommandsBuilder/ValkeyCommandsRender.swift
@@ -88,6 +88,15 @@ extension String {
             )
         }
         self.append("\n")
+        let commandParametersString =
+            arguments
+            .map { "\($0.name.swiftVariable): \(parameterType($0, names: names, scope: nil, isArray: true))" }
+            .joined(separator: ", ")
+        self.append("\n\(tab)        @inlinable public init(\(commandParametersString)) {\n")
+        for arg in arguments {
+            self.append("\(tab)            self.\(arg.name.swiftVariable) = \(arg.name.swiftVariable)\n")
+        }
+        self.append("\(tab)        }\n\n")
         self.append("\(tab)        @inlinable\n")
         self.append("\(tab)        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {\n")
         self.append("\(tab)            var count = 0\n")


### PR DESCRIPTION
Command generator was creating init functions for types used within commands. Now it is