### PR TITLE
Add ValkeyConnectionProtocol for a connection that can send commands

### DIFF
--- a/Sources/Valkey/Commands/BitmapCommands.swift
+++ b/Sources/Valkey/Commands/BitmapCommands.swift
@@ -444,7 +444,7 @@ public struct SETBIT: ValkeyCommand {
     }
 }
 
-extension ValkeyConnection {
+extension ValkeyConnectionProtocol {
     /// Counts the number of set bits (population counting) in a string.
     ///
     /// - Documentation: [BITCOUNT](https:/valkey.io/commands/bitcount)

--- a/Sources/Valkey/Commands/ClusterCommands.swift
+++ b/Sources/Valkey/Commands/ClusterCommands.swift
@@ -513,7 +513,7 @@ public struct READWRITE: ValkeyCommand {
     }
 }
 
-extension ValkeyConnection {
+extension ValkeyConnectionProtocol {
     /// Signals that a cluster client is following an -ASK redirect.
     ///
     /// - Documentation: [ASKING](https:/valkey.io/commands/asking)

--- a/Sources/Valkey/Commands/ConnectionCommands.swift
+++ b/Sources/Valkey/Commands/ConnectionCommands.swift
@@ -642,7 +642,7 @@ public struct SELECT: ValkeyCommand {
     }
 }
 
-extension ValkeyConnection {
+extension ValkeyConnectionProtocol {
     /// Authenticates the connection.
     ///
     /// - Documentation: [AUTH](https:/valkey.io/commands/auth)

--- a/Sources/Valkey/Commands/GenericCommands.swift
+++ b/Sources/Valkey/Commands/GenericCommands.swift
@@ -862,7 +862,7 @@ public struct WAITAOF: ValkeyCommand {
     }
 }
 
-extension ValkeyConnection {
+extension ValkeyConnectionProtocol {
     /// Copies the value of a key to a new key.
     ///
     /// - Documentation: [COPY](https:/valkey.io/commands/copy)

--- a/Sources/Valkey/Commands/GeoCommands.swift
+++ b/Sources/Valkey/Commands/GeoCommands.swift
@@ -978,7 +978,7 @@ public struct GEOSEARCHSTORE: ValkeyCommand {
     }
 }
 
-extension ValkeyConnection {
+extension ValkeyConnectionProtocol {
     /// Adds one or more members to a geospatial index. The key is created if it doesn't exist.
     ///
     /// - Documentation: [GEOADD](https:/valkey.io/commands/geoadd)

--- a/Sources/Valkey/Commands/HashCommands.swift
+++ b/Sources/Valkey/Commands/HashCommands.swift
@@ -388,7 +388,7 @@ public struct HVALS: ValkeyCommand {
     }
 }
 
-extension ValkeyConnection {
+extension ValkeyConnectionProtocol {
     /// Deletes one or more fields and their values from a hash. Deletes the hash if no fields remain.
     ///
     /// - Documentation: [HDEL](https:/valkey.io/commands/hdel)

--- a/Sources/Valkey/Commands/HyperloglogCommands.swift
+++ b/Sources/Valkey/Commands/HyperloglogCommands.swift
@@ -85,7 +85,7 @@ public struct PFSELFTEST: ValkeyCommand {
     }
 }
 
-extension ValkeyConnection {
+extension ValkeyConnectionProtocol {
     /// Adds elements to a HyperLogLog key. Creates the key if it doesn't exist.
     ///
     /// - Documentation: [PFADD](https:/valkey.io/commands/pfadd)

--- a/Sources/Valkey/Commands/ListCommands.swift
+++ b/Sources/Valkey/Commands/ListCommands.swift
@@ -573,7 +573,7 @@ public struct RPUSHX<Element: RESPStringRenderable>: ValkeyCommand {
     }
 }
 
-extension ValkeyConnection {
+extension ValkeyConnectionProtocol {
     /// Pops an element from a list, pushes it to another list and returns it. Blocks until an element is available otherwise. Deletes the list if the last element was moved.
     ///
     /// - Documentation: [BLMOVE](https:/valkey.io/commands/blmove)

--- a/Sources/Valkey/Commands/PubsubCommands.swift
+++ b/Sources/Valkey/Commands/PubsubCommands.swift
@@ -222,7 +222,7 @@ public struct UNSUBSCRIBE: ValkeyCommand {
     }
 }
 
-extension ValkeyConnection {
+extension ValkeyConnectionProtocol {
     /// Posts a message to a channel.
     ///
     /// - Documentation: [PUBLISH](https:/valkey.io/commands/publish)

--- a/Sources/Valkey/Commands/ScriptingCommands.swift
+++ b/Sources/Valkey/Commands/ScriptingCommands.swift
@@ -401,7 +401,7 @@ public struct FCALLRO<Function: RESPStringRenderable>: ValkeyCommand {
     }
 }
 
-extension ValkeyConnection {
+extension ValkeyConnectionProtocol {
     /// Executes a server-side Lua script.
     ///
     /// - Documentation: [EVAL](https:/valkey.io/commands/eval)

--- a/Sources/Valkey/Commands/ServerCommands.swift
+++ b/Sources/Valkey/Commands/ServerCommands.swift
@@ -1249,7 +1249,7 @@ public struct TIME: ValkeyCommand {
     }
 }
 
-extension ValkeyConnection {
+extension ValkeyConnectionProtocol {
     /// Lists the ACL categories, or the commands inside a category.
     ///
     /// - Documentation: [ACL CAT](https:/valkey.io/commands/acl-cat)

--- a/Sources/Valkey/Commands/SetCommands.swift
+++ b/Sources/Valkey/Commands/SetCommands.swift
@@ -339,7 +339,7 @@ public struct SUNIONSTORE: ValkeyCommand {
     }
 }
 
-extension ValkeyConnection {
+extension ValkeyConnectionProtocol {
     /// Adds one or more members to a set. Creates the key if it doesn't exist.
     ///
     /// - Documentation: [SADD](https:/valkey.io/commands/sadd)

--- a/Sources/Valkey/Commands/SortedSetCommands.swift
+++ b/Sources/Valkey/Commands/SortedSetCommands.swift
@@ -1108,7 +1108,7 @@ public struct ZUNIONSTORE: ValkeyCommand {
     }
 }
 
-extension ValkeyConnection {
+extension ValkeyConnectionProtocol {
     /// Removes and returns a member by score from one or more sorted sets. Blocks until a member is available otherwise. Deletes the sorted set if the last element was popped.
     ///
     /// - Documentation: [BZMPOP](https:/valkey.io/commands/bzmpop)

--- a/Sources/Valkey/Commands/StreamCommands.swift
+++ b/Sources/Valkey/Commands/StreamCommands.swift
@@ -820,7 +820,7 @@ public struct XTRIM<Threshold: RESPStringRenderable>: ValkeyCommand {
     }
 }
 
-extension ValkeyConnection {
+extension ValkeyConnectionProtocol {
     /// Returns the number of messages that were successfully acknowledged by the consumer group member of a stream.
     ///
     /// - Documentation: [XACK](https:/valkey.io/commands/xack)

--- a/Sources/Valkey/Commands/StringCommands.swift
+++ b/Sources/Valkey/Commands/StringCommands.swift
@@ -550,7 +550,7 @@ public struct SUBSTR: ValkeyCommand {
     }
 }
 
-extension ValkeyConnection {
+extension ValkeyConnectionProtocol {
     /// Appends a string to the value of a key. Creates the key if it doesn't exist.
     ///
     /// - Documentation: [APPEND](https:/valkey.io/commands/append)

--- a/Sources/Valkey/Commands/TransactionsCommands.swift
+++ b/Sources/Valkey/Commands/TransactionsCommands.swift
@@ -79,7 +79,7 @@ public struct WATCH: ValkeyCommand {
     }
 }
 
-extension ValkeyConnection {
+extension ValkeyConnectionProtocol {
     /// Discards a transaction.
     ///
     /// - Documentation: [DISCARD](https:/valkey.io/commands/discard)

--- a/Sources/Valkey/Connection/ValkeyConnection.swift
+++ b/Sources/Valkey/Connection/ValkeyConnection.swift
@@ -42,7 +42,7 @@ public struct ServerAddress: Sendable, Equatable {
 }
 
 /// Single connection to a Valkey database
-public final class ValkeyConnection: Sendable {
+public final class ValkeyConnection: ValkeyConnectionProtocol, Sendable {
     /// Logger used by Server
     let logger: Logger
     @usableFromInline

--- a/Sources/Valkey/Connection/ValkeyConnectionProtocol.swift
+++ b/Sources/Valkey/Connection/ValkeyConnectionProtocol.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-valkey project
+//
+// Copyright (c) 2025 the swift-valkey authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See swift-valkey/CONTRIBUTORS.txt for the list of swift-valkey authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Protocol for a Valkey connection that can send a command and get a response
+public protocol ValkeyConnectionProtocol {
+    /// Send RESP command to Valkey connection
+    /// - Parameter command: ValkeyCommand structure
+    /// - Returns: The command response as defined in the ValkeyCommand
+    func send<Command: ValkeyCommand>(command: Command) async throws -> Command.Response
+}

--- a/Sources/ValkeyCommandsBuilder/ValkeyCommandsRender.swift
+++ b/Sources/ValkeyCommandsBuilder/ValkeyCommandsRender.swift
@@ -357,7 +357,7 @@ func renderValkeyCommands(_ commands: [String: ValkeyCommand], replies: RESPRepl
     let subscribeFunctions = ["SUBSCRIBE", "PSUBSCRIBE", "SSUBSCRIBE", "UNSUBSCRIBE", "PUNSUBSCRIBE", "SUNSUBSCRIBE"]
     keys.removeAll { subscribeFunctions.contains($0) }
 
-    string.append("extension ValkeyConnection {\n")
+    string.append("extension ValkeyConnectionProtocol {\n")
     for key in keys {
         let command = commands[key]!
         // if there is no reply info assume command is a container command


### PR DESCRIPTION
Basically create protocol with one requirement `send<Command: ValkeyCommand>(command:)` then extend it with all the Valkey commands. Extend `ValkeyConnectionProtocol` with all the commands and conform `ValkeyConnection` to `ValkeyConnectionProtocol`.

This allows us to create other types of connection eg cluster/cached and bring along all the commands.