### PR TITLE
Fix: Nodes in `CLUSTER SHARDS` are not sorted

### DIFF
--- a/Sources/Valkey/Cluster/HashSlotShardMap.swift
+++ b/Sources/Valkey/Cluster/HashSlotShardMap.swift
@@ -133,13 +133,27 @@ package struct HashSlotShardMap: Sendable {
 
         var shardID = 0
         for shard in shards {
-            guard let master = shard.master else {
+            var master: ValkeyNodeID?
+            var replicas = [ValkeyNodeID]()
+            replicas.reserveCapacity(shard.nodes.count - 1)
+
+            for node in shard.nodes {
+                switch node.role.base {
+                case .master:
+                    master = node.nodeID
+
+                case .replica:
+                    replicas.append(node.nodeID)
+                }
+            }
+
+            guard let master else {
                 continue
             }
 
             let nodeIDs = ValkeyShardNodeIDs(
-                master: master.nodeID,
-                replicas: shard.replicas.map(\.nodeID)
+                master: master,
+                replicas: replicas
             )
 
             defer { shardID += 1 }

--- a/Sources/Valkey/Cluster/ValkeyClusterError.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterError.swift
@@ -15,11 +15,15 @@
 @usableFromInline
 package enum ValkeyClusterError: Error {
     case clusterIsMissingSlotAssignment
+    case clusterIsMissingMovedErrorNode
+    case shardIsMissingMasterNode
+    case shardHasMultipleMasterNodes
     case noNodeToTalkTo
     case serverDiscoveryFailedNoKnownNode
     case keysInCommandRequireMultipleNodes
-    case noConsensusReached
+    case clusterIsUnavailable
     case noConsensusReachedCircuitBreakerOpen
     case clusterHasNoNodes
+    case clusterClientIsShutDown
 }
 

--- a/Sources/Valkey/Cluster/ValkeyMovedError.swift
+++ b/Sources/Valkey/Cluster/ValkeyMovedError.swift
@@ -32,6 +32,11 @@ struct ValkeyMovedError: Hashable, Sendable {
     
     /// The port number of the node that owns the requested hash slot.
     var port: Int
+
+    @usableFromInline
+    var nodeID: ValkeyNodeID {
+        ValkeyNodeID(endpoint: self.endpoint, port: self.port)
+    }
 }
 
 extension RESPToken {

--- a/Sources/Valkey/Cluster/ValkeyTopologyCandidate.swift
+++ b/Sources/Valkey/Cluster/ValkeyTopologyCandidate.swift
@@ -18,38 +18,38 @@
 /// designed specifically for efficient comparison during cluster updates. It preserves
 /// only the essential properties needed to determine if a topology has changed, while
 /// maintaining consistent ordering of elements to ensure reliable equality checks.
-struct ValkeyTopologyCandidate: Hashable {
+package struct ValkeyTopologyCandidate: Hashable {
     /// Represents a shard (hash slot range) within a Valkey cluster topology.
     ///
     /// A shard consists of a set of hash slots assigned to a master node and optional replica nodes.
-    struct Shard: Hashable {
+    package struct Shard: Hashable {
         /// The hash slots assigned to this shard.
-        var slots: HashSlots
+        package var slots: HashSlots
 
         /// The master node responsible for this shard.
-        var master: Node
-        
+        package var master: Node
+
         /// The replica nodes for this shard, sorted by endpoint, port, and TLS status for consistent equality checking.
-        var replicas: [Node]
+        package var replicas: [Node]
     }
 
     /// Represents a node (either master or replica) in the Valkey cluster topology.
     ///
     /// Contains only the essential connection properties needed to identify and connect to a node.
-    struct Node: Hashable {
+    package struct Node: Hashable {
         /// The endpoint (hostname or IP address) of the node.
-        var endpoint: String
-        
+        package var endpoint: String
+
         /// The port to connect to (either standard port or TLS port).
-        var port: Int
-        
+        package var port: Int
+
         /// Whether TLS should be used for connecting to this node.
-        var useTLS: Bool
+        package var useTLS: Bool
 
         /// Creates a simplified node representation from a `ValkeyClusterDescription.Node`.
         ///
         /// - Parameter node: The source node from a cluster description.
-        init(_ node: ValkeyClusterDescription.Node) {
+        package init(_ node: ValkeyClusterDescription.Node) {
             self.endpoint = node.endpoint
             self.port = node.tlsPort ?? node.port ?? 6379
             self.useTLS = node.tlsPort != nil
@@ -57,7 +57,7 @@ struct ValkeyTopologyCandidate: Hashable {
     }
 
     /// Shards in the cluster topology, sorted by starting hash slot for consistent equality checking.
-    var shards: [Shard]
+    package var shards: [Shard]
 
     /// Creates a topology candidate from a cluster description.
     ///
@@ -67,27 +67,54 @@ struct ValkeyTopologyCandidate: Hashable {
     /// - Sorts shards by their starting hash slot for consistent equality checking
     ///
     /// - Parameter description: The cluster description to create a topology candidate from.
-    init(_ description: ValkeyClusterDescription) {
+    package init(_ description: ValkeyClusterDescription) throws(ValkeyClusterError) {
 
-        self.shards = description.shards.map({ shard in
-            Shard(
-                slots: shard.slots,
-                master: Node(shard.master!),
-                replicas: shard.replicas.map { Node($0) }.sorted(by: { lhs, rhs in
-                    if lhs.endpoint != rhs.endpoint {
-                        return lhs.endpoint < rhs.endpoint
+        self.shards = try description.shards.map({ shard throws(ValkeyClusterError) in
+            var master: Node?
+            var replicas = [Node]()
+            replicas.reserveCapacity(shard.nodes.count)
+
+            for node in shard.nodes {
+                switch node.role.base {
+                case .master:
+                    if master != nil {
+                        throw ValkeyClusterError.shardHasMultipleMasterNodes
                     }
-                    if lhs.port != rhs.port {
-                        return lhs.port < rhs.port
-                    }
-                    if lhs.useTLS != rhs.useTLS {
-                        return !lhs.useTLS
-                    }
-                    return true
-                })
+                    master = Node(node)
+                case .replica:
+                    replicas.append(Node(node))
+                }
+            }
+
+            let sorted = replicas.sorted(by: { lhs, rhs in
+                if lhs.endpoint != rhs.endpoint {
+                    return lhs.endpoint < rhs.endpoint
+                }
+                if lhs.port != rhs.port {
+                    return lhs.port < rhs.port
+                }
+                if lhs.useTLS != rhs.useTLS {
+                    return !lhs.useTLS
+                }
+                return true
+            })
+
+            guard let master else {
+                throw ValkeyClusterError.shardIsMissingMasterNode
+            }
+
+            return Shard(
+                slots: shard.slots.sorted(by: { $0.startIndex < $1.startIndex }),
+                master: master,
+                replicas: sorted
             )
         })
         // Sort shards by starting hash slot
         self.shards = self.shards.sorted(by: { (lhs, rhs) in (lhs.slots.first?.startIndex ?? .pastEnd) < (rhs.slots.first?.startIndex ?? .pastEnd) })
     }
+}
+
+struct ValkeyClusterVoter<ConnectionPool: ValkeyNodeConnectionPool> {
+    var client: ConnectionPool
+    var nodeID: ValkeyNodeID
 }

--- a/Sources/Valkey/Cluster/ValkeyTopologyElection.swift
+++ b/Sources/Valkey/Cluster/ValkeyTopologyElection.swift
@@ -1,0 +1,127 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-valkey project
+//
+// Copyright (c) 2025 the swift-valkey authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See swift-valkey/CONTRIBUTORS.txt for the list of swift-valkey authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// ``ValkeyTopologyElection`` manages the consensus process for electing a cluster topology.
+///
+/// This struct tracks votes from cluster nodes for different topology candidates, keeping count of
+/// received votes and determining when a consensus is reached. Once a candidate receives more than half
+/// of the possible votes from all nodes in the cluster, it becomes the elected topology configuration.
+///
+/// The election process handles:
+/// - Recording votes from nodes
+/// - Tracking vote counts for each topology candidate
+/// - Managing revotes (nodes changing their vote)
+/// - Determining when a winner has been elected
+package struct ValkeyTopologyElection {
+    /// Represents a candidate in the topology election, tracking votes and thresholds.
+    ///
+    /// Each candidate corresponds to a specific cluster description and maintains
+    /// count of the votes it has received and how many votes it needs to win.
+    private struct Candidate {
+        /// The cluster configuration this candidate represents.
+        var description: ValkeyClusterDescription
+
+        /// The number of votes needed for this candidate to win the election.
+        /// Calculated as a simple majority of the total nodes in the cluster.
+        var needed: Int
+
+        /// The number of votes this candidate has received so far.
+        var received: Int
+
+        init(description: ValkeyClusterDescription) {
+            self.description = description
+            // Calculate the needed votes as a simple majority of all nodes across all shards
+            self.needed = description.shards.reduce(0) { $0 + $1.nodes.count } / 2 + 1
+            self.received = 0
+        }
+
+        /// Adds a vote for this candidate and checks if it has reached the winning threshold.
+        ///
+        /// - Returns: `true` if this candidate has received enough votes to win, `false` otherwise
+        mutating func addVote() -> Bool {
+            self.received += 1
+            return self.received >= self.needed
+        }
+    }
+
+    /// Provides metrics about the current state of the election process.
+    ///
+    /// This structure encapsulates information about a specific topology candidate,
+    /// including how many votes it has received and how many it needs to win.
+    package struct VoteMetrics {
+        /// The total number of topology configurations being considered in this election.
+        package var candidateCount: Int
+
+        /// The specific topology candidate these metrics refer to.
+        package var candidate: ValkeyTopologyCandidate
+
+        /// The number of votes this candidate has received so far.
+        package var votesReceived: Int
+
+        /// The number of votes needed for this candidate to win the election.
+        /// This is calculated as (total nodes / 2) + 1, representing a simple majority.
+        package var votesNeeded: Int
+    }
+
+    private var votes = [ValkeyNodeID: ValkeyTopologyCandidate]()
+    private var results = [ValkeyTopologyCandidate: Candidate]()
+
+    /// The currently elected cluster configuration, if any.
+    /// This is set to the first candidate that reaches the required vote threshold.
+    package private(set) var winner: ValkeyClusterDescription?
+
+    package init() {}
+
+    /// Records a vote from a node for a specific cluster description.
+    ///
+    /// This method handles the core voting logic:
+    /// 1. If the node has voted before, its previous vote is removed
+    /// 2. The new vote is recorded
+    /// 3. If this vote causes a candidate to reach the required threshold, it becomes the winner
+    ///
+    /// - Parameters:
+    ///   - description: The cluster configuration the node is voting for
+    ///   - voter: The ID of the node casting the vote
+    ///
+    /// - Returns: Metrics about the current state of the election after recording this vote
+    ///
+    /// - Throws: ``ValkeyClusterError`` if the provided cluster description cannot be converted to a valid topology candidate
+    package mutating func voteReceived(
+        for description: ValkeyClusterDescription,
+        from voter: ValkeyNodeID
+    ) throws(ValkeyClusterError) -> VoteMetrics {
+        // 1. check that the voter hasn't voted before.
+        //    - if it has voted before, remove its earlier vote.
+
+        let topologyCandidate = try ValkeyTopologyCandidate(description)
+
+        if let previousVote = self.votes[voter] {
+            self.results[previousVote]!.received -= 1
+        }
+
+        self.votes[voter] = topologyCandidate
+        if self.results[topologyCandidate, default: .init(description: description)].addVote() {
+            if self.winner == nil {
+                self.winner = description
+            }
+        }
+
+        return VoteMetrics(
+            candidateCount: self.results.count,
+            candidate: topologyCandidate,
+            votesReceived: self.results[topologyCandidate]!.received,
+            votesNeeded: self.results[topologyCandidate]!.needed
+        )
+    }
+}

--- a/Sources/Valkey/Commands/Custom/ClusterCustomCommands.swift
+++ b/Sources/Valkey/Commands/Custom/ClusterCustomCommands.swift
@@ -65,7 +65,7 @@ public struct ValkeyClusterDescription: Hashable, Sendable, RESPTokenDecodable {
                 case replica
             }
 
-            private var base: Base
+            private(set) var base: Base
 
             init(base: Base) {
                 self.base = base

--- a/Tests/ValkeyTests/Cluster/ValkeyTopologyCandidateTests.swift
+++ b/Tests/ValkeyTests/Cluster/ValkeyTopologyCandidateTests.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-valkey project
+//
+// Copyright (c) 2025 the swift-valkey authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See swift-valkey/CONTRIBUTORS.txt for the list of swift-valkey authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import Valkey
+
+@Suite("Topology Candidate Tests")
+struct ValkeyTopologyCandidateTests {
+
+    @Test("Ensure the same description in different order is considered equal")
+    func ensureOrderDoesntMatter() throws {
+        let description = ValkeyClusterDescription([
+            .init(
+                slots: [0...2000, 8000...12000],
+                nodes: [
+                    .init(id: "node1", port: nil, tlsPort: 6379, ip: "192.168.12.1", hostname: "node1", endpoint: "node1", role: .replica, replicationOffset: 123, health: .online),
+                    .init(id: "node2", port: nil, tlsPort: 6379, ip: "192.168.12.2", hostname: "node2", endpoint: "node2", role: .replica, replicationOffset: 123, health: .online),
+                    .init(id: "node3", port: nil, tlsPort: 6379, ip: "192.168.12.3", hostname: "node3", endpoint: "node3", role: .master, replicationOffset: 123, health: .online),
+                ]
+            ),
+            .init(
+                slots: [3000...8000, 12000...13000],
+                nodes: [
+                    .init(id: "node4", port: nil, tlsPort: 6379, ip: "192.168.12.4", hostname: "node4", endpoint: "node4", role: .replica, replicationOffset: 123, health: .online),
+                    .init(id: "node5", port: nil, tlsPort: 6379, ip: "192.168.12.5", hostname: "node5", endpoint: "node5", role: .replica, replicationOffset: 123, health: .online),
+                    .init(id: "node6", port: nil, tlsPort: 6379, ip: "192.168.12.6", hostname: "node6", endpoint: "node6", role: .master, replicationOffset: 123, health: .online),
+                ]
+            )
+        ])
+
+        var copy1 = description
+        copy1.shards = description.shards.reversed()
+        copy1.shards[0].nodes = description.shards[0].nodes.reversed()
+        copy1.shards[1].nodes = description.shards[1].nodes.reversed()
+        copy1.shards[0].slots = description.shards[0].slots.reversed()
+        copy1.shards[1].slots = description.shards[1].slots.reversed()
+
+        let candidate1 = try ValkeyTopologyCandidate(description)
+        let candidate2 = try ValkeyTopologyCandidate(copy1)
+
+        #expect(candidate1 == candidate2)
+    }
+
+    @Test("Two master nodes for the same shard throws")
+    func twoMasterNodesForTheSameShardThrows() {
+        let description = ValkeyClusterDescription([
+            .init(
+                slots: [0...2000, 8000...12000],
+                nodes: [
+                    .init(id: "node1", port: nil, tlsPort: 6379, ip: "192.168.12.1", hostname: "node1", endpoint: "node1", role: .replica, replicationOffset: 123, health: .online),
+                    .init(id: "node2", port: nil, tlsPort: 6379, ip: "192.168.12.2", hostname: "node2", endpoint: "node2", role: .master, replicationOffset: 123, health: .online),
+                    .init(id: "node3", port: nil, tlsPort: 6379, ip: "192.168.12.3", hostname: "node3", endpoint: "node3", role: .master, replicationOffset: 123, health: .online),
+                ]
+            ),
+        ])
+
+        #expect(throws: ValkeyClusterError.shardHasMultipleMasterNodes) { try ValkeyTopologyCandidate(description) }
+    }
+
+    @Test("No master node for a shard throws")
+    func noMasterNodeForAShardThrows() {
+        let description = ValkeyClusterDescription([
+            .init(
+                slots: [0...2000, 8000...12000],
+                nodes: [
+                    .init(id: "node1", port: nil, tlsPort: 6379, ip: "192.168.12.1", hostname: "node1", endpoint: "node1", role: .replica, replicationOffset: 123, health: .online),
+                    .init(id: "node2", port: nil, tlsPort: 6379, ip: "192.168.12.2", hostname: "node2", endpoint: "node2", role: .replica, replicationOffset: 123, health: .online),
+                    .init(id: "node3", port: nil, tlsPort: 6379, ip: "192.168.12.3", hostname: "node3", endpoint: "node3", role: .replica, replicationOffset: 123, health: .online),
+                ]
+            ),
+        ])
+
+        #expect(throws: ValkeyClusterError.shardIsMissingMasterNode) { try ValkeyTopologyCandidate(description) }
+    }
+}

--- a/Tests/ValkeyTests/Cluster/ValkeyTopologyElectionTests.swift
+++ b/Tests/ValkeyTests/Cluster/ValkeyTopologyElectionTests.swift
@@ -1,0 +1,273 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-valkey project
+//
+// Copyright (c) 2025 the swift-valkey authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See swift-valkey/CONTRIBUTORS.txt for the list of swift-valkey authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import Valkey
+
+@Suite("Topology Election Tests")
+struct ValkeyTopologyElectionTests {
+    /// Creates a simple cluster description with a single shard and node
+    func createSingleShardCluster(id: String = "node1", endpoint: String = "localhost", slots: [ClosedRange<HashSlot>] = [0...5]) -> ValkeyClusterDescription {
+        let node = ValkeyClusterDescription.Node(
+            id: id,
+            port: 6379,
+            tlsPort: 6380,
+            ip: "127.0.0.1", 
+            hostname: "localhost",
+            endpoint: endpoint,
+            role: .master,
+            replicationOffset: 0,
+            health: .online
+        )
+        
+        let shard = ValkeyClusterDescription.Shard(slots: slots, nodes: [node])
+        return ValkeyClusterDescription([shard])
+    }
+    
+    /// Creates a cluster description with multiple shards
+    func createMultiShardCluster() -> ValkeyClusterDescription {
+        let node1 = ValkeyClusterDescription.Node(
+            id: "node1",
+            port: 6379,
+            tlsPort: 6380,
+            ip: "127.0.0.1", 
+            hostname: "server1",
+            endpoint: "server1.example.com",
+            role: .master,
+            replicationOffset: 0,
+            health: .online
+        )
+        
+        let node2 = ValkeyClusterDescription.Node(
+            id: "node2",
+            port: 6379,
+            tlsPort: 6380,
+            ip: "127.0.0.2", 
+            hostname: "server2",
+            endpoint: "server2.example.com",
+            role: .master,
+            replicationOffset: 0,
+            health: .online
+        )
+        
+        let shard1 = ValkeyClusterDescription.Shard(slots: [0...8000], nodes: [node1])
+        let shard2 = ValkeyClusterDescription.Shard(slots: [8001...16383], nodes: [node2])
+        return ValkeyClusterDescription([shard1, shard2])
+    }
+    
+    /// Creates a cluster description with a master and replica nodes
+    func createClusterWithReplicas() -> ValkeyClusterDescription {
+        let master = ValkeyClusterDescription.Node(
+            id: "master1",
+            port: 6379,
+            tlsPort: 6380,
+            ip: "127.0.0.1", 
+            hostname: "master",
+            endpoint: "master.example.com",
+            role: .master,
+            replicationOffset: 100,
+            health: .online
+        )
+        
+        let replica1 = ValkeyClusterDescription.Node(
+            id: "replica1",
+            port: 6379,
+            tlsPort: 6380,
+            ip: "127.0.0.2", 
+            hostname: "replica1",
+            endpoint: "replica1.example.com",
+            role: .replica,
+            replicationOffset: 95,
+            health: .online
+        )
+        
+        let replica2 = ValkeyClusterDescription.Node(
+            id: "replica2",
+            port: 6379,
+            tlsPort: 6380,
+            ip: "127.0.0.3", 
+            hostname: "replica2",
+            endpoint: "replica2.example.com",
+            role: .replica,
+            replicationOffset: 98,
+            health: .online
+        )
+        
+        let shard = ValkeyClusterDescription.Shard(
+            slots: [0...16383], 
+            nodes: [master, replica1, replica2]
+        )
+        return ValkeyClusterDescription([shard])
+    }
+    
+    @Test("Initial state has no winner")
+    func initialState() {
+        let election = ValkeyTopologyElection()
+        #expect(election.winner == nil)
+    }
+    
+    @Test("Single vote does not establish a winner in multi node scenario")
+    func singleVoteBelowThreshold() throws {
+        var election = ValkeyTopologyElection()
+        
+        // Create a larger cluster description so a single vote isn't enough to win
+        let multiNodeDescription = createClusterWithReplicas()
+        
+        let voterID = ValkeyNodeID(endpoint: "voter1.example.com", port: 6380)
+        let metrics = try election.voteReceived(for: multiNodeDescription, from: voterID)
+        
+        // With 3 nodes in the cluster, we need 2 votes to win (3/2 + 1 = 2)
+        #expect(metrics.votesNeeded == 2)
+        #expect(metrics.votesReceived == 1)
+        #expect(metrics.candidateCount == 1)
+        #expect(election.winner == nil, "A single vote shouldn't be enough to win")
+    }
+    
+    @Test("Sufficient votes establish a winner")
+    func sufficientVotesToWin() throws {
+        var election = ValkeyTopologyElection()
+        let description = createSingleShardCluster()
+        
+        // Single node cluster only needs 1 vote to win (1/2 + 1 = 1)
+        let voterID = ValkeyNodeID(endpoint: "voter1.example.com", port: 6380)
+        let metrics = try election.voteReceived(for: description, from: voterID)
+        
+        #expect(metrics.votesNeeded == 1)
+        #expect(metrics.votesReceived == 1)
+        #expect(election.winner != nil, "Should have a winner with sufficient votes")
+        #expect(election.winner?.shards.count == 1, "Winner should match the voted description")
+    }
+    
+    @Test("First candidate to reach threshold becomes winner")
+    func firstCandidateWins() throws {
+        var election = ValkeyTopologyElection()
+        
+        // Create two different cluster descriptions
+        let description1 = createSingleShardCluster(endpoint: "node1")
+        let description2 = createSingleShardCluster(endpoint: "node2")
+
+        // Vote for the first configuration
+        let voter1 = ValkeyNodeID(endpoint: "voter1.example.com", port: 6380)
+        let voteMetrics1 = try election.voteReceived(for: description1, from: voter1)
+
+        #expect(voteMetrics1.votesReceived == 1)
+        #expect(voteMetrics1.votesNeeded == 1)
+        #expect(voteMetrics1.candidateCount == 1)
+
+        // At this point description1 should be the winner
+        #expect(election.winner == description1, "Should have a winner")
+
+        // Vote for the second configuration
+        let voter2 = ValkeyNodeID(endpoint: "voter2.example.com", port: 6380)
+        let voteMetrics2 = try election.voteReceived(for: description2, from: voter2)
+
+        #expect(voteMetrics2.votesReceived == 1)
+        #expect(voteMetrics2.votesNeeded == 1)
+        #expect(voteMetrics2.candidateCount == 2)
+
+        // The winner should still be the first description
+        #expect(election.winner == description1, "Winner shouldn't change once established")
+    }
+    
+    @Test("The same instance voting twice for the same candidate doesn't count twice")
+    func sameInstanceVotingTwiceDoesntCountTwice() throws {
+        var election = ValkeyTopologyElection()
+
+        // Create a description that will need 3 votes to win
+        let description = createClusterWithReplicas()
+
+        // Cast 3 votes from different voters
+        let voter1 = ValkeyNodeID(endpoint: "master.example.com", port: 6380)
+        let voter2 = ValkeyNodeID(endpoint: "replica1.example.com", port: 6380)
+        let voter3 = ValkeyNodeID(endpoint: "replica2.example.com", port: 6380)
+
+        let metrics1 = try election.voteReceived(for: description, from: voter1)
+        #expect(metrics1.votesReceived == 1)
+        #expect(metrics1.votesNeeded == 2) // (3 nodes / 2) + 1 = 2
+        #expect(election.winner == nil)
+
+        let metrics2 = try election.voteReceived(for: description, from: voter1)
+        #expect(metrics2.votesReceived == 1)
+        #expect(metrics2.votesNeeded == 2) // (3 nodes / 2) + 1 = 2
+        #expect(election.winner == nil)
+
+        let metrics3 = try election.voteReceived(for: description, from: voter2)
+        #expect(metrics3.votesReceived == 2)
+        #expect(election.winner == description, "Should have a winner after reaching the threshold")
+
+        let metrics4 = try election.voteReceived(for: description, from: voter3)
+        #expect(metrics4.votesReceived == 3, "Should count additional votes even after winning")
+    }
+
+    @Test("The same instance can move its vote to another candidate")
+    func sameInstanceVotingTwiceRemovesCountForInitialVote() throws {
+        var election = ValkeyTopologyElection()
+
+        // Create a description that will need 3 votes to win
+        let description1 = createClusterWithReplicas()
+
+        // Cast 3 votes from different voters
+        let voter1 = ValkeyNodeID(endpoint: "master.example.com", port: 6380)
+        let voter2 = ValkeyNodeID(endpoint: "replica1.example.com", port: 6380)
+        let voter3 = ValkeyNodeID(endpoint: "replica2.example.com", port: 6380)
+
+        var description2 = description1
+        description2.shards[0].nodes.removeLast()
+
+        let metrics1 = try election.voteReceived(for: description1, from: voter1)
+        #expect(metrics1.votesReceived == 1)
+        #expect(metrics1.votesNeeded == 2) // (3 nodes / 2) + 1 = 2
+        #expect(election.winner == nil)
+
+        let metrics2 = try election.voteReceived(for: description2, from: voter1)
+        #expect(metrics2.votesReceived == 1)
+        #expect(metrics2.votesNeeded == 2) // (3 nodes / 2) + 1 = 2
+        #expect(election.winner == nil)
+
+        let metrics3 = try election.voteReceived(for: description1, from: voter2)
+        #expect(metrics3.votesReceived == 1, "Vote count still at one, because voter1 moved his vote to description2")
+        #expect(election.winner == nil, "Should have a winner after reaching the threshold")
+
+        let metrics4 = try election.voteReceived(for: description1, from: voter3)
+        #expect(metrics4.votesReceived == 2, "Should count additional votes")
+        #expect(election.winner == description1, "voter2 and voter3 make description1 the winner")
+    }
+
+    @Test("Topology candidates with same structure are equal")
+    func topologyCandidateEquality() throws {
+        // Create two descriptions with the same structure but different node IDs
+        let description1 = createSingleShardCluster(id: "node1")
+        let description2 = createSingleShardCluster(id: "node2")
+        
+        let candidate1 = try ValkeyTopologyCandidate(description1)
+        let candidate2 = try ValkeyTopologyCandidate(description2)
+        
+        // The candidates should be considered equal since they have the same structure
+        // Note: This assumes ValkeyTopologyCandidate equality is based on structure, not node IDs
+        #expect(candidate1 == candidate2, 
+            "Candidates with same structure but different node IDs should be equal")
+    }
+    
+    @Test("Different topology structures produce different candidates")
+    func differentTopologyStructures() throws {
+        let description1 = createSingleShardCluster(slots: [0...5000])
+        let description2 = createSingleShardCluster(slots: [0...8000])
+        
+        let candidate1 = try ValkeyTopologyCandidate(description1)
+        let candidate2 = try ValkeyTopologyCandidate(description2)
+        
+        #expect(candidate1 != candidate2, 
+            "Candidates with different slot ranges should not be equal")
+    }
+}


### PR DESCRIPTION
- We can not rely on the cluster description being sorted correctly.
- Adding `ValkeyTopologyElection` to perform elections.