### PR TITLE
Precompute the RESPCommand length before writing

### DIFF
--- a/Sources/Valkey/Commands/BitmapCommands.swift
+++ b/Sources/Valkey/Commands/BitmapCommands.swift
@@ -28,8 +28,15 @@ public struct BITCOUNT: RESPCommand {
         case byte
         case bit
 
+        public var respEntries: Int {
+            switch self {
+            case .byte: "BYTE".respEntries
+            case .bit: "BIT".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .byte: "BYTE".encode(into: &commandEncoder)
             case .bit: "BIT".encode(into: &commandEncoder)
@@ -49,12 +56,15 @@ public struct BITCOUNT: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += start.encode(into: &commandEncoder)
-            count += end.encode(into: &commandEncoder)
-            count += unit.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            start.respEntries + end.respEntries + unit.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            start.encode(into: &commandEncoder)
+            end.encode(into: &commandEncoder)
+            unit.encode(into: &commandEncoder)
         }
     }
     public typealias Response = Int
@@ -85,11 +95,14 @@ public struct BITFIELD: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += encoding.encode(into: &commandEncoder)
-            count += offset.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            encoding.respEntries + offset.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            encoding.encode(into: &commandEncoder)
+            offset.encode(into: &commandEncoder)
         }
     }
     public enum OperationWriteOverflowBlock: RESPRenderable, Sendable {
@@ -97,8 +110,16 @@ public struct BITFIELD: RESPCommand {
         case sat
         case fail
 
+        public var respEntries: Int {
+            switch self {
+            case .wrap: "WRAP".respEntries
+            case .sat: "SAT".respEntries
+            case .fail: "FAIL".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .wrap: "WRAP".encode(into: &commandEncoder)
             case .sat: "SAT".encode(into: &commandEncoder)
@@ -119,12 +140,15 @@ public struct BITFIELD: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += encoding.encode(into: &commandEncoder)
-            count += offset.encode(into: &commandEncoder)
-            count += value.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            encoding.respEntries + offset.respEntries + value.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            encoding.encode(into: &commandEncoder)
+            offset.encode(into: &commandEncoder)
+            value.encode(into: &commandEncoder)
         }
     }
     public struct OperationWriteWriteOperationIncrbyBlock: RESPRenderable, Sendable {
@@ -140,20 +164,30 @@ public struct BITFIELD: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += encoding.encode(into: &commandEncoder)
-            count += offset.encode(into: &commandEncoder)
-            count += increment.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            encoding.respEntries + offset.respEntries + increment.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            encoding.encode(into: &commandEncoder)
+            offset.encode(into: &commandEncoder)
+            increment.encode(into: &commandEncoder)
         }
     }
     public enum OperationWriteWriteOperation: RESPRenderable, Sendable {
         case setBlock(OperationWriteWriteOperationSetBlock)
         case incrbyBlock(OperationWriteWriteOperationIncrbyBlock)
 
+        public var respEntries: Int {
+            switch self {
+            case .setBlock(let setBlock): RESPWithToken("SET", setBlock).respEntries
+            case .incrbyBlock(let incrbyBlock): RESPWithToken("INCRBY", incrbyBlock).respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .setBlock(let setBlock): RESPWithToken("SET", setBlock).encode(into: &commandEncoder)
             case .incrbyBlock(let incrbyBlock): RESPWithToken("INCRBY", incrbyBlock).encode(into: &commandEncoder)
@@ -171,19 +205,29 @@ public struct BITFIELD: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += RESPWithToken("OVERFLOW", overflowBlock).encode(into: &commandEncoder)
-            count += writeOperation.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            RESPWithToken("OVERFLOW", overflowBlock).respEntries + writeOperation.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            RESPWithToken("OVERFLOW", overflowBlock).encode(into: &commandEncoder)
+            writeOperation.encode(into: &commandEncoder)
         }
     }
     public enum Operation: RESPRenderable, Sendable {
         case getBlock(OperationGetBlock)
         case write(OperationWrite)
 
+        public var respEntries: Int {
+            switch self {
+            case .getBlock(let getBlock): RESPWithToken("GET", getBlock).respEntries
+            case .write(let write): write.respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .getBlock(let getBlock): RESPWithToken("GET", getBlock).encode(into: &commandEncoder)
             case .write(let write): write.encode(into: &commandEncoder)
@@ -218,11 +262,14 @@ public struct BITFIELDRO: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += encoding.encode(into: &commandEncoder)
-            count += offset.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            encoding.respEntries + offset.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            encoding.encode(into: &commandEncoder)
+            offset.encode(into: &commandEncoder)
         }
     }
     public typealias Response = [RESPToken]
@@ -248,8 +295,17 @@ public struct BITOP: RESPCommand {
         case xor
         case not
 
+        public var respEntries: Int {
+            switch self {
+            case .and: "AND".respEntries
+            case .or: "OR".respEntries
+            case .xor: "XOR".respEntries
+            case .not: "NOT".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .and: "AND".encode(into: &commandEncoder)
             case .or: "OR".encode(into: &commandEncoder)
@@ -281,8 +337,15 @@ public struct BITPOS: RESPCommand {
         case byte
         case bit
 
+        public var respEntries: Int {
+            switch self {
+            case .byte: "BYTE".respEntries
+            case .bit: "BIT".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .byte: "BYTE".encode(into: &commandEncoder)
             case .bit: "BIT".encode(into: &commandEncoder)
@@ -300,11 +363,14 @@ public struct BITPOS: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += end.encode(into: &commandEncoder)
-            count += unit.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            end.respEntries + unit.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            end.encode(into: &commandEncoder)
+            unit.encode(into: &commandEncoder)
         }
     }
     public struct Range: RESPRenderable, Sendable {
@@ -318,11 +384,14 @@ public struct BITPOS: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += start.encode(into: &commandEncoder)
-            count += endUnitBlock.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            start.respEntries + endUnitBlock.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            start.encode(into: &commandEncoder)
+            endUnitBlock.encode(into: &commandEncoder)
         }
     }
     public typealias Response = Int

--- a/Sources/Valkey/Commands/ClusterCommands.swift
+++ b/Sources/Valkey/Commands/ClusterCommands.swift
@@ -52,11 +52,14 @@ public enum CLUSTER {
             }
 
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-                var count = 0
-                count += startSlot.encode(into: &commandEncoder)
-                count += endSlot.encode(into: &commandEncoder)
-                return count
+            public var respEntries: Int {
+                startSlot.respEntries + endSlot.respEntries
+            }
+
+            @inlinable
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
+                startSlot.encode(into: &commandEncoder)
+                endSlot.encode(into: &commandEncoder)
             }
         }
         public typealias Response = RESPToken
@@ -143,11 +146,14 @@ public enum CLUSTER {
             }
 
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-                var count = 0
-                count += startSlot.encode(into: &commandEncoder)
-                count += endSlot.encode(into: &commandEncoder)
-                return count
+            public var respEntries: Int {
+                startSlot.respEntries + endSlot.respEntries
+            }
+
+            @inlinable
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
+                startSlot.encode(into: &commandEncoder)
+                endSlot.encode(into: &commandEncoder)
             }
         }
         public typealias Response = RESPToken
@@ -169,8 +175,15 @@ public enum CLUSTER {
             case force
             case takeover
 
+            public var respEntries: Int {
+                switch self {
+                case .force: "FORCE".respEntries
+                case .takeover: "TAKEOVER".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .force: "FORCE".encode(into: &commandEncoder)
                 case .takeover: "TAKEOVER".encode(into: &commandEncoder)
@@ -383,8 +396,15 @@ public enum CLUSTER {
             case hard
             case soft
 
+            public var respEntries: Int {
+                switch self {
+                case .hard: "HARD".respEntries
+                case .soft: "SOFT".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .hard: "HARD".encode(into: &commandEncoder)
                 case .soft: "SOFT".encode(into: &commandEncoder)
@@ -440,8 +460,17 @@ public enum CLUSTER {
             case node(String)
             case stable
 
+            public var respEntries: Int {
+                switch self {
+                case .importing(let importing): RESPWithToken("IMPORTING", importing).respEntries
+                case .migrating(let migrating): RESPWithToken("MIGRATING", migrating).respEntries
+                case .node(let node): RESPWithToken("NODE", node).respEntries
+                case .stable: "STABLE".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .importing(let importing): RESPWithToken("IMPORTING", importing).encode(into: &commandEncoder)
                 case .migrating(let migrating): RESPWithToken("MIGRATING", migrating).encode(into: &commandEncoder)

--- a/Sources/Valkey/Commands/ConnectionCommands.swift
+++ b/Sources/Valkey/Commands/ConnectionCommands.swift
@@ -30,8 +30,15 @@ public enum CLIENT {
             case yes
             case no
 
+            public var respEntries: Int {
+                switch self {
+                case .yes: "YES".respEntries
+                case .no: "NO".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .yes: "YES".encode(into: &commandEncoder)
                 case .no: "NO".encode(into: &commandEncoder)
@@ -125,8 +132,18 @@ public enum CLIENT {
             case replica
             case pubsub
 
+            public var respEntries: Int {
+                switch self {
+                case .normal: "NORMAL".respEntries
+                case .master: "MASTER".respEntries
+                case .slave: "SLAVE".respEntries
+                case .replica: "REPLICA".respEntries
+                case .pubsub: "PUBSUB".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .normal: "NORMAL".encode(into: &commandEncoder)
                 case .master: "MASTER".encode(into: &commandEncoder)
@@ -140,8 +157,15 @@ public enum CLIENT {
             case yes
             case no
 
+            public var respEntries: Int {
+                switch self {
+                case .yes: "YES".respEntries
+                case .no: "NO".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .yes: "YES".encode(into: &commandEncoder)
                 case .no: "NO".encode(into: &commandEncoder)
@@ -156,8 +180,19 @@ public enum CLIENT {
             case laddr(String?)
             case skipme(FilterNewFormatSkipme?)
 
+            public var respEntries: Int {
+                switch self {
+                case .clientId(let clientId): RESPWithToken("ID", clientId).respEntries
+                case .clientType(let clientType): RESPWithToken("TYPE", clientType).respEntries
+                case .username(let username): RESPWithToken("USER", username).respEntries
+                case .addr(let addr): RESPWithToken("ADDR", addr).respEntries
+                case .laddr(let laddr): RESPWithToken("LADDR", laddr).respEntries
+                case .skipme(let skipme): RESPWithToken("SKIPME", skipme).respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .clientId(let clientId): RESPWithToken("ID", clientId).encode(into: &commandEncoder)
                 case .clientType(let clientType): RESPWithToken("TYPE", clientType).encode(into: &commandEncoder)
@@ -172,8 +207,15 @@ public enum CLIENT {
             case oldFormat(String)
             case newFormat([FilterNewFormat])
 
+            public var respEntries: Int {
+                switch self {
+                case .oldFormat(let oldFormat): oldFormat.respEntries
+                case .newFormat(let newFormat): newFormat.respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .oldFormat(let oldFormat): oldFormat.encode(into: &commandEncoder)
                 case .newFormat(let newFormat): newFormat.encode(into: &commandEncoder)
@@ -201,8 +243,17 @@ public enum CLIENT {
             case replica
             case pubsub
 
+            public var respEntries: Int {
+                switch self {
+                case .normal: "NORMAL".respEntries
+                case .master: "MASTER".respEntries
+                case .replica: "REPLICA".respEntries
+                case .pubsub: "PUBSUB".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .normal: "NORMAL".encode(into: &commandEncoder)
                 case .master: "MASTER".encode(into: &commandEncoder)
@@ -232,8 +283,15 @@ public enum CLIENT {
             case on
             case off
 
+            public var respEntries: Int {
+                switch self {
+                case .on: "ON".respEntries
+                case .off: "OFF".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .on: "ON".encode(into: &commandEncoder)
                 case .off: "OFF".encode(into: &commandEncoder)
@@ -259,8 +317,15 @@ public enum CLIENT {
             case on
             case off
 
+            public var respEntries: Int {
+                switch self {
+                case .on: "ON".respEntries
+                case .off: "OFF".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .on: "ON".encode(into: &commandEncoder)
                 case .off: "OFF".encode(into: &commandEncoder)
@@ -286,8 +351,15 @@ public enum CLIENT {
             case write
             case all
 
+            public var respEntries: Int {
+                switch self {
+                case .write: "WRITE".respEntries
+                case .all: "ALL".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .write: "WRITE".encode(into: &commandEncoder)
                 case .all: "ALL".encode(into: &commandEncoder)
@@ -316,8 +388,16 @@ public enum CLIENT {
             case off
             case skip
 
+            public var respEntries: Int {
+                switch self {
+                case .on: "ON".respEntries
+                case .off: "OFF".respEntries
+                case .skip: "SKIP".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .on: "ON".encode(into: &commandEncoder)
                 case .off: "OFF".encode(into: &commandEncoder)
@@ -344,8 +424,15 @@ public enum CLIENT {
             case libname(String)
             case libver(String)
 
+            public var respEntries: Int {
+                switch self {
+                case .libname(let libname): RESPWithToken("LIB-NAME", libname).respEntries
+                case .libver(let libver): RESPWithToken("LIB-VER", libver).respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .libname(let libname): RESPWithToken("LIB-NAME", libname).encode(into: &commandEncoder)
                 case .libver(let libver): RESPWithToken("LIB-VER", libver).encode(into: &commandEncoder)
@@ -386,8 +473,15 @@ public enum CLIENT {
             case on
             case off
 
+            public var respEntries: Int {
+                switch self {
+                case .on: "ON".respEntries
+                case .off: "OFF".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .on: "ON".encode(into: &commandEncoder)
                 case .off: "OFF".encode(into: &commandEncoder)
@@ -438,8 +532,15 @@ public enum CLIENT {
             case timeout
             case error
 
+            public var respEntries: Int {
+                switch self {
+                case .timeout: "TIMEOUT".respEntries
+                case .error: "ERROR".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .timeout: "TIMEOUT".encode(into: &commandEncoder)
                 case .error: "ERROR".encode(into: &commandEncoder)
@@ -521,11 +622,14 @@ public struct HELLO: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += username.encode(into: &commandEncoder)
-            count += password.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            username.respEntries + password.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            username.encode(into: &commandEncoder)
+            password.encode(into: &commandEncoder)
         }
     }
     public struct Arguments: RESPRenderable, Sendable {
@@ -541,12 +645,15 @@ public struct HELLO: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += protover.encode(into: &commandEncoder)
-            count += RESPWithToken("AUTH", auth).encode(into: &commandEncoder)
-            count += RESPWithToken("SETNAME", clientname).encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            protover.respEntries + RESPWithToken("AUTH", auth).respEntries + RESPWithToken("SETNAME", clientname).respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            protover.encode(into: &commandEncoder)
+            RESPWithToken("AUTH", auth).encode(into: &commandEncoder)
+            RESPWithToken("SETNAME", clientname).encode(into: &commandEncoder)
         }
     }
     public typealias Response = [String: RESPToken]

--- a/Sources/Valkey/Commands/GenericCommands.swift
+++ b/Sources/Valkey/Commands/GenericCommands.swift
@@ -173,8 +173,17 @@ public struct EXPIRE: RESPCommand {
         case gt
         case lt
 
+        public var respEntries: Int {
+            switch self {
+            case .nx: "NX".respEntries
+            case .xx: "XX".respEntries
+            case .gt: "GT".respEntries
+            case .lt: "LT".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .nx: "NX".encode(into: &commandEncoder)
             case .xx: "XX".encode(into: &commandEncoder)
@@ -208,8 +217,17 @@ public struct EXPIREAT: RESPCommand {
         case gt
         case lt
 
+        public var respEntries: Int {
+            switch self {
+            case .nx: "NX".respEntries
+            case .xx: "XX".respEntries
+            case .gt: "GT".respEntries
+            case .lt: "LT".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .nx: "NX".encode(into: &commandEncoder)
             case .xx: "XX".encode(into: &commandEncoder)
@@ -271,8 +289,15 @@ public struct MIGRATE: RESPCommand {
         case key(RESPKey)
         case emptyString
 
+        public var respEntries: Int {
+            switch self {
+            case .key(let key): key.respEntries
+            case .emptyString: "".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .key(let key): key.encode(into: &commandEncoder)
             case .emptyString: "".encode(into: &commandEncoder)
@@ -290,19 +315,29 @@ public struct MIGRATE: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += username.encode(into: &commandEncoder)
-            count += password.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            username.respEntries + password.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            username.encode(into: &commandEncoder)
+            password.encode(into: &commandEncoder)
         }
     }
     public enum Authentication: RESPRenderable, Sendable {
         case auth(String)
         case auth2(AuthenticationAuth2)
 
+        public var respEntries: Int {
+            switch self {
+            case .auth(let auth): RESPWithToken("AUTH", auth).respEntries
+            case .auth2(let auth2): RESPWithToken("AUTH2", auth2).respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .auth(let auth): RESPWithToken("AUTH", auth).encode(into: &commandEncoder)
             case .auth2(let auth2): RESPWithToken("AUTH2", auth2).encode(into: &commandEncoder)
@@ -378,8 +413,17 @@ public struct PEXPIRE: RESPCommand {
         case gt
         case lt
 
+        public var respEntries: Int {
+            switch self {
+            case .nx: "NX".respEntries
+            case .xx: "XX".respEntries
+            case .gt: "GT".respEntries
+            case .lt: "LT".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .nx: "NX".encode(into: &commandEncoder)
             case .xx: "XX".encode(into: &commandEncoder)
@@ -413,8 +457,17 @@ public struct PEXPIREAT: RESPCommand {
         case gt
         case lt
 
+        public var respEntries: Int {
+            switch self {
+            case .nx: "NX".respEntries
+            case .xx: "XX".respEntries
+            case .gt: "GT".respEntries
+            case .lt: "LT".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .nx: "NX".encode(into: &commandEncoder)
             case .xx: "XX".encode(into: &commandEncoder)
@@ -578,19 +631,29 @@ public struct SORT: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += offset.encode(into: &commandEncoder)
-            count += count.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            offset.respEntries + count.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            offset.encode(into: &commandEncoder)
+            count.encode(into: &commandEncoder)
         }
     }
     public enum Order: RESPRenderable, Sendable {
         case asc
         case desc
 
+        public var respEntries: Int {
+            switch self {
+            case .asc: "ASC".respEntries
+            case .desc: "DESC".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .asc: "ASC".encode(into: &commandEncoder)
             case .desc: "DESC".encode(into: &commandEncoder)
@@ -635,19 +698,29 @@ public struct SORTRO: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += offset.encode(into: &commandEncoder)
-            count += count.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            offset.respEntries + count.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            offset.encode(into: &commandEncoder)
+            count.encode(into: &commandEncoder)
         }
     }
     public enum Order: RESPRenderable, Sendable {
         case asc
         case desc
 
+        public var respEntries: Int {
+            switch self {
+            case .asc: "ASC".respEntries
+            case .desc: "DESC".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .asc: "ASC".encode(into: &commandEncoder)
             case .desc: "DESC".encode(into: &commandEncoder)

--- a/Sources/Valkey/Commands/GeoCommands.swift
+++ b/Sources/Valkey/Commands/GeoCommands.swift
@@ -28,8 +28,15 @@ public struct GEOADD: RESPCommand {
         case nx
         case xx
 
+        public var respEntries: Int {
+            switch self {
+            case .nx: "NX".respEntries
+            case .xx: "XX".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .nx: "NX".encode(into: &commandEncoder)
             case .xx: "XX".encode(into: &commandEncoder)
@@ -49,12 +56,15 @@ public struct GEOADD: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += longitude.encode(into: &commandEncoder)
-            count += latitude.encode(into: &commandEncoder)
-            count += member.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            longitude.respEntries + latitude.respEntries + member.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            longitude.encode(into: &commandEncoder)
+            latitude.encode(into: &commandEncoder)
+            member.encode(into: &commandEncoder)
         }
     }
     public typealias Response = Int
@@ -84,8 +94,17 @@ public struct GEODIST: RESPCommand {
         case ft
         case mi
 
+        public var respEntries: Int {
+            switch self {
+            case .m: "M".respEntries
+            case .km: "KM".respEntries
+            case .ft: "FT".respEntries
+            case .mi: "MI".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .m: "M".encode(into: &commandEncoder)
             case .km: "KM".encode(into: &commandEncoder)
@@ -156,8 +175,17 @@ public struct GEORADIUS: RESPCommand {
         case ft
         case mi
 
+        public var respEntries: Int {
+            switch self {
+            case .m: "M".respEntries
+            case .km: "KM".respEntries
+            case .ft: "FT".respEntries
+            case .mi: "MI".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .m: "M".encode(into: &commandEncoder)
             case .km: "KM".encode(into: &commandEncoder)
@@ -177,19 +205,29 @@ public struct GEORADIUS: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += RESPWithToken("COUNT", count).encode(into: &commandEncoder)
-            if self.any { count += "ANY".encode(into: &commandEncoder) }
-            return count
+        public var respEntries: Int {
+            RESPWithToken("COUNT", count).respEntries + "ANY".respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            RESPWithToken("COUNT", count).encode(into: &commandEncoder)
+            "ANY".encode(into: &commandEncoder)
         }
     }
     public enum Order: RESPRenderable, Sendable {
         case asc
         case desc
 
+        public var respEntries: Int {
+            switch self {
+            case .asc: "ASC".respEntries
+            case .desc: "DESC".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .asc: "ASC".encode(into: &commandEncoder)
             case .desc: "DESC".encode(into: &commandEncoder)
@@ -200,8 +238,15 @@ public struct GEORADIUS: RESPCommand {
         case storekey(RESPKey)
         case storedistkey(RESPKey)
 
+        public var respEntries: Int {
+            switch self {
+            case .storekey(let storekey): RESPWithToken("STORE", storekey).respEntries
+            case .storedistkey(let storedistkey): RESPWithToken("STOREDIST", storedistkey).respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .storekey(let storekey): RESPWithToken("STORE", storekey).encode(into: &commandEncoder)
             case .storedistkey(let storedistkey): RESPWithToken("STOREDIST", storedistkey).encode(into: &commandEncoder)
@@ -250,8 +295,17 @@ public struct GEORADIUSBYMEMBER: RESPCommand {
         case ft
         case mi
 
+        public var respEntries: Int {
+            switch self {
+            case .m: "M".respEntries
+            case .km: "KM".respEntries
+            case .ft: "FT".respEntries
+            case .mi: "MI".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .m: "M".encode(into: &commandEncoder)
             case .km: "KM".encode(into: &commandEncoder)
@@ -271,19 +325,29 @@ public struct GEORADIUSBYMEMBER: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += RESPWithToken("COUNT", count).encode(into: &commandEncoder)
-            if self.any { count += "ANY".encode(into: &commandEncoder) }
-            return count
+        public var respEntries: Int {
+            RESPWithToken("COUNT", count).respEntries + "ANY".respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            RESPWithToken("COUNT", count).encode(into: &commandEncoder)
+            "ANY".encode(into: &commandEncoder)
         }
     }
     public enum Order: RESPRenderable, Sendable {
         case asc
         case desc
 
+        public var respEntries: Int {
+            switch self {
+            case .asc: "ASC".respEntries
+            case .desc: "DESC".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .asc: "ASC".encode(into: &commandEncoder)
             case .desc: "DESC".encode(into: &commandEncoder)
@@ -294,8 +358,15 @@ public struct GEORADIUSBYMEMBER: RESPCommand {
         case storekey(RESPKey)
         case storedistkey(RESPKey)
 
+        public var respEntries: Int {
+            switch self {
+            case .storekey(let storekey): RESPWithToken("STORE", storekey).respEntries
+            case .storedistkey(let storedistkey): RESPWithToken("STOREDIST", storedistkey).respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .storekey(let storekey): RESPWithToken("STORE", storekey).encode(into: &commandEncoder)
             case .storedistkey(let storedistkey): RESPWithToken("STOREDIST", storedistkey).encode(into: &commandEncoder)
@@ -342,8 +413,17 @@ public struct GEORADIUSBYMEMBERRO: RESPCommand {
         case ft
         case mi
 
+        public var respEntries: Int {
+            switch self {
+            case .m: "M".respEntries
+            case .km: "KM".respEntries
+            case .ft: "FT".respEntries
+            case .mi: "MI".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .m: "M".encode(into: &commandEncoder)
             case .km: "KM".encode(into: &commandEncoder)
@@ -363,19 +443,29 @@ public struct GEORADIUSBYMEMBERRO: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += RESPWithToken("COUNT", count).encode(into: &commandEncoder)
-            if self.any { count += "ANY".encode(into: &commandEncoder) }
-            return count
+        public var respEntries: Int {
+            RESPWithToken("COUNT", count).respEntries + "ANY".respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            RESPWithToken("COUNT", count).encode(into: &commandEncoder)
+            "ANY".encode(into: &commandEncoder)
         }
     }
     public enum Order: RESPRenderable, Sendable {
         case asc
         case desc
 
+        public var respEntries: Int {
+            switch self {
+            case .asc: "ASC".respEntries
+            case .desc: "DESC".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .asc: "ASC".encode(into: &commandEncoder)
             case .desc: "DESC".encode(into: &commandEncoder)
@@ -420,8 +510,17 @@ public struct GEORADIUSRO: RESPCommand {
         case ft
         case mi
 
+        public var respEntries: Int {
+            switch self {
+            case .m: "M".respEntries
+            case .km: "KM".respEntries
+            case .ft: "FT".respEntries
+            case .mi: "MI".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .m: "M".encode(into: &commandEncoder)
             case .km: "KM".encode(into: &commandEncoder)
@@ -441,19 +540,29 @@ public struct GEORADIUSRO: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += RESPWithToken("COUNT", count).encode(into: &commandEncoder)
-            if self.any { count += "ANY".encode(into: &commandEncoder) }
-            return count
+        public var respEntries: Int {
+            RESPWithToken("COUNT", count).respEntries + "ANY".respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            RESPWithToken("COUNT", count).encode(into: &commandEncoder)
+            "ANY".encode(into: &commandEncoder)
         }
     }
     public enum Order: RESPRenderable, Sendable {
         case asc
         case desc
 
+        public var respEntries: Int {
+            switch self {
+            case .asc: "ASC".respEntries
+            case .desc: "DESC".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .asc: "ASC".encode(into: &commandEncoder)
             case .desc: "DESC".encode(into: &commandEncoder)
@@ -504,19 +613,29 @@ public struct GEOSEARCH: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += longitude.encode(into: &commandEncoder)
-            count += latitude.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            longitude.respEntries + latitude.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            longitude.encode(into: &commandEncoder)
+            latitude.encode(into: &commandEncoder)
         }
     }
     public enum From: RESPRenderable, Sendable {
         case member(String)
         case fromlonlat(FromFromlonlat)
 
+        public var respEntries: Int {
+            switch self {
+            case .member(let member): RESPWithToken("FROMMEMBER", member).respEntries
+            case .fromlonlat(let fromlonlat): RESPWithToken("FROMLONLAT", fromlonlat).respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .member(let member): RESPWithToken("FROMMEMBER", member).encode(into: &commandEncoder)
             case .fromlonlat(let fromlonlat): RESPWithToken("FROMLONLAT", fromlonlat).encode(into: &commandEncoder)
@@ -529,8 +648,17 @@ public struct GEOSEARCH: RESPCommand {
         case ft
         case mi
 
+        public var respEntries: Int {
+            switch self {
+            case .m: "M".respEntries
+            case .km: "KM".respEntries
+            case .ft: "FT".respEntries
+            case .mi: "MI".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .m: "M".encode(into: &commandEncoder)
             case .km: "KM".encode(into: &commandEncoder)
@@ -550,11 +678,14 @@ public struct GEOSEARCH: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += RESPWithToken("BYRADIUS", radius).encode(into: &commandEncoder)
-            count += unit.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            RESPWithToken("BYRADIUS", radius).respEntries + unit.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            RESPWithToken("BYRADIUS", radius).encode(into: &commandEncoder)
+            unit.encode(into: &commandEncoder)
         }
     }
     public enum ByBoxUnit: RESPRenderable, Sendable {
@@ -563,8 +694,17 @@ public struct GEOSEARCH: RESPCommand {
         case ft
         case mi
 
+        public var respEntries: Int {
+            switch self {
+            case .m: "M".respEntries
+            case .km: "KM".respEntries
+            case .ft: "FT".respEntries
+            case .mi: "MI".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .m: "M".encode(into: &commandEncoder)
             case .km: "KM".encode(into: &commandEncoder)
@@ -586,20 +726,30 @@ public struct GEOSEARCH: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += RESPWithToken("BYBOX", width).encode(into: &commandEncoder)
-            count += height.encode(into: &commandEncoder)
-            count += unit.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            RESPWithToken("BYBOX", width).respEntries + height.respEntries + unit.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            RESPWithToken("BYBOX", width).encode(into: &commandEncoder)
+            height.encode(into: &commandEncoder)
+            unit.encode(into: &commandEncoder)
         }
     }
     public enum By: RESPRenderable, Sendable {
         case circle(ByCircle)
         case box(ByBox)
 
+        public var respEntries: Int {
+            switch self {
+            case .circle(let circle): circle.respEntries
+            case .box(let box): box.respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .circle(let circle): circle.encode(into: &commandEncoder)
             case .box(let box): box.encode(into: &commandEncoder)
@@ -610,8 +760,15 @@ public struct GEOSEARCH: RESPCommand {
         case asc
         case desc
 
+        public var respEntries: Int {
+            switch self {
+            case .asc: "ASC".respEntries
+            case .desc: "DESC".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .asc: "ASC".encode(into: &commandEncoder)
             case .desc: "DESC".encode(into: &commandEncoder)
@@ -629,11 +786,14 @@ public struct GEOSEARCH: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += RESPWithToken("COUNT", count).encode(into: &commandEncoder)
-            if self.any { count += "ANY".encode(into: &commandEncoder) }
-            return count
+        public var respEntries: Int {
+            RESPWithToken("COUNT", count).respEntries + "ANY".respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            RESPWithToken("COUNT", count).encode(into: &commandEncoder)
+            "ANY".encode(into: &commandEncoder)
         }
     }
     public typealias Response = RESPToken
@@ -676,19 +836,29 @@ public struct GEOSEARCHSTORE: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += longitude.encode(into: &commandEncoder)
-            count += latitude.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            longitude.respEntries + latitude.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            longitude.encode(into: &commandEncoder)
+            latitude.encode(into: &commandEncoder)
         }
     }
     public enum From: RESPRenderable, Sendable {
         case member(String)
         case fromlonlat(FromFromlonlat)
 
+        public var respEntries: Int {
+            switch self {
+            case .member(let member): RESPWithToken("FROMMEMBER", member).respEntries
+            case .fromlonlat(let fromlonlat): RESPWithToken("FROMLONLAT", fromlonlat).respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .member(let member): RESPWithToken("FROMMEMBER", member).encode(into: &commandEncoder)
             case .fromlonlat(let fromlonlat): RESPWithToken("FROMLONLAT", fromlonlat).encode(into: &commandEncoder)
@@ -701,8 +871,17 @@ public struct GEOSEARCHSTORE: RESPCommand {
         case ft
         case mi
 
+        public var respEntries: Int {
+            switch self {
+            case .m: "M".respEntries
+            case .km: "KM".respEntries
+            case .ft: "FT".respEntries
+            case .mi: "MI".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .m: "M".encode(into: &commandEncoder)
             case .km: "KM".encode(into: &commandEncoder)
@@ -722,11 +901,14 @@ public struct GEOSEARCHSTORE: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += RESPWithToken("BYRADIUS", radius).encode(into: &commandEncoder)
-            count += unit.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            RESPWithToken("BYRADIUS", radius).respEntries + unit.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            RESPWithToken("BYRADIUS", radius).encode(into: &commandEncoder)
+            unit.encode(into: &commandEncoder)
         }
     }
     public enum ByBoxUnit: RESPRenderable, Sendable {
@@ -735,8 +917,17 @@ public struct GEOSEARCHSTORE: RESPCommand {
         case ft
         case mi
 
+        public var respEntries: Int {
+            switch self {
+            case .m: "M".respEntries
+            case .km: "KM".respEntries
+            case .ft: "FT".respEntries
+            case .mi: "MI".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .m: "M".encode(into: &commandEncoder)
             case .km: "KM".encode(into: &commandEncoder)
@@ -758,20 +949,30 @@ public struct GEOSEARCHSTORE: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += RESPWithToken("BYBOX", width).encode(into: &commandEncoder)
-            count += height.encode(into: &commandEncoder)
-            count += unit.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            RESPWithToken("BYBOX", width).respEntries + height.respEntries + unit.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            RESPWithToken("BYBOX", width).encode(into: &commandEncoder)
+            height.encode(into: &commandEncoder)
+            unit.encode(into: &commandEncoder)
         }
     }
     public enum By: RESPRenderable, Sendable {
         case circle(ByCircle)
         case box(ByBox)
 
+        public var respEntries: Int {
+            switch self {
+            case .circle(let circle): circle.respEntries
+            case .box(let box): box.respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .circle(let circle): circle.encode(into: &commandEncoder)
             case .box(let box): box.encode(into: &commandEncoder)
@@ -782,8 +983,15 @@ public struct GEOSEARCHSTORE: RESPCommand {
         case asc
         case desc
 
+        public var respEntries: Int {
+            switch self {
+            case .asc: "ASC".respEntries
+            case .desc: "DESC".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .asc: "ASC".encode(into: &commandEncoder)
             case .desc: "DESC".encode(into: &commandEncoder)
@@ -801,11 +1009,14 @@ public struct GEOSEARCHSTORE: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += RESPWithToken("COUNT", count).encode(into: &commandEncoder)
-            if self.any { count += "ANY".encode(into: &commandEncoder) }
-            return count
+        public var respEntries: Int {
+            RESPWithToken("COUNT", count).respEntries + "ANY".respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            RESPWithToken("COUNT", count).encode(into: &commandEncoder)
+            "ANY".encode(into: &commandEncoder)
         }
     }
     public typealias Response = Int

--- a/Sources/Valkey/Commands/HashCommands.swift
+++ b/Sources/Valkey/Commands/HashCommands.swift
@@ -187,11 +187,14 @@ public struct HMSET: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += field.encode(into: &commandEncoder)
-            count += value.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            field.respEntries + value.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            field.encode(into: &commandEncoder)
+            value.encode(into: &commandEncoder)
         }
     }
     public typealias Response = RESPToken
@@ -222,11 +225,14 @@ public struct HRANDFIELD: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += count.encode(into: &commandEncoder)
-            if self.withvalues { count += "WITHVALUES".encode(into: &commandEncoder) }
-            return count
+        public var respEntries: Int {
+            count.respEntries + "WITHVALUES".respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            count.encode(into: &commandEncoder)
+            "WITHVALUES".encode(into: &commandEncoder)
         }
     }
     public typealias Response = RESPToken
@@ -278,11 +284,14 @@ public struct HSET: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += field.encode(into: &commandEncoder)
-            count += value.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            field.respEntries + value.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            field.encode(into: &commandEncoder)
+            value.encode(into: &commandEncoder)
         }
     }
     public typealias Response = Int

--- a/Sources/Valkey/Commands/ListCommands.swift
+++ b/Sources/Valkey/Commands/ListCommands.swift
@@ -28,8 +28,15 @@ public struct BLMOVE: RESPCommand {
         case left
         case right
 
+        public var respEntries: Int {
+            switch self {
+            case .left: "LEFT".respEntries
+            case .right: "RIGHT".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .left: "LEFT".encode(into: &commandEncoder)
             case .right: "RIGHT".encode(into: &commandEncoder)
@@ -40,8 +47,15 @@ public struct BLMOVE: RESPCommand {
         case left
         case right
 
+        public var respEntries: Int {
+            switch self {
+            case .left: "LEFT".respEntries
+            case .right: "RIGHT".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .left: "LEFT".encode(into: &commandEncoder)
             case .right: "RIGHT".encode(into: &commandEncoder)
@@ -75,8 +89,15 @@ public struct BLMPOP: RESPCommand {
         case left
         case right
 
+        public var respEntries: Int {
+            switch self {
+            case .left: "LEFT".respEntries
+            case .right: "RIGHT".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .left: "LEFT".encode(into: &commandEncoder)
             case .right: "RIGHT".encode(into: &commandEncoder)
@@ -179,8 +200,15 @@ public struct LINSERT: RESPCommand {
         case before
         case after
 
+        public var respEntries: Int {
+            switch self {
+            case .before: "BEFORE".respEntries
+            case .after: "AFTER".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .before: "BEFORE".encode(into: &commandEncoder)
             case .after: "AFTER".encode(into: &commandEncoder)
@@ -227,8 +255,15 @@ public struct LMOVE: RESPCommand {
         case left
         case right
 
+        public var respEntries: Int {
+            switch self {
+            case .left: "LEFT".respEntries
+            case .right: "RIGHT".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .left: "LEFT".encode(into: &commandEncoder)
             case .right: "RIGHT".encode(into: &commandEncoder)
@@ -239,8 +274,15 @@ public struct LMOVE: RESPCommand {
         case left
         case right
 
+        public var respEntries: Int {
+            switch self {
+            case .left: "LEFT".respEntries
+            case .right: "RIGHT".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .left: "LEFT".encode(into: &commandEncoder)
             case .right: "RIGHT".encode(into: &commandEncoder)
@@ -272,8 +314,15 @@ public struct LMPOP: RESPCommand {
         case left
         case right
 
+        public var respEntries: Int {
+            switch self {
+            case .left: "LEFT".respEntries
+            case .right: "RIGHT".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .left: "LEFT".encode(into: &commandEncoder)
             case .right: "RIGHT".encode(into: &commandEncoder)

--- a/Sources/Valkey/Commands/ScriptingCommands.swift
+++ b/Sources/Valkey/Commands/ScriptingCommands.swift
@@ -58,8 +58,15 @@ public enum FUNCTION {
             case async
             case sync
 
+            public var respEntries: Int {
+                switch self {
+                case .async: "ASYNC".respEntries
+                case .sync: "SYNC".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .async: "ASYNC".encode(into: &commandEncoder)
                 case .sync: "SYNC".encode(into: &commandEncoder)
@@ -146,8 +153,16 @@ public enum FUNCTION {
             case append
             case replace
 
+            public var respEntries: Int {
+                switch self {
+                case .flush: "FLUSH".respEntries
+                case .append: "APPEND".respEntries
+                case .replace: "REPLACE".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .flush: "FLUSH".encode(into: &commandEncoder)
                 case .append: "APPEND".encode(into: &commandEncoder)
@@ -194,8 +209,16 @@ public enum SCRIPT {
             case sync
             case no
 
+            public var respEntries: Int {
+                switch self {
+                case .yes: "YES".respEntries
+                case .sync: "SYNC".respEntries
+                case .no: "NO".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .yes: "YES".encode(into: &commandEncoder)
                 case .sync: "SYNC".encode(into: &commandEncoder)
@@ -237,8 +260,15 @@ public enum SCRIPT {
             case async
             case sync
 
+            public var respEntries: Int {
+                switch self {
+                case .async: "ASYNC".respEntries
+                case .sync: "SYNC".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .async: "ASYNC".encode(into: &commandEncoder)
                 case .sync: "SYNC".encode(into: &commandEncoder)

--- a/Sources/Valkey/Commands/SortedSetCommands.swift
+++ b/Sources/Valkey/Commands/SortedSetCommands.swift
@@ -28,8 +28,15 @@ public struct BZMPOP: RESPCommand {
         case min
         case max
 
+        public var respEntries: Int {
+            switch self {
+            case .min: "MIN".respEntries
+            case .max: "MAX".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .min: "MIN".encode(into: &commandEncoder)
             case .max: "MAX".encode(into: &commandEncoder)
@@ -95,8 +102,15 @@ public struct ZADD: RESPCommand {
         case nx
         case xx
 
+        public var respEntries: Int {
+            switch self {
+            case .nx: "NX".respEntries
+            case .xx: "XX".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .nx: "NX".encode(into: &commandEncoder)
             case .xx: "XX".encode(into: &commandEncoder)
@@ -107,8 +121,15 @@ public struct ZADD: RESPCommand {
         case gt
         case lt
 
+        public var respEntries: Int {
+            switch self {
+            case .gt: "GT".respEntries
+            case .lt: "LT".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .gt: "GT".encode(into: &commandEncoder)
             case .lt: "LT".encode(into: &commandEncoder)
@@ -126,11 +147,14 @@ public struct ZADD: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += score.encode(into: &commandEncoder)
-            count += member.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            score.respEntries + member.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            score.encode(into: &commandEncoder)
+            member.encode(into: &commandEncoder)
         }
     }
     public typealias Response = RESPToken
@@ -250,8 +274,16 @@ public struct ZINTER: RESPCommand {
         case min
         case max
 
+        public var respEntries: Int {
+            switch self {
+            case .sum: "SUM".respEntries
+            case .min: "MIN".respEntries
+            case .max: "MAX".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .sum: "SUM".encode(into: &commandEncoder)
             case .min: "MIN".encode(into: &commandEncoder)
@@ -302,8 +334,16 @@ public struct ZINTERSTORE: RESPCommand {
         case min
         case max
 
+        public var respEntries: Int {
+            switch self {
+            case .sum: "SUM".respEntries
+            case .min: "MIN".respEntries
+            case .max: "MAX".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .sum: "SUM".encode(into: &commandEncoder)
             case .min: "MIN".encode(into: &commandEncoder)
@@ -355,8 +395,15 @@ public struct ZMPOP: RESPCommand {
         case min
         case max
 
+        public var respEntries: Int {
+            switch self {
+            case .min: "MIN".respEntries
+            case .max: "MAX".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .min: "MIN".encode(into: &commandEncoder)
             case .max: "MAX".encode(into: &commandEncoder)
@@ -444,11 +491,14 @@ public struct ZRANDMEMBER: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += count.encode(into: &commandEncoder)
-            if self.withscores { count += "WITHSCORES".encode(into: &commandEncoder) }
-            return count
+        public var respEntries: Int {
+            count.respEntries + "WITHSCORES".respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            count.encode(into: &commandEncoder)
+            "WITHSCORES".encode(into: &commandEncoder)
         }
     }
     public typealias Response = RESPToken
@@ -472,8 +522,15 @@ public struct ZRANGE: RESPCommand {
         case byscore
         case bylex
 
+        public var respEntries: Int {
+            switch self {
+            case .byscore: "BYSCORE".respEntries
+            case .bylex: "BYLEX".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .byscore: "BYSCORE".encode(into: &commandEncoder)
             case .bylex: "BYLEX".encode(into: &commandEncoder)
@@ -491,11 +548,14 @@ public struct ZRANGE: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += offset.encode(into: &commandEncoder)
-            count += count.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            offset.respEntries + count.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            offset.encode(into: &commandEncoder)
+            count.encode(into: &commandEncoder)
         }
     }
     public typealias Response = [RESPToken]
@@ -537,11 +597,14 @@ public struct ZRANGEBYLEX: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += offset.encode(into: &commandEncoder)
-            count += count.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            offset.respEntries + count.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            offset.encode(into: &commandEncoder)
+            count.encode(into: &commandEncoder)
         }
     }
     public typealias Response = [RESPToken]
@@ -577,11 +640,14 @@ public struct ZRANGEBYSCORE: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += offset.encode(into: &commandEncoder)
-            count += count.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            offset.respEntries + count.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            offset.encode(into: &commandEncoder)
+            count.encode(into: &commandEncoder)
         }
     }
     public typealias Response = [RESPToken]
@@ -611,8 +677,15 @@ public struct ZRANGESTORE: RESPCommand {
         case byscore
         case bylex
 
+        public var respEntries: Int {
+            switch self {
+            case .byscore: "BYSCORE".respEntries
+            case .bylex: "BYLEX".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .byscore: "BYSCORE".encode(into: &commandEncoder)
             case .bylex: "BYLEX".encode(into: &commandEncoder)
@@ -630,11 +703,14 @@ public struct ZRANGESTORE: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += offset.encode(into: &commandEncoder)
-            count += count.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            offset.respEntries + count.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            offset.encode(into: &commandEncoder)
+            count.encode(into: &commandEncoder)
         }
     }
     public typealias Response = Int
@@ -791,11 +867,14 @@ public struct ZREVRANGEBYLEX: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += offset.encode(into: &commandEncoder)
-            count += count.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            offset.respEntries + count.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            offset.encode(into: &commandEncoder)
+            count.encode(into: &commandEncoder)
         }
     }
     public typealias Response = [RESPToken]
@@ -831,11 +910,14 @@ public struct ZREVRANGEBYSCORE: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += offset.encode(into: &commandEncoder)
-            count += count.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            offset.respEntries + count.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            offset.encode(into: &commandEncoder)
+            count.encode(into: &commandEncoder)
         }
     }
     public typealias Response = [RESPToken]
@@ -923,8 +1005,16 @@ public struct ZUNION: RESPCommand {
         case min
         case max
 
+        public var respEntries: Int {
+            switch self {
+            case .sum: "SUM".respEntries
+            case .min: "MIN".respEntries
+            case .max: "MAX".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .sum: "SUM".encode(into: &commandEncoder)
             case .min: "MIN".encode(into: &commandEncoder)
@@ -958,8 +1048,16 @@ public struct ZUNIONSTORE: RESPCommand {
         case min
         case max
 
+        public var respEntries: Int {
+            switch self {
+            case .sum: "SUM".respEntries
+            case .min: "MIN".respEntries
+            case .max: "MAX".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .sum: "SUM".encode(into: &commandEncoder)
             case .min: "MIN".encode(into: &commandEncoder)

--- a/Sources/Valkey/Commands/StreamCommands.swift
+++ b/Sources/Valkey/Commands/StreamCommands.swift
@@ -30,8 +30,15 @@ public enum XGROUP {
             case id(String)
             case newId
 
+            public var respEntries: Int {
+                switch self {
+                case .id(let id): id.respEntries
+                case .newId: "$".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .id(let id): id.encode(into: &commandEncoder)
                 case .newId: "$".encode(into: &commandEncoder)
@@ -133,8 +140,15 @@ public enum XGROUP {
             case id(String)
             case newId
 
+            public var respEntries: Int {
+                switch self {
+                case .id(let id): id.respEntries
+                case .newId: "$".respEntries
+                }
+            }
+
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
                 switch self {
                 case .id(let id): id.encode(into: &commandEncoder)
                 case .newId: "$".encode(into: &commandEncoder)
@@ -222,11 +236,14 @@ public enum XINFO {
             }
 
             @inlinable
-            public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-                var count = 0
-                if self.full { count += "FULL".encode(into: &commandEncoder) }
-                count += RESPWithToken("COUNT", count).encode(into: &commandEncoder)
-                return count
+            public var respEntries: Int {
+                "FULL".respEntries + RESPWithToken("COUNT", count).respEntries
+            }
+
+            @inlinable
+            public func encode(into commandEncoder: inout RESPCommandEncoder) {
+                "FULL".encode(into: &commandEncoder)
+                RESPWithToken("COUNT", count).encode(into: &commandEncoder)
             }
         }
         public typealias Response = [String: RESPToken]
@@ -271,8 +288,15 @@ public struct XADD: RESPCommand {
         case maxlen
         case minid
 
+        public var respEntries: Int {
+            switch self {
+            case .maxlen: "MAXLEN".respEntries
+            case .minid: "MINID".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .maxlen: "MAXLEN".encode(into: &commandEncoder)
             case .minid: "MINID".encode(into: &commandEncoder)
@@ -283,8 +307,15 @@ public struct XADD: RESPCommand {
         case equal
         case approximately
 
+        public var respEntries: Int {
+            switch self {
+            case .equal: "=".respEntries
+            case .approximately: "~".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .equal: "=".encode(into: &commandEncoder)
             case .approximately: "~".encode(into: &commandEncoder)
@@ -306,21 +337,31 @@ public struct XADD: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += strategy.encode(into: &commandEncoder)
-            count += `operator`.encode(into: &commandEncoder)
-            count += threshold.encode(into: &commandEncoder)
-            count += RESPWithToken("LIMIT", count).encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            strategy.respEntries + `operator`.respEntries + threshold.respEntries + RESPWithToken("LIMIT", count).respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            strategy.encode(into: &commandEncoder)
+            `operator`.encode(into: &commandEncoder)
+            threshold.encode(into: &commandEncoder)
+            RESPWithToken("LIMIT", count).encode(into: &commandEncoder)
         }
     }
     public enum IdSelector: RESPRenderable, Sendable {
         case autoId
         case id(String)
 
+        public var respEntries: Int {
+            switch self {
+            case .autoId: "*".respEntries
+            case .id(let id): id.respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .autoId: "*".encode(into: &commandEncoder)
             case .id(let id): id.encode(into: &commandEncoder)
@@ -338,11 +379,14 @@ public struct XADD: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += field.encode(into: &commandEncoder)
-            count += value.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            field.respEntries + value.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            field.encode(into: &commandEncoder)
+            value.encode(into: &commandEncoder)
         }
     }
     public typealias Response = String?
@@ -479,14 +523,17 @@ public struct XPENDING: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += RESPWithToken("IDLE", minIdleTime).encode(into: &commandEncoder)
-            count += start.encode(into: &commandEncoder)
-            count += end.encode(into: &commandEncoder)
-            count += count.encode(into: &commandEncoder)
-            count += consumer.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            RESPWithToken("IDLE", minIdleTime).respEntries + start.respEntries + end.respEntries + count.respEntries + consumer.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            RESPWithToken("IDLE", minIdleTime).encode(into: &commandEncoder)
+            start.encode(into: &commandEncoder)
+            end.encode(into: &commandEncoder)
+            count.encode(into: &commandEncoder)
+            consumer.encode(into: &commandEncoder)
         }
     }
     public typealias Response = [RESPToken]
@@ -540,11 +587,14 @@ public struct XREAD: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += key.encode(into: &commandEncoder)
-            count += id.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            key.respEntries + id.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            key.encode(into: &commandEncoder)
+            id.encode(into: &commandEncoder)
         }
     }
     public typealias Response = [String: RESPToken]?
@@ -577,11 +627,14 @@ public struct XREADGROUP: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += group.encode(into: &commandEncoder)
-            count += consumer.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            group.respEntries + consumer.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            group.encode(into: &commandEncoder)
+            consumer.encode(into: &commandEncoder)
         }
     }
     public struct Streams: RESPRenderable, Sendable {
@@ -595,11 +648,14 @@ public struct XREADGROUP: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += key.encode(into: &commandEncoder)
-            count += id.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            key.respEntries + id.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            key.encode(into: &commandEncoder)
+            id.encode(into: &commandEncoder)
         }
     }
     public typealias Response = [String: RESPToken]?
@@ -671,8 +727,15 @@ public struct XTRIM: RESPCommand {
         case maxlen
         case minid
 
+        public var respEntries: Int {
+            switch self {
+            case .maxlen: "MAXLEN".respEntries
+            case .minid: "MINID".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .maxlen: "MAXLEN".encode(into: &commandEncoder)
             case .minid: "MINID".encode(into: &commandEncoder)
@@ -683,8 +746,15 @@ public struct XTRIM: RESPCommand {
         case equal
         case approximately
 
+        public var respEntries: Int {
+            switch self {
+            case .equal: "=".respEntries
+            case .approximately: "~".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .equal: "=".encode(into: &commandEncoder)
             case .approximately: "~".encode(into: &commandEncoder)
@@ -706,13 +776,16 @@ public struct XTRIM: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += strategy.encode(into: &commandEncoder)
-            count += `operator`.encode(into: &commandEncoder)
-            count += threshold.encode(into: &commandEncoder)
-            count += RESPWithToken("LIMIT", count).encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            strategy.respEntries + `operator`.respEntries + threshold.respEntries + RESPWithToken("LIMIT", count).respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            strategy.encode(into: &commandEncoder)
+            `operator`.encode(into: &commandEncoder)
+            threshold.encode(into: &commandEncoder)
+            RESPWithToken("LIMIT", count).encode(into: &commandEncoder)
         }
     }
     public typealias Response = Int

--- a/Sources/Valkey/Commands/StringCommands.swift
+++ b/Sources/Valkey/Commands/StringCommands.swift
@@ -110,8 +110,18 @@ public struct GETEX: RESPCommand {
         case unixTimeMilliseconds(Date)
         case persist
 
+        public var respEntries: Int {
+            switch self {
+            case .seconds(let seconds): RESPWithToken("EX", seconds).respEntries
+            case .milliseconds(let milliseconds): RESPWithToken("PX", milliseconds).respEntries
+            case .unixTimeSeconds(let unixTimeSeconds): RESPWithToken("EXAT", Int(unixTimeSeconds.timeIntervalSince1970)).respEntries
+            case .unixTimeMilliseconds(let unixTimeMilliseconds): RESPWithToken("PXAT", Int(unixTimeMilliseconds.timeIntervalSince1970 * 1000)).respEntries
+            case .persist: "PERSIST".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .seconds(let seconds): RESPWithToken("EX", seconds).encode(into: &commandEncoder)
             case .milliseconds(let milliseconds): RESPWithToken("PX", milliseconds).encode(into: &commandEncoder)
@@ -275,11 +285,14 @@ public struct MSET: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += key.encode(into: &commandEncoder)
-            count += value.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            key.respEntries + value.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            key.encode(into: &commandEncoder)
+            value.encode(into: &commandEncoder)
         }
     }
     public typealias Response = RESPToken
@@ -308,11 +321,14 @@ public struct MSETNX: RESPCommand {
         }
 
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-            var count = 0
-            count += key.encode(into: &commandEncoder)
-            count += value.encode(into: &commandEncoder)
-            return count
+        public var respEntries: Int {
+            key.respEntries + value.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
+            key.encode(into: &commandEncoder)
+            value.encode(into: &commandEncoder)
         }
     }
     public typealias Response = Int
@@ -354,8 +370,15 @@ public struct SET: RESPCommand {
         case nx
         case xx
 
+        public var respEntries: Int {
+            switch self {
+            case .nx: "NX".respEntries
+            case .xx: "XX".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .nx: "NX".encode(into: &commandEncoder)
             case .xx: "XX".encode(into: &commandEncoder)
@@ -369,8 +392,18 @@ public struct SET: RESPCommand {
         case unixTimeMilliseconds(Date)
         case keepttl
 
+        public var respEntries: Int {
+            switch self {
+            case .seconds(let seconds): RESPWithToken("EX", seconds).respEntries
+            case .milliseconds(let milliseconds): RESPWithToken("PX", milliseconds).respEntries
+            case .unixTimeSeconds(let unixTimeSeconds): RESPWithToken("EXAT", Int(unixTimeSeconds.timeIntervalSince1970)).respEntries
+            case .unixTimeMilliseconds(let unixTimeMilliseconds): RESPWithToken("PXAT", Int(unixTimeMilliseconds.timeIntervalSince1970 * 1000)).respEntries
+            case .keepttl: "KEEPTTL".respEntries
+            }
+        }
+
         @inlinable
-        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+        public func encode(into commandEncoder: inout RESPCommandEncoder) {
             switch self {
             case .seconds(let seconds): RESPWithToken("EX", seconds).encode(into: &commandEncoder)
             case .milliseconds(let milliseconds): RESPWithToken("PX", milliseconds).encode(into: &commandEncoder)

--- a/Sources/Valkey/RESP/RESPCommandEncoder-multi-encode.swift
+++ b/Sources/Valkey/RESP/RESPCommandEncoder-multi-encode.swift
@@ -7,450 +7,240 @@ extension RESPCommandEncoder {
     @inlinable
     public mutating func encodeArray<T0: RESPRenderable>(_ t0: T0) {
         self.encodeIdentifier(.array)
-        var count = 0
-        let arrayCountIndex = buffer.writerIndex
-        self.buffer.writeStaticString("0\r\n")
-        count += t0.encode(into: &self)
-        if count > 9 {
-            // I'm being lazy here and not supporting more than 99 arguments
-            precondition(count < 100)
-            // We need to rebuild ByteBuffer with space for double digit count
-            // skip past count + \r\n
-            let sliceStart = arrayCountIndex + 3
-            var slice = buffer.getSlice(at: sliceStart, length: buffer.writerIndex - sliceStart)!
-            self.buffer.moveWriterIndex(to: arrayCountIndex)
-            self.buffer.writeString(String(count))
-            self.buffer.writeStaticString("\r\n")
-            self.buffer.writeBuffer(&slice)
-        } else {
-            self.buffer.setString(String(count), at: arrayCountIndex)
-        }
+        let count = t0.respEntries
+        self.buffer.writeString("\(count)")
+        self.buffer.writeStaticString("\r\n")
+        t0.encode(into: &self)
     }
 
     @inlinable
     public mutating func encodeArray<T0: RESPRenderable, T1: RESPRenderable>(_ t0: T0, _ t1: T1) {
         self.encodeIdentifier(.array)
-        var count = 0
-        let arrayCountIndex = buffer.writerIndex
-        self.buffer.writeStaticString("0\r\n")
-        count += t0.encode(into: &self)
-        count += t1.encode(into: &self)
-        if count > 9 {
-            // I'm being lazy here and not supporting more than 99 arguments
-            precondition(count < 100)
-            // We need to rebuild ByteBuffer with space for double digit count
-            // skip past count + \r\n
-            let sliceStart = arrayCountIndex + 3
-            var slice = buffer.getSlice(at: sliceStart, length: buffer.writerIndex - sliceStart)!
-            self.buffer.moveWriterIndex(to: arrayCountIndex)
-            self.buffer.writeString(String(count))
-            self.buffer.writeStaticString("\r\n")
-            self.buffer.writeBuffer(&slice)
-        } else {
-            self.buffer.setString(String(count), at: arrayCountIndex)
-        }
+        let count = t0.respEntries + t1.respEntries
+        self.buffer.writeString("\(count)")
+        self.buffer.writeStaticString("\r\n")
+        t0.encode(into: &self)
+        t1.encode(into: &self)
     }
 
     @inlinable
     public mutating func encodeArray<T0: RESPRenderable, T1: RESPRenderable, T2: RESPRenderable>(_ t0: T0, _ t1: T1, _ t2: T2) {
         self.encodeIdentifier(.array)
-        var count = 0
-        let arrayCountIndex = buffer.writerIndex
-        self.buffer.writeStaticString("0\r\n")
-        count += t0.encode(into: &self)
-        count += t1.encode(into: &self)
-        count += t2.encode(into: &self)
-        if count > 9 {
-            // I'm being lazy here and not supporting more than 99 arguments
-            precondition(count < 100)
-            // We need to rebuild ByteBuffer with space for double digit count
-            // skip past count + \r\n
-            let sliceStart = arrayCountIndex + 3
-            var slice = buffer.getSlice(at: sliceStart, length: buffer.writerIndex - sliceStart)!
-            self.buffer.moveWriterIndex(to: arrayCountIndex)
-            self.buffer.writeString(String(count))
-            self.buffer.writeStaticString("\r\n")
-            self.buffer.writeBuffer(&slice)
-        } else {
-            self.buffer.setString(String(count), at: arrayCountIndex)
-        }
+        let count = t0.respEntries + t1.respEntries + t2.respEntries
+        self.buffer.writeString("\(count)")
+        self.buffer.writeStaticString("\r\n")
+        t0.encode(into: &self)
+        t1.encode(into: &self)
+        t2.encode(into: &self)
     }
 
     @inlinable
     public mutating func encodeArray<T0: RESPRenderable, T1: RESPRenderable, T2: RESPRenderable, T3: RESPRenderable>(_ t0: T0, _ t1: T1, _ t2: T2, _ t3: T3) {
         self.encodeIdentifier(.array)
-        var count = 0
-        let arrayCountIndex = buffer.writerIndex
-        self.buffer.writeStaticString("0\r\n")
-        count += t0.encode(into: &self)
-        count += t1.encode(into: &self)
-        count += t2.encode(into: &self)
-        count += t3.encode(into: &self)
-        if count > 9 {
-            // I'm being lazy here and not supporting more than 99 arguments
-            precondition(count < 100)
-            // We need to rebuild ByteBuffer with space for double digit count
-            // skip past count + \r\n
-            let sliceStart = arrayCountIndex + 3
-            var slice = buffer.getSlice(at: sliceStart, length: buffer.writerIndex - sliceStart)!
-            self.buffer.moveWriterIndex(to: arrayCountIndex)
-            self.buffer.writeString(String(count))
-            self.buffer.writeStaticString("\r\n")
-            self.buffer.writeBuffer(&slice)
-        } else {
-            self.buffer.setString(String(count), at: arrayCountIndex)
-        }
+        let count = t0.respEntries + t1.respEntries + t2.respEntries + t3.respEntries
+        self.buffer.writeString("\(count)")
+        self.buffer.writeStaticString("\r\n")
+        t0.encode(into: &self)
+        t1.encode(into: &self)
+        t2.encode(into: &self)
+        t3.encode(into: &self)
     }
 
     @inlinable
     public mutating func encodeArray<T0: RESPRenderable, T1: RESPRenderable, T2: RESPRenderable, T3: RESPRenderable, T4: RESPRenderable>(_ t0: T0, _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4) {
         self.encodeIdentifier(.array)
-        var count = 0
-        let arrayCountIndex = buffer.writerIndex
-        self.buffer.writeStaticString("0\r\n")
-        count += t0.encode(into: &self)
-        count += t1.encode(into: &self)
-        count += t2.encode(into: &self)
-        count += t3.encode(into: &self)
-        count += t4.encode(into: &self)
-        if count > 9 {
-            // I'm being lazy here and not supporting more than 99 arguments
-            precondition(count < 100)
-            // We need to rebuild ByteBuffer with space for double digit count
-            // skip past count + \r\n
-            let sliceStart = arrayCountIndex + 3
-            var slice = buffer.getSlice(at: sliceStart, length: buffer.writerIndex - sliceStart)!
-            self.buffer.moveWriterIndex(to: arrayCountIndex)
-            self.buffer.writeString(String(count))
-            self.buffer.writeStaticString("\r\n")
-            self.buffer.writeBuffer(&slice)
-        } else {
-            self.buffer.setString(String(count), at: arrayCountIndex)
-        }
+        let count = t0.respEntries + t1.respEntries + t2.respEntries + t3.respEntries + t4.respEntries
+        self.buffer.writeString("\(count)")
+        self.buffer.writeStaticString("\r\n")
+        t0.encode(into: &self)
+        t1.encode(into: &self)
+        t2.encode(into: &self)
+        t3.encode(into: &self)
+        t4.encode(into: &self)
     }
 
     @inlinable
     public mutating func encodeArray<T0: RESPRenderable, T1: RESPRenderable, T2: RESPRenderable, T3: RESPRenderable, T4: RESPRenderable, T5: RESPRenderable>(_ t0: T0, _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4, _ t5: T5) {
         self.encodeIdentifier(.array)
-        var count = 0
-        let arrayCountIndex = buffer.writerIndex
-        self.buffer.writeStaticString("0\r\n")
-        count += t0.encode(into: &self)
-        count += t1.encode(into: &self)
-        count += t2.encode(into: &self)
-        count += t3.encode(into: &self)
-        count += t4.encode(into: &self)
-        count += t5.encode(into: &self)
-        if count > 9 {
-            // I'm being lazy here and not supporting more than 99 arguments
-            precondition(count < 100)
-            // We need to rebuild ByteBuffer with space for double digit count
-            // skip past count + \r\n
-            let sliceStart = arrayCountIndex + 3
-            var slice = buffer.getSlice(at: sliceStart, length: buffer.writerIndex - sliceStart)!
-            self.buffer.moveWriterIndex(to: arrayCountIndex)
-            self.buffer.writeString(String(count))
-            self.buffer.writeStaticString("\r\n")
-            self.buffer.writeBuffer(&slice)
-        } else {
-            self.buffer.setString(String(count), at: arrayCountIndex)
-        }
+        let count = t0.respEntries + t1.respEntries + t2.respEntries + t3.respEntries + t4.respEntries + t5.respEntries
+        self.buffer.writeString("\(count)")
+        self.buffer.writeStaticString("\r\n")
+        t0.encode(into: &self)
+        t1.encode(into: &self)
+        t2.encode(into: &self)
+        t3.encode(into: &self)
+        t4.encode(into: &self)
+        t5.encode(into: &self)
     }
 
     @inlinable
     public mutating func encodeArray<T0: RESPRenderable, T1: RESPRenderable, T2: RESPRenderable, T3: RESPRenderable, T4: RESPRenderable, T5: RESPRenderable, T6: RESPRenderable>(_ t0: T0, _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4, _ t5: T5, _ t6: T6) {
         self.encodeIdentifier(.array)
-        var count = 0
-        let arrayCountIndex = buffer.writerIndex
-        self.buffer.writeStaticString("0\r\n")
-        count += t0.encode(into: &self)
-        count += t1.encode(into: &self)
-        count += t2.encode(into: &self)
-        count += t3.encode(into: &self)
-        count += t4.encode(into: &self)
-        count += t5.encode(into: &self)
-        count += t6.encode(into: &self)
-        if count > 9 {
-            // I'm being lazy here and not supporting more than 99 arguments
-            precondition(count < 100)
-            // We need to rebuild ByteBuffer with space for double digit count
-            // skip past count + \r\n
-            let sliceStart = arrayCountIndex + 3
-            var slice = buffer.getSlice(at: sliceStart, length: buffer.writerIndex - sliceStart)!
-            self.buffer.moveWriterIndex(to: arrayCountIndex)
-            self.buffer.writeString(String(count))
-            self.buffer.writeStaticString("\r\n")
-            self.buffer.writeBuffer(&slice)
-        } else {
-            self.buffer.setString(String(count), at: arrayCountIndex)
-        }
+        let count = t0.respEntries + t1.respEntries + t2.respEntries + t3.respEntries + t4.respEntries + t5.respEntries + t6.respEntries
+        self.buffer.writeString("\(count)")
+        self.buffer.writeStaticString("\r\n")
+        t0.encode(into: &self)
+        t1.encode(into: &self)
+        t2.encode(into: &self)
+        t3.encode(into: &self)
+        t4.encode(into: &self)
+        t5.encode(into: &self)
+        t6.encode(into: &self)
     }
 
     @inlinable
     public mutating func encodeArray<T0: RESPRenderable, T1: RESPRenderable, T2: RESPRenderable, T3: RESPRenderable, T4: RESPRenderable, T5: RESPRenderable, T6: RESPRenderable, T7: RESPRenderable>(_ t0: T0, _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4, _ t5: T5, _ t6: T6, _ t7: T7) {
         self.encodeIdentifier(.array)
-        var count = 0
-        let arrayCountIndex = buffer.writerIndex
-        self.buffer.writeStaticString("0\r\n")
-        count += t0.encode(into: &self)
-        count += t1.encode(into: &self)
-        count += t2.encode(into: &self)
-        count += t3.encode(into: &self)
-        count += t4.encode(into: &self)
-        count += t5.encode(into: &self)
-        count += t6.encode(into: &self)
-        count += t7.encode(into: &self)
-        if count > 9 {
-            // I'm being lazy here and not supporting more than 99 arguments
-            precondition(count < 100)
-            // We need to rebuild ByteBuffer with space for double digit count
-            // skip past count + \r\n
-            let sliceStart = arrayCountIndex + 3
-            var slice = buffer.getSlice(at: sliceStart, length: buffer.writerIndex - sliceStart)!
-            self.buffer.moveWriterIndex(to: arrayCountIndex)
-            self.buffer.writeString(String(count))
-            self.buffer.writeStaticString("\r\n")
-            self.buffer.writeBuffer(&slice)
-        } else {
-            self.buffer.setString(String(count), at: arrayCountIndex)
-        }
+        let count = t0.respEntries + t1.respEntries + t2.respEntries + t3.respEntries + t4.respEntries + t5.respEntries + t6.respEntries + t7.respEntries
+        self.buffer.writeString("\(count)")
+        self.buffer.writeStaticString("\r\n")
+        t0.encode(into: &self)
+        t1.encode(into: &self)
+        t2.encode(into: &self)
+        t3.encode(into: &self)
+        t4.encode(into: &self)
+        t5.encode(into: &self)
+        t6.encode(into: &self)
+        t7.encode(into: &self)
     }
 
     @inlinable
     public mutating func encodeArray<T0: RESPRenderable, T1: RESPRenderable, T2: RESPRenderable, T3: RESPRenderable, T4: RESPRenderable, T5: RESPRenderable, T6: RESPRenderable, T7: RESPRenderable, T8: RESPRenderable>(_ t0: T0, _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4, _ t5: T5, _ t6: T6, _ t7: T7, _ t8: T8) {
         self.encodeIdentifier(.array)
-        var count = 0
-        let arrayCountIndex = buffer.writerIndex
-        self.buffer.writeStaticString("0\r\n")
-        count += t0.encode(into: &self)
-        count += t1.encode(into: &self)
-        count += t2.encode(into: &self)
-        count += t3.encode(into: &self)
-        count += t4.encode(into: &self)
-        count += t5.encode(into: &self)
-        count += t6.encode(into: &self)
-        count += t7.encode(into: &self)
-        count += t8.encode(into: &self)
-        if count > 9 {
-            // I'm being lazy here and not supporting more than 99 arguments
-            precondition(count < 100)
-            // We need to rebuild ByteBuffer with space for double digit count
-            // skip past count + \r\n
-            let sliceStart = arrayCountIndex + 3
-            var slice = buffer.getSlice(at: sliceStart, length: buffer.writerIndex - sliceStart)!
-            self.buffer.moveWriterIndex(to: arrayCountIndex)
-            self.buffer.writeString(String(count))
-            self.buffer.writeStaticString("\r\n")
-            self.buffer.writeBuffer(&slice)
-        } else {
-            self.buffer.setString(String(count), at: arrayCountIndex)
-        }
+        let count = t0.respEntries + t1.respEntries + t2.respEntries + t3.respEntries + t4.respEntries + t5.respEntries + t6.respEntries + t7.respEntries + t8.respEntries
+        self.buffer.writeString("\(count)")
+        self.buffer.writeStaticString("\r\n")
+        t0.encode(into: &self)
+        t1.encode(into: &self)
+        t2.encode(into: &self)
+        t3.encode(into: &self)
+        t4.encode(into: &self)
+        t5.encode(into: &self)
+        t6.encode(into: &self)
+        t7.encode(into: &self)
+        t8.encode(into: &self)
     }
 
     @inlinable
     public mutating func encodeArray<T0: RESPRenderable, T1: RESPRenderable, T2: RESPRenderable, T3: RESPRenderable, T4: RESPRenderable, T5: RESPRenderable, T6: RESPRenderable, T7: RESPRenderable, T8: RESPRenderable, T9: RESPRenderable>(_ t0: T0, _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4, _ t5: T5, _ t6: T6, _ t7: T7, _ t8: T8, _ t9: T9) {
         self.encodeIdentifier(.array)
-        var count = 0
-        let arrayCountIndex = buffer.writerIndex
-        self.buffer.writeStaticString("0\r\n")
-        count += t0.encode(into: &self)
-        count += t1.encode(into: &self)
-        count += t2.encode(into: &self)
-        count += t3.encode(into: &self)
-        count += t4.encode(into: &self)
-        count += t5.encode(into: &self)
-        count += t6.encode(into: &self)
-        count += t7.encode(into: &self)
-        count += t8.encode(into: &self)
-        count += t9.encode(into: &self)
-        if count > 9 {
-            // I'm being lazy here and not supporting more than 99 arguments
-            precondition(count < 100)
-            // We need to rebuild ByteBuffer with space for double digit count
-            // skip past count + \r\n
-            let sliceStart = arrayCountIndex + 3
-            var slice = buffer.getSlice(at: sliceStart, length: buffer.writerIndex - sliceStart)!
-            self.buffer.moveWriterIndex(to: arrayCountIndex)
-            self.buffer.writeString(String(count))
-            self.buffer.writeStaticString("\r\n")
-            self.buffer.writeBuffer(&slice)
-        } else {
-            self.buffer.setString(String(count), at: arrayCountIndex)
-        }
+        let count = t0.respEntries + t1.respEntries + t2.respEntries + t3.respEntries + t4.respEntries + t5.respEntries + t6.respEntries + t7.respEntries + t8.respEntries + t9.respEntries
+        self.buffer.writeString("\(count)")
+        self.buffer.writeStaticString("\r\n")
+        t0.encode(into: &self)
+        t1.encode(into: &self)
+        t2.encode(into: &self)
+        t3.encode(into: &self)
+        t4.encode(into: &self)
+        t5.encode(into: &self)
+        t6.encode(into: &self)
+        t7.encode(into: &self)
+        t8.encode(into: &self)
+        t9.encode(into: &self)
     }
 
     @inlinable
     public mutating func encodeArray<T0: RESPRenderable, T1: RESPRenderable, T2: RESPRenderable, T3: RESPRenderable, T4: RESPRenderable, T5: RESPRenderable, T6: RESPRenderable, T7: RESPRenderable, T8: RESPRenderable, T9: RESPRenderable, T10: RESPRenderable>(_ t0: T0, _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4, _ t5: T5, _ t6: T6, _ t7: T7, _ t8: T8, _ t9: T9, _ t10: T10) {
         self.encodeIdentifier(.array)
-        var count = 0
-        let arrayCountIndex = buffer.writerIndex
-        self.buffer.writeStaticString("0\r\n")
-        count += t0.encode(into: &self)
-        count += t1.encode(into: &self)
-        count += t2.encode(into: &self)
-        count += t3.encode(into: &self)
-        count += t4.encode(into: &self)
-        count += t5.encode(into: &self)
-        count += t6.encode(into: &self)
-        count += t7.encode(into: &self)
-        count += t8.encode(into: &self)
-        count += t9.encode(into: &self)
-        count += t10.encode(into: &self)
-        if count > 9 {
-            // I'm being lazy here and not supporting more than 99 arguments
-            precondition(count < 100)
-            // We need to rebuild ByteBuffer with space for double digit count
-            // skip past count + \r\n
-            let sliceStart = arrayCountIndex + 3
-            var slice = buffer.getSlice(at: sliceStart, length: buffer.writerIndex - sliceStart)!
-            self.buffer.moveWriterIndex(to: arrayCountIndex)
-            self.buffer.writeString(String(count))
-            self.buffer.writeStaticString("\r\n")
-            self.buffer.writeBuffer(&slice)
-        } else {
-            self.buffer.setString(String(count), at: arrayCountIndex)
-        }
+        let count = t0.respEntries + t1.respEntries + t2.respEntries + t3.respEntries + t4.respEntries + t5.respEntries + t6.respEntries + t7.respEntries + t8.respEntries + t9.respEntries + t10.respEntries
+        self.buffer.writeString("\(count)")
+        self.buffer.writeStaticString("\r\n")
+        t0.encode(into: &self)
+        t1.encode(into: &self)
+        t2.encode(into: &self)
+        t3.encode(into: &self)
+        t4.encode(into: &self)
+        t5.encode(into: &self)
+        t6.encode(into: &self)
+        t7.encode(into: &self)
+        t8.encode(into: &self)
+        t9.encode(into: &self)
+        t10.encode(into: &self)
     }
 
     @inlinable
     public mutating func encodeArray<T0: RESPRenderable, T1: RESPRenderable, T2: RESPRenderable, T3: RESPRenderable, T4: RESPRenderable, T5: RESPRenderable, T6: RESPRenderable, T7: RESPRenderable, T8: RESPRenderable, T9: RESPRenderable, T10: RESPRenderable, T11: RESPRenderable>(_ t0: T0, _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4, _ t5: T5, _ t6: T6, _ t7: T7, _ t8: T8, _ t9: T9, _ t10: T10, _ t11: T11) {
         self.encodeIdentifier(.array)
-        var count = 0
-        let arrayCountIndex = buffer.writerIndex
-        self.buffer.writeStaticString("0\r\n")
-        count += t0.encode(into: &self)
-        count += t1.encode(into: &self)
-        count += t2.encode(into: &self)
-        count += t3.encode(into: &self)
-        count += t4.encode(into: &self)
-        count += t5.encode(into: &self)
-        count += t6.encode(into: &self)
-        count += t7.encode(into: &self)
-        count += t8.encode(into: &self)
-        count += t9.encode(into: &self)
-        count += t10.encode(into: &self)
-        count += t11.encode(into: &self)
-        if count > 9 {
-            // I'm being lazy here and not supporting more than 99 arguments
-            precondition(count < 100)
-            // We need to rebuild ByteBuffer with space for double digit count
-            // skip past count + \r\n
-            let sliceStart = arrayCountIndex + 3
-            var slice = buffer.getSlice(at: sliceStart, length: buffer.writerIndex - sliceStart)!
-            self.buffer.moveWriterIndex(to: arrayCountIndex)
-            self.buffer.writeString(String(count))
-            self.buffer.writeStaticString("\r\n")
-            self.buffer.writeBuffer(&slice)
-        } else {
-            self.buffer.setString(String(count), at: arrayCountIndex)
-        }
+        let count = t0.respEntries + t1.respEntries + t2.respEntries + t3.respEntries + t4.respEntries + t5.respEntries + t6.respEntries + t7.respEntries + t8.respEntries + t9.respEntries + t10.respEntries + t11.respEntries
+        self.buffer.writeString("\(count)")
+        self.buffer.writeStaticString("\r\n")
+        t0.encode(into: &self)
+        t1.encode(into: &self)
+        t2.encode(into: &self)
+        t3.encode(into: &self)
+        t4.encode(into: &self)
+        t5.encode(into: &self)
+        t6.encode(into: &self)
+        t7.encode(into: &self)
+        t8.encode(into: &self)
+        t9.encode(into: &self)
+        t10.encode(into: &self)
+        t11.encode(into: &self)
     }
 
     @inlinable
     public mutating func encodeArray<T0: RESPRenderable, T1: RESPRenderable, T2: RESPRenderable, T3: RESPRenderable, T4: RESPRenderable, T5: RESPRenderable, T6: RESPRenderable, T7: RESPRenderable, T8: RESPRenderable, T9: RESPRenderable, T10: RESPRenderable, T11: RESPRenderable, T12: RESPRenderable>(_ t0: T0, _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4, _ t5: T5, _ t6: T6, _ t7: T7, _ t8: T8, _ t9: T9, _ t10: T10, _ t11: T11, _ t12: T12) {
         self.encodeIdentifier(.array)
-        var count = 0
-        let arrayCountIndex = buffer.writerIndex
-        self.buffer.writeStaticString("0\r\n")
-        count += t0.encode(into: &self)
-        count += t1.encode(into: &self)
-        count += t2.encode(into: &self)
-        count += t3.encode(into: &self)
-        count += t4.encode(into: &self)
-        count += t5.encode(into: &self)
-        count += t6.encode(into: &self)
-        count += t7.encode(into: &self)
-        count += t8.encode(into: &self)
-        count += t9.encode(into: &self)
-        count += t10.encode(into: &self)
-        count += t11.encode(into: &self)
-        count += t12.encode(into: &self)
-        if count > 9 {
-            // I'm being lazy here and not supporting more than 99 arguments
-            precondition(count < 100)
-            // We need to rebuild ByteBuffer with space for double digit count
-            // skip past count + \r\n
-            let sliceStart = arrayCountIndex + 3
-            var slice = buffer.getSlice(at: sliceStart, length: buffer.writerIndex - sliceStart)!
-            self.buffer.moveWriterIndex(to: arrayCountIndex)
-            self.buffer.writeString(String(count))
-            self.buffer.writeStaticString("\r\n")
-            self.buffer.writeBuffer(&slice)
-        } else {
-            self.buffer.setString(String(count), at: arrayCountIndex)
-        }
+        let count = t0.respEntries + t1.respEntries + t2.respEntries + t3.respEntries + t4.respEntries + t5.respEntries + t6.respEntries + t7.respEntries + t8.respEntries + t9.respEntries + t10.respEntries + t11.respEntries + t12.respEntries
+        self.buffer.writeString("\(count)")
+        self.buffer.writeStaticString("\r\n")
+        t0.encode(into: &self)
+        t1.encode(into: &self)
+        t2.encode(into: &self)
+        t3.encode(into: &self)
+        t4.encode(into: &self)
+        t5.encode(into: &self)
+        t6.encode(into: &self)
+        t7.encode(into: &self)
+        t8.encode(into: &self)
+        t9.encode(into: &self)
+        t10.encode(into: &self)
+        t11.encode(into: &self)
+        t12.encode(into: &self)
     }
 
     @inlinable
     public mutating func encodeArray<T0: RESPRenderable, T1: RESPRenderable, T2: RESPRenderable, T3: RESPRenderable, T4: RESPRenderable, T5: RESPRenderable, T6: RESPRenderable, T7: RESPRenderable, T8: RESPRenderable, T9: RESPRenderable, T10: RESPRenderable, T11: RESPRenderable, T12: RESPRenderable, T13: RESPRenderable>(_ t0: T0, _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4, _ t5: T5, _ t6: T6, _ t7: T7, _ t8: T8, _ t9: T9, _ t10: T10, _ t11: T11, _ t12: T12, _ t13: T13) {
         self.encodeIdentifier(.array)
-        var count = 0
-        let arrayCountIndex = buffer.writerIndex
-        self.buffer.writeStaticString("0\r\n")
-        count += t0.encode(into: &self)
-        count += t1.encode(into: &self)
-        count += t2.encode(into: &self)
-        count += t3.encode(into: &self)
-        count += t4.encode(into: &self)
-        count += t5.encode(into: &self)
-        count += t6.encode(into: &self)
-        count += t7.encode(into: &self)
-        count += t8.encode(into: &self)
-        count += t9.encode(into: &self)
-        count += t10.encode(into: &self)
-        count += t11.encode(into: &self)
-        count += t12.encode(into: &self)
-        count += t13.encode(into: &self)
-        if count > 9 {
-            // I'm being lazy here and not supporting more than 99 arguments
-            precondition(count < 100)
-            // We need to rebuild ByteBuffer with space for double digit count
-            // skip past count + \r\n
-            let sliceStart = arrayCountIndex + 3
-            var slice = buffer.getSlice(at: sliceStart, length: buffer.writerIndex - sliceStart)!
-            self.buffer.moveWriterIndex(to: arrayCountIndex)
-            self.buffer.writeString(String(count))
-            self.buffer.writeStaticString("\r\n")
-            self.buffer.writeBuffer(&slice)
-        } else {
-            self.buffer.setString(String(count), at: arrayCountIndex)
-        }
+        let count = t0.respEntries + t1.respEntries + t2.respEntries + t3.respEntries + t4.respEntries + t5.respEntries + t6.respEntries + t7.respEntries + t8.respEntries + t9.respEntries + t10.respEntries + t11.respEntries + t12.respEntries + t13.respEntries
+        self.buffer.writeString("\(count)")
+        self.buffer.writeStaticString("\r\n")
+        t0.encode(into: &self)
+        t1.encode(into: &self)
+        t2.encode(into: &self)
+        t3.encode(into: &self)
+        t4.encode(into: &self)
+        t5.encode(into: &self)
+        t6.encode(into: &self)
+        t7.encode(into: &self)
+        t8.encode(into: &self)
+        t9.encode(into: &self)
+        t10.encode(into: &self)
+        t11.encode(into: &self)
+        t12.encode(into: &self)
+        t13.encode(into: &self)
     }
 
     @inlinable
     public mutating func encodeArray<T0: RESPRenderable, T1: RESPRenderable, T2: RESPRenderable, T3: RESPRenderable, T4: RESPRenderable, T5: RESPRenderable, T6: RESPRenderable, T7: RESPRenderable, T8: RESPRenderable, T9: RESPRenderable, T10: RESPRenderable, T11: RESPRenderable, T12: RESPRenderable, T13: RESPRenderable, T14: RESPRenderable>(_ t0: T0, _ t1: T1, _ t2: T2, _ t3: T3, _ t4: T4, _ t5: T5, _ t6: T6, _ t7: T7, _ t8: T8, _ t9: T9, _ t10: T10, _ t11: T11, _ t12: T12, _ t13: T13, _ t14: T14) {
         self.encodeIdentifier(.array)
-        var count = 0
-        let arrayCountIndex = buffer.writerIndex
-        self.buffer.writeStaticString("0\r\n")
-        count += t0.encode(into: &self)
-        count += t1.encode(into: &self)
-        count += t2.encode(into: &self)
-        count += t3.encode(into: &self)
-        count += t4.encode(into: &self)
-        count += t5.encode(into: &self)
-        count += t6.encode(into: &self)
-        count += t7.encode(into: &self)
-        count += t8.encode(into: &self)
-        count += t9.encode(into: &self)
-        count += t10.encode(into: &self)
-        count += t11.encode(into: &self)
-        count += t12.encode(into: &self)
-        count += t13.encode(into: &self)
-        count += t14.encode(into: &self)
-        if count > 9 {
-            // I'm being lazy here and not supporting more than 99 arguments
-            precondition(count < 100)
-            // We need to rebuild ByteBuffer with space for double digit count
-            // skip past count + \r\n
-            let sliceStart = arrayCountIndex + 3
-            var slice = buffer.getSlice(at: sliceStart, length: buffer.writerIndex - sliceStart)!
-            self.buffer.moveWriterIndex(to: arrayCountIndex)
-            self.buffer.writeString(String(count))
-            self.buffer.writeStaticString("\r\n")
-            self.buffer.writeBuffer(&slice)
-        } else {
-            self.buffer.setString(String(count), at: arrayCountIndex)
-        }
+        let count = t0.respEntries + t1.respEntries + t2.respEntries + t3.respEntries + t4.respEntries + t5.respEntries + t6.respEntries + t7.respEntries + t8.respEntries + t9.respEntries + t10.respEntries + t11.respEntries + t12.respEntries + t13.respEntries + t14.respEntries
+        self.buffer.writeString("\(count)")
+        self.buffer.writeStaticString("\r\n")
+        t0.encode(into: &self)
+        t1.encode(into: &self)
+        t2.encode(into: &self)
+        t3.encode(into: &self)
+        t4.encode(into: &self)
+        t5.encode(into: &self)
+        t6.encode(into: &self)
+        t7.encode(into: &self)
+        t8.encode(into: &self)
+        t9.encode(into: &self)
+        t10.encode(into: &self)
+        t11.encode(into: &self)
+        t12.encode(into: &self)
+        t13.encode(into: &self)
+        t14.encode(into: &self)
     }
 }

--- a/Sources/Valkey/RESP/RESPKey.swift
+++ b/Sources/Valkey/RESP/RESPKey.swift
@@ -39,8 +39,12 @@ extension RESPKey: CustomStringConvertible {
 }
 
 extension RESPKey: RESPRenderable {
+
     @inlinable
-    public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+    public var respEntries: Int { 1 }
+
+    @inlinable
+    public func encode(into commandEncoder: inout RESPCommandEncoder) {
         self.rawValue.encode(into: &commandEncoder)
     }
 }

--- a/Sources/Valkey/RESP/RESPRenderable.swift
+++ b/Sources/Valkey/RESP/RESPRenderable.swift
@@ -16,52 +16,77 @@ import NIOCore
 
 /// Type that can be rendered into a RESP buffer
 public protocol RESPRenderable {
-    func encode(into commandEncoder: inout RESPCommandEncoder) -> Int
+    var respEntries: Int { get }
+
+    func encode(into commandEncoder: inout RESPCommandEncoder)
 }
 
 extension Optional: RESPRenderable where Wrapped: RESPRenderable {
+
     @inlinable
-    public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+    public var respEntries: Int {
+        switch self {
+        case .none:
+            return 0
+        case .some(let value):
+            return value.respEntries
+        }
+    }
+
+    @inlinable
+    public func encode(into commandEncoder: inout RESPCommandEncoder) {
         switch self {
         case .some(let wrapped):
             return wrapped.encode(into: &commandEncoder)
         case .none:
-            return 0
+            return
         }
     }
 }
 
 extension Array: RESPRenderable where Element: RESPRenderable {
     @inlinable
-    public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
-        var count = 0
+    public var respEntries: Int {
+        self.reduce(0) { $0 + $1.respEntries }
+    }
+
+    @inlinable
+    public func encode(into commandEncoder: inout RESPCommandEncoder) {
         for element in self {
-            count += element.encode(into: &commandEncoder)
+            element.encode(into: &commandEncoder)
         }
-        return count
     }
 }
 
 extension String: RESPRenderable {
+
     @inlinable
-    public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+    public var respEntries: Int { 1 }
+
+    @inlinable
+    public func encode(into commandEncoder: inout RESPCommandEncoder) {
         commandEncoder.encodeBulkString(self)
-        return 1
     }
 }
 
 extension Int: RESPRenderable {
+
     @inlinable
-    public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+    public var respEntries: Int { 1 }
+
+    @inlinable
+    public func encode(into commandEncoder: inout RESPCommandEncoder) {
         commandEncoder.encodeBulkString(String(self))
-        return 1
     }
 }
 
 extension Double: RESPRenderable {
+
     @inlinable
-    public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {
+    public var respEntries: Int { 1 }
+
+    @inlinable
+    public func encode(into commandEncoder: inout RESPCommandEncoder) {
         commandEncoder.encodeBulkString(String(self))
-        return 1
     }
 }

--- a/Sources/ValkeyCommandsBuilder/ValkeyCommandsRender.swift
+++ b/Sources/ValkeyCommandsBuilder/ValkeyCommandsRender.swift
@@ -57,8 +57,23 @@ extension String {
             }
         }
         self.append("\n")
+        self.append("\(tab)        public var respEntries: Int {\n")
+        self.append("\(tab)            switch self {\n")
+        for arg in arguments {
+            if case .pureToken = arg.type {
+                self.append(
+                    "\(tab)            case .\(arg.swiftArgument): \"\(arg.token!)\".respEntries\n"
+                )
+            } else {
+                self.append(
+                    "\(tab)            case .\(arg.swiftArgument)(let \(arg.swiftArgument)): \(arg.respRepresentable(isArray: false)).respEntries\n"
+                )
+            }
+        }
+        self.append("\(tab)            }\n")
+        self.append("\(tab)        }\n\n")
         self.append("\(tab)        @inlinable\n")
-        self.append("\(tab)        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {\n")
+        self.append("\(tab)        public func encode(into commandEncoder: inout RESPCommandEncoder) {\n")
         self.append("\(tab)            switch self {\n")
         for arg in arguments {
             if case .pureToken = arg.type {
@@ -106,16 +121,27 @@ extension String {
         }
         self.append("\(tab)        }\n\n")
         self.append("\(tab)        @inlinable\n")
-        self.append("\(tab)        public func encode(into commandEncoder: inout RESPCommandEncoder) -> Int {\n")
-        self.append("\(tab)            var count = 0\n")
-        for arg in arguments {
-            if case .pureToken = arg.type {
-                self.append("\(tab)            if self.\(arg.swiftArgument) { count += \"\(arg.token!)\".encode(into: &commandEncoder) }\n")
+        self.append("\(tab)        public var respEntries: Int {\n")
+        self.append("\(tab)            ")
+        let entries = arguments.map {
+            if case .pureToken = $0.type {
+                "\"\($0.token!)\".respEntries"
             } else {
-                self.append("\(tab)            count += \(arg.respRepresentable(isArray: false)).encode(into: &commandEncoder)\n")
+                "\($0.respRepresentable(isArray: false)).respEntries"
             }
         }
-        self.append("\(tab)            return count\n")
+        self.append(entries.joined(separator: " + "))
+        self.append("\n")
+        self.append("\(tab)        }\n\n")
+        self.append("\(tab)        @inlinable\n")
+        self.append("\(tab)        public func encode(into commandEncoder: inout RESPCommandEncoder) {\n")
+        for arg in arguments {
+            if case .pureToken = arg.type {
+                self.append("\(tab)            \"\(arg.token!)\".encode(into: &commandEncoder)\n")
+            } else {
+                self.append("\(tab)            \(arg.respRepresentable(isArray: false)).encode(into: &commandEncoder)\n")
+            }
+        }
         self.append("\(tab)        }\n")
         self.append("\(tab)    }\n")
     }

--- a/dev/generate-multi-command-encoder.sh
+++ b/dev/generate-multi-command-encoder.sh
@@ -22,26 +22,16 @@ function genWithoutContextParameter() {
     echo ") {"
 
     echo "        self.encodeIdentifier(.array)"
-    echo "        var count = 0"
-    echo "        let arrayCountIndex = buffer.writerIndex"
-    echo "        self.buffer.writeStaticString(\"0\\r\\n\")"
-    for ((n = 0; n<$how_many; n +=1)); do
-        echo "        count += t$(($n)).encode(into: &self)"
+    echo -n "        let count = t0.respEntries"
+    for ((n = 1; n<$how_many; n +=1)); do
+        echo -n " + t$(($n)).respEntries"
     done
-    echo "        if count > 9 {"
-    echo "            // I'm being lazy here and not supporting more than 99 arguments"
-    echo "            precondition(count < 100)"
-    echo "            // We need to rebuild ByteBuffer with space for double digit count"
-    echo "            // skip past count + \r\n"
-    echo "            let sliceStart = arrayCountIndex + 3"
-    echo "            var slice = buffer.getSlice(at: sliceStart, length: buffer.writerIndex - sliceStart)!"
-    echo "            self.buffer.moveWriterIndex(to: arrayCountIndex)"
-    echo "            self.buffer.writeString(String(count))"
-    echo "            self.buffer.writeStaticString(\"\\r\\n\")"
-    echo "            self.buffer.writeBuffer(&slice)"
-    echo "        } else {"
-    echo "            self.buffer.setString(String(count), at: arrayCountIndex)"
-    echo "        }"
+    echo
+    echo "        self.buffer.writeString(\"\\(count)\")"
+    echo "        self.buffer.writeStaticString(\"\\r\\n\")"
+    for ((n = 0; n<$how_many; n +=1)); do
+        echo "        t$(($n)).encode(into: &self)"
+    done
     echo "    }"
 }
 


### PR DESCRIPTION
### Motivation

If our command is currently longer than 10 elements, we need to go back and rewrite the array length.

### Changes

- We can precompute the command array length before writing it

### Result

This should be faster in the special case. It also makes code generation significantly easier, as variadic generics currently crash the compiler in release builds.