### PR TITLE
Add ValkeyMovedError for Cluster Redirect Handling

### DIFF
--- a/Sources/Valkey/Cluster/ValkeyMovedError.swift
+++ b/Sources/Valkey/Cluster/ValkeyMovedError.swift
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-valkey project
+//
+// Copyright (c) 2025 the swift-valkey authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See swift-valkey/CONTRIBUTORS.txt for the list of swift-valkey authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+/// Represents a `MOVED` redirection error from a Valkey cluster node.
+///
+/// When a client sends a command to a Valkey cluster node that doesn't own
+/// the hash slot for the specified key, the node responds with a `MOVED` error
+/// containing information about which node actually owns that slot.
+///
+/// This error provides the necessary information for clients to redirect their
+/// request to the correct node in the cluster.
+@usableFromInline
+struct ValkeyMovedError: Hashable, Sendable {
+    /// The hash slot number that triggered the redirection.
+    var slot: HashSlot
+    
+    /// The hostname or IP address of the node that owns the requested hash slot.
+    var endpoint: String
+    
+    /// The port number of the node that owns the requested hash slot.
+    var port: Int
+}
+
+extension RESPToken {
+    static let movedPrefix = "MOVED "
+
+    /// Attempts to parse a RESP error token as a Valkey MOVED error.
+    ///
+    /// This method extracts the hash slot, endpoint, and port information from a RESP error
+    /// token if it represents a Valkey MOVED error. MOVED errors are returned by Valkey cluster 
+    /// nodes when a client attempts to access a key that belongs to a different node.
+    ///
+    /// The error format is expected to be: `"MOVED <slot> <endpoint>:<port>"`
+    ///
+    /// - Returns: A `ValkeyMovedError` if the token represents a valid MOVED error, or `nil` otherwise.
+    @usableFromInline
+    func parseMovedError() -> ValkeyMovedError? {
+        let byteBuffer: ByteBuffer? = switch self.value {
+        case .bulkError(let byteBuffer),
+             .simpleError(let byteBuffer):
+            byteBuffer
+
+        case .simpleString,
+             .bulkString,
+             .verbatimString,
+             .number,
+             .double,
+             .boolean,
+             .bigNumber,
+             .array,
+             .attribute,
+             .map,
+             .set,
+             .push,
+             .null:
+            nil
+        }
+
+        guard var byteBuffer else {
+            return nil
+        }
+        let errorMessage = byteBuffer.readString(length: byteBuffer.readableBytes)!
+        guard errorMessage.hasPrefix(Self.movedPrefix) else {
+            return nil
+        }
+
+        let msg = errorMessage.dropFirst(Self.movedPrefix.count)
+        guard let spaceAfterSlotIndex = msg.firstIndex(where: { $0 == " " }) else {
+            return nil
+        }
+
+        let hashSlice = msg[msg.startIndex..<spaceAfterSlotIndex]
+        guard let hashInt = UInt16(hashSlice), let slot = HashSlot(rawValue: hashInt) else {
+            return nil
+        }
+
+        let firstEndpointIndex = msg.index(after: spaceAfterSlotIndex)
+
+        guard let colonIndex = msg[spaceAfterSlotIndex...].firstIndex(where: { $0 == ":" }) else {
+            return nil
+        }
+
+        let firstPortIndex = msg.index(after: colonIndex)
+
+        let endpoint = msg[firstEndpointIndex..<colonIndex]
+        guard let port = Int(msg[firstPortIndex...]) else {
+            return nil
+        }
+
+        return ValkeyMovedError(slot: slot, endpoint: String(endpoint), port: port)
+    }
+}
+

--- a/Tests/ValkeyTests/Cluster/ValkeyMovedErrorTests.swift
+++ b/Tests/ValkeyTests/Cluster/ValkeyMovedErrorTests.swift
@@ -1,0 +1,123 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-valkey project
+//
+// Copyright (c) 2025 the swift-valkey authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See swift-valkey/CONTRIBUTORS.txt for the list of swift-valkey authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+import Testing
+
+@testable import Valkey
+
+@Suite("ValkeyMovedError")
+struct ValkeyMovedErrorTests {
+    
+    @Test("parseMovedError parses valid MOVED error")
+    func testParseValidMovedError() async throws {
+        // Create a RESPToken with a MOVED error
+        let token = RESPToken(.simpleError("MOVED 1234 redis.example.com:6379"))
+
+        // Parse the moved error
+        let movedError = token.parseMovedError()
+        
+        // Verify the moved error is parsed correctly
+        #expect(movedError != nil)
+        #expect(movedError?.slot.rawValue == 1234)
+        #expect(movedError?.endpoint == "redis.example.com")
+        #expect(movedError?.port == 6379)
+    }
+    
+    @Test("parseMovedError parses valid MOVED error from bulkError")
+    func testParseValidMovedErrorFromBulkError() async throws {
+        // Create a RESPToken with a MOVED error
+        let errorMessage = "MOVED 5000 10.0.0.1:6380"
+        let byteBuffer = ByteBuffer(string: errorMessage)
+        let token = RESPToken(.bulkError(byteBuffer))
+        
+        // Parse the moved error
+        let movedError = token.parseMovedError()
+        
+        // Verify the moved error is parsed correctly
+        #expect(movedError != nil)
+        #expect(movedError?.slot.rawValue == 5000)
+        #expect(movedError?.endpoint == "10.0.0.1")
+        #expect(movedError?.port == 6380)
+    }
+    
+    @Test("parseMovedError returns nil for non-error tokens")
+    func testParseNonErrorToken() async throws {
+        // Test with various non-error token types
+        let nullToken = RESPToken(.null)
+        #expect(nullToken.parseMovedError() == nil)
+        
+        let stringToken = RESPToken(.simpleString("OK"))
+        #expect(stringToken.parseMovedError() == nil)
+        
+        let numberToken = RESPToken(.number(42))
+        #expect(numberToken.parseMovedError() == nil)
+        
+        let arrayToken = RESPToken(.array([.number(1), .number(2)]))
+        #expect(arrayToken.parseMovedError() == nil)
+    }
+    
+    @Test("parseMovedError returns nil for error tokens without MOVED prefix")
+    func testParseNonMovedError() async throws {
+        let errorMessage = "ERR unknown command"
+        let byteBuffer = ByteBuffer(string: errorMessage)
+        let token = RESPToken(.simpleError(byteBuffer))
+        
+        #expect(token.parseMovedError() == nil)
+    }
+    
+    @Test("parseMovedError returns nil for invalid MOVED format")
+    func testParseInvalidMovedFormat() async throws {
+        // Test with various invalid MOVED formats
+        
+        // Missing slot number
+        let missingSlot = RESPToken(.simpleError("MOVED redis.example.com:6379"))
+        #expect(missingSlot.parseMovedError() == nil)
+        
+        // Missing port number
+        let missingPort = RESPToken(.simpleError("MOVED 1234 redis.example.com"))
+        #expect(missingPort.parseMovedError() == nil)
+        
+        // Invalid slot number
+        let invalidSlot = RESPToken(.simpleError("MOVED abc redis.example.com:6379"))
+        #expect(invalidSlot.parseMovedError() == nil)
+        
+        // Invalid port number
+        let invalidPort = RESPToken(.simpleError("MOVED 1234 redis.example.com:port"))
+        #expect(invalidPort.parseMovedError() == nil)
+        
+        // Slot number out of range
+        let outOfRangeSlot = RESPToken(.simpleError("MOVED 999999 redis.example.com:6379"))
+        #expect(outOfRangeSlot.parseMovedError() == nil)
+    }
+    
+    @Test("ValkeyMovedError is Hashable")
+    func testHashable() async throws {
+        let error1 = ValkeyMovedError(slot: 1234, endpoint: "redis1.example.com", port: 6379)
+        let error2 = ValkeyMovedError(slot: 1234, endpoint: "redis1.example.com", port: 6379)
+        let error3 = ValkeyMovedError(slot: 5678, endpoint: "redis2.example.com", port: 6380)
+        
+        #expect(error1 == error2)
+        #expect(error1 != error3)
+        
+        var set = Set<ValkeyMovedError>()
+        set.insert(error1)
+        set.insert(error2) // This should not increase the size as it's equal to error1
+        set.insert(error3)
+        
+        #expect(set.count == 2)
+        #expect(set.contains(error1))
+        #expect(set.contains(error3))
+    }
+}

--- a/Tests/ValkeyTests/Utils/RESP3Value.swift
+++ b/Tests/ValkeyTests/Utils/RESP3Value.swift
@@ -159,13 +159,11 @@ enum RESP3Value: Hashable {
 }
 
 extension RESPToken {
-
     init(_ value: RESP3Value) {
         var buffer = ByteBuffer()
         value.writeTo(&buffer)
         try! self.init(consuming: &buffer)!
     }
-
 }
 
 extension ByteBuffer {


### PR DESCRIPTION
### Summary

This PR introduces `ValkeyMovedError`, a specialized error type for handling Valkey cluster redirection responses. When working with a Valkey cluster, commands may be sent to nodes that don't own the required hash slot for a particular key, resulting in "MOVED" error responses. This new error type properly encapsulates the redirection information, enabling clients to seamlessly redirect requests to the appropriate node.

### Details

- Added `ValkeyMovedError` struct that captures the hash slot, endpoint, and port information from MOVED responses
- Implemented parsing logic in an extension to `RESPToken` to extract redirection information from error messages
- The parser handles the standard Valkey MOVED error format: `"MOVED <slot> <endpoint>:<port>"`

### Motivation

In a clustered Valkey environment, proper handling of MOVED responses is essential for building resilient clients. This error type:
1. Enables automatic retries and redirects to the correct node
2. Improves client-side handling of cluster topology changes
3. Provides a foundation for implementing smart routing strategies that can learn and adapt to the cluster configuration

### Impact

This addition is a key building block for cluster-aware clients that can efficiently work with distributed Valkey deployments. It allows clients to gracefully handle redirection scenarios without exposing the underlying complexity to application code.
