### PR TITLE
ValkeyChannelHandler StateMachine version 2

### DIFF
--- a/Sources/Valkey/Connection/ValkeyChannelHandler+stateMachine.swift
+++ b/Sources/Valkey/Connection/ValkeyChannelHandler+stateMachine.swift
@@ -1,0 +1,140 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-valkey project
+//
+// Copyright (c) 2025 the swift-valkey authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See swift-valkey/CONTRIBUTORS.txt for the list of swift-valkey authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+extension ValkeyChannelHandler {
+    @usableFromInline
+    struct StateMachine<Context> {
+        @usableFromInline
+        enum State {
+            case initializing
+            case active(ActiveState)
+            case closing(ClosingState)
+            case closed
+        }
+        @usableFromInline
+        var state: State
+
+        @usableFromInline
+        struct ActiveState {
+            let context: Context
+        }
+
+        @usableFromInline
+        struct ClosingState {
+            let context: Context
+        }
+
+        init() {
+            self.state = .initializing
+        }
+
+        /// handler has become active
+        @usableFromInline
+        mutating func setActive(context: Context) {
+            switch self.state {
+            case .initializing:
+                self.state = .active(.init(context: context))
+            case .active, .closing, .closed:
+                preconditionFailure("Cannot set active state when state is \(self.state)")
+            }
+        }
+
+        @usableFromInline
+        enum SendCommandAction {
+            case sendCommand(Context)
+            case throwError(Error)
+        }
+
+        /// handler wants to send a command
+        @usableFromInline
+        func sendCommand() -> SendCommandAction {
+            switch self.state {
+            case .initializing:
+                preconditionFailure("Cannot send command when initializing")
+            case .active(let state):
+                return .sendCommand(state.context)
+            case .closing:
+                return .throwError(ValkeyClientError(.connectionClosing))
+            case .closed:
+                return .throwError(ValkeyClientError(.connectionClosed))
+            }
+        }
+
+        @usableFromInline
+        enum GracefulShutdownAction {
+            case waitForPendingCommands(Context)
+            case doNothing
+        }
+        /// Want to gracefully shutdown the handler
+        @usableFromInline
+        mutating func gracefulShutdown() -> GracefulShutdownAction {
+            switch self.state {
+            case .initializing:
+                self.state = .closed
+                return .doNothing
+            case .active(let state):
+                self.state = .closing(ClosingState(context: state.context))
+                return .waitForPendingCommands(state.context)
+            case .closed, .closing:
+                return .doNothing
+            }
+        }
+
+        @usableFromInline
+        enum CloseAction {
+            case close(Context)
+            case doNothing
+        }
+        /// Want to close the connection
+        @usableFromInline
+        mutating func close() -> CloseAction {
+            switch self.state {
+            case .initializing:
+                self.state = .closed
+                return .doNothing
+            case .active(let state):
+                self.state = .closed
+                return .close(state.context)
+            case .closing(let state):
+                self.state = .closed
+                return .close(state.context)
+            case .closed:
+                return .doNothing
+            }
+        }
+
+        @usableFromInline
+        enum SetClosedAction {
+            case failPendingCommands
+            case doNothing
+        }
+
+        /// The connection has been closed
+        @usableFromInline
+        mutating func setClosed() -> SetClosedAction {
+            switch self.state {
+            case .initializing:
+                self.state = .closed
+                return .doNothing
+            case .active, .closing:
+                self.state = .closed
+                return .failPendingCommands
+            case .closed:
+                return .doNothing
+            }
+        }
+    }
+}

--- a/Sources/Valkey/ValkeyClientError.swift
+++ b/Sources/Valkey/ValkeyClientError.swift
@@ -16,6 +16,7 @@
 public struct ValkeyClientError: Error, CustomStringConvertible, Equatable {
     public struct ErrorCode: Equatable, Sendable {
         fileprivate enum _Internal: Equatable, Sendable {
+            case connectionClosing
             case connectionClosed
             case commandError
             case subscriptionError
@@ -29,6 +30,8 @@ public struct ValkeyClientError: Error, CustomStringConvertible, Equatable {
             self.value = value
         }
 
+        /// Connection is closing
+        public static var connectionClosing: Self { .init(.connectionClosing) }
         /// Connection is closed
         public static var connectionClosed: Self { .init(.connectionClosed) }
         /// Error returned by Valkey command
@@ -52,6 +55,7 @@ public struct ValkeyClientError: Error, CustomStringConvertible, Equatable {
 
     public var description: String {
         switch self.errorCode.value {
+        case .connectionClosing: "Connection is closing"
         case .connectionClosed: "Connection has been closed"
         case .commandError: self.message ?? "Valkey command returned an error"
         case .subscriptionError: self.message ?? "Received invalid subscription push event"

--- a/Tests/ValkeyTests/ValkeyChannelHandlerStateMachineTests.swift
+++ b/Tests/ValkeyTests/ValkeyChannelHandlerStateMachineTests.swift
@@ -1,0 +1,104 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-valkey open source project
+//
+// Copyright (c) 2025 Apple Inc. and the swift-valkey project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-valkey project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import Testing
+
+@testable import Valkey
+
+struct ValkeyChannelHandlerStateMachineTests {
+    @Test
+    func testClose() async throws {
+        var stateMachine = ValkeyChannelHandler.StateMachine<String>()
+        stateMachine.setActive(context: "testClose")
+        #expect(stateMachine.state == .active(.init(context: "testClose")))
+        switch stateMachine.close() {
+        case .close(let context):
+            #expect(context == "testClose")
+        default:
+            Issue.record("Invalid close action")
+        }
+        #expect(stateMachine.state == .closed)
+    }
+
+    @Test
+    func testClosed() async throws {
+        var stateMachine = ValkeyChannelHandler.StateMachine<String>()
+        stateMachine.setActive(context: "testClosed")
+        switch stateMachine.setClosed() {
+        case .failPendingCommands:
+            break
+        default:
+            Issue.record("Invalid close action")
+        }
+        #expect(stateMachine.state == .closed)
+    }
+
+    @Test
+    func testGracefulShutdown() async throws {
+        var stateMachine = ValkeyChannelHandler.StateMachine<String>()
+        stateMachine.setActive(context: "testGracefulShutdown")
+        switch stateMachine.gracefulShutdown() {
+        case .waitForPendingCommands(let context):
+            #expect(context == "testGracefulShutdown")
+        default:
+            Issue.record("Invalid waitForPendingCommands action")
+        }
+        #expect(stateMachine.state == .closing(.init(context: "testGracefulShutdown")))
+        switch stateMachine.close() {
+        case .close(let context):
+            #expect(context == "testGracefulShutdown")
+        default:
+            Issue.record("Invalid close action")
+        }
+        #expect(stateMachine.state == .closed)
+    }
+
+    @Test
+    func testClosedClosingState() async throws {
+        var stateMachine = ValkeyChannelHandler.StateMachine<String>()
+        stateMachine.setActive(context: "testClosedClosingState")
+        switch stateMachine.gracefulShutdown() {
+        case .waitForPendingCommands(let context):
+            #expect(context == "testClosedClosingState")
+        default:
+            Issue.record("Invalid waitForPendingCommands action")
+        }
+        #expect(stateMachine.state == .closing(.init(context: "testClosedClosingState")))
+        switch stateMachine.setClosed() {
+        case .failPendingCommands:
+            break
+        default:
+            Issue.record("Invalid close action")
+        }
+        #expect(stateMachine.state == .closed)
+    }
+}
+
+extension ValkeyChannelHandler.StateMachine<String>.State: Equatable {
+    public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.initializing, .initializing):
+            return true
+        case (.active(let lhs), .active(let rhs)):
+            return lhs.context == rhs.context
+        case (.closing(let lhs), .closing(let rhs)):
+            return lhs.context == rhs.context
+        case (.closed, .closed):
+            return true
+        default:
+            return false
+        }
+    }
+}


### PR DESCRIPTION
Re-implemented the state machine for ValkeyChannelHandler with latest changes

The state machine supports gracefulShutdown but I haven't come up for a satisfactory way to implement it in the channel handler. I can't chain a promise onto the last `ValkeyPromise` in the queue as it could be a continuation.