### PR TITLE
Remove option to use RESP2 protocol

### DIFF
--- a/Sources/Valkey/Connection/ValkeyChannelHandler.swift
+++ b/Sources/Valkey/Connection/ValkeyChannelHandler.swift
@@ -49,7 +49,6 @@ enum ValkeyRequest: Sendable {
 @usableFromInline
 final class ValkeyChannelHandler: ChannelInboundHandler {
     struct Configuration {
-        let respVersion: ValkeyClientConfiguration.RESPVersion
         let authentication: ValkeyClientConfiguration.Authentication?
         let clientName: String?
     }
@@ -218,23 +217,21 @@ final class ValkeyChannelHandler: ChannelInboundHandler {
     @usableFromInline
     func hello(context: ChannelHandlerContext) {
         // send hello with protocol, authentication and client name details
-        if configuration.respVersion == .v3 || configuration.authentication != nil || configuration.clientName != nil {
-            self._send(
-                command: HELLO(
-                    arguments: .init(
-                        protover: configuration.respVersion.rawValue,
-                        auth: configuration.authentication.map { .init(username: $0.username, password: $0.password) },
-                        clientname: configuration.clientName
-                    )
+        self._send(
+            command: HELLO(
+                arguments: .init(
+                    protover: 3,
+                    auth: configuration.authentication.map { .init(username: $0.username, password: $0.password) },
+                    clientname: configuration.clientName
                 )
-            ).assumeIsolated().whenComplete { result in
-                switch result {
-                case .failure(let error):
-                    context.fireErrorCaught(error)
-                    context.close(promise: nil)
-                case .success:
-                    break
-                }
+            )
+        ).assumeIsolated().whenComplete { result in
+            switch result {
+            case .failure(let error):
+                context.fireErrorCaught(error)
+                context.close(promise: nil)
+            case .success:
+                break
             }
         }
     }

--- a/Sources/Valkey/Connection/ValkeyConnection.swift
+++ b/Sources/Valkey/Connection/ValkeyConnection.swift
@@ -219,7 +219,7 @@ public final class ValkeyConnection: Sendable {
 
     package static func setupChannelAndConnect(
         _ channel: any Channel,
-        configuration: ValkeyClientConfiguration,
+        configuration: ValkeyClientConfiguration = .init(),
         clientName: String? = nil,
         logger: Logger
     ) async throws -> ValkeyConnection {
@@ -269,7 +269,7 @@ public final class ValkeyConnection: Sendable {
             break
         }
         let valkeyChannelHandler = ValkeyChannelHandler(
-            configuration: .init(respVersion: configuration.respVersion, authentication: configuration.authentication, clientName: clientName),
+            configuration: .init(authentication: configuration.authentication, clientName: clientName),
             eventLoop: channel.eventLoop,
             logger: logger
         )

--- a/Sources/Valkey/ValkeyClientConfiguration.swift
+++ b/Sources/Valkey/ValkeyClientConfiguration.swift
@@ -16,13 +16,6 @@ import NIOSSL
 
 /// Configuration for the Valkey client
 public struct ValkeyClientConfiguration: Sendable {
-    public struct RESPVersion: Sendable, Equatable {
-        let rawValue: Int
-
-        public static var v2: Self { .init(rawValue: 2) }
-        public static var v3: Self { .init(rawValue: 3) }
-    }
-
     public struct TLS: Sendable {
         enum Base {
             case disable
@@ -47,8 +40,6 @@ public struct ValkeyClientConfiguration: Sendable {
         }
     }
 
-    /// Version of RESP protocol
-    public var respVersion: RESPVersion
     /// authentication details
     public var authentication: Authentication?
     /// TLS setup
@@ -56,15 +47,12 @@ public struct ValkeyClientConfiguration: Sendable {
 
     ///  Initialize ValkeyClientConfiguration
     /// - Parameters
-    ///   - respVersion: RESP protocol version to use
     ///   - authentication: Authentication details
     ///   - tlsConfiguration: TLS configuration
     public init(
-        respVersion: RESPVersion = .v3,
         authentication: Authentication? = nil,
         tls: TLS = .disable
     ) {
-        self.respVersion = respVersion
         self.authentication = authentication
         self.tls = tls
     }

--- a/Tests/IntegrationTests/ValkeyTests.swift
+++ b/Tests/IntegrationTests/ValkeyTests.swift
@@ -502,7 +502,6 @@ struct GeneratedCommands {
             group.addTask {
                 try await ValkeyClient(
                     .hostname(valkeyHostname, port: 6379),
-                    configuration: .init(respVersion: .v3),
                     logger: logger
                 ).withConnection(logger: logger) { connection in
                     try await connection.subscribe(to: "testSubscriptions") { subscription in

--- a/Tests/ValkeyTests/Utils/NIOAsyncTestingChannel+hello.swift
+++ b/Tests/ValkeyTests/Utils/NIOAsyncTestingChannel+hello.swift
@@ -19,9 +19,9 @@ import Testing
 @testable import Valkey
 
 extension NIOAsyncTestingChannel {
-    func processHello(version: ValkeyClientConfiguration.RESPVersion = .v3) async throws {
+    func processHello() async throws {
         let hello = try await self.waitForOutboundWrite(as: ByteBuffer.self)
-        #expect(hello == RESPToken(.array([.bulkString("HELLO"), .bulkString("\(version.rawValue)")])).base)
+        #expect(hello == RESPToken(.array([.bulkString("HELLO"), .bulkString("3")])).base)
         try await self.writeInbound(
             RESPToken(
                 .map([

--- a/Tests/ValkeyTests/ValkeyConnectionTests.swift
+++ b/Tests/ValkeyTests/ValkeyConnectionTests.swift
@@ -70,7 +70,6 @@ struct ConnectionTests {
         _ = try await ValkeyConnection.setupChannelAndConnect(
             channel,
             configuration: .init(
-                respVersion: .v3,
                 authentication: .init(username: "john", password: "smith")
             ),
             logger: logger
@@ -86,13 +85,12 @@ struct ConnectionTests {
         let logger = Logger(label: "test")
         _ = try await ValkeyConnection.setupChannelAndConnect(
             channel,
-            configuration: .init(respVersion: .v2),
             clientName: "Testing",
             logger: logger
         )
 
         let outbound = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
-        #expect(outbound == RESPToken(.command(["HELLO", "2", "SETNAME", "Testing"])).base)
+        #expect(outbound == RESPToken(.command(["HELLO", "3", "SETNAME", "Testing"])).base)
     }
 
     @Test


### PR DESCRIPTION
This means we don't need to add additional support to the channel handler to support RESP2 subscriptions
Also a number of commands return different types based on whether you are using RESP2 or 3. Sticking to one return type would make life a lot easier.