### PR TITLE
Return ByteBuffer when expect a bulk string

### DIFF
--- a/Benchmarks/ValkeyBenchmarks/ValkeyBenchmarks.swift
+++ b/Benchmarks/ValkeyBenchmarks/ValkeyBenchmarks.swift
@@ -53,7 +53,7 @@ let benchmarks: @Sendable () -> Void = {
 
                     for _ in benchmark.scaledIterations {
                         let foo = try await connection.get(key: "foo")
-                        precondition(foo.map { String($0) } == "Bar")
+                        precondition(foo.map { String(buffer: $0) } == "Bar")
                     }
 
                     benchmark.stopMeasurement()

--- a/Sources/Valkey/Commands/ClusterCommands.swift
+++ b/Sources/Valkey/Commands/ClusterCommands.swift
@@ -76,7 +76,7 @@ public enum CLUSTER {
     /// Advances the cluster config epoch.
     @_documentation(visibility: internal)
     public struct BUMPEPOCH: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         @inlinable public init() {
         }
@@ -254,7 +254,7 @@ public enum CLUSTER {
     /// Returns information about the state of a node.
     @_documentation(visibility: internal)
     public struct INFO: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         @inlinable public init() {
         }
@@ -314,7 +314,7 @@ public enum CLUSTER {
     /// Returns the ID of a node.
     @_documentation(visibility: internal)
     public struct MYID: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         @inlinable public init() {
         }
@@ -327,7 +327,7 @@ public enum CLUSTER {
     /// Returns the shard ID of a node.
     @_documentation(visibility: internal)
     public struct MYSHARDID: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         @inlinable public init() {
         }
@@ -340,7 +340,7 @@ public enum CLUSTER {
     /// Returns the cluster configuration for a node.
     @_documentation(visibility: internal)
     public struct NODES: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         @inlinable public init() {
         }
@@ -687,7 +687,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: If the epoch was incremented.
     ///     * [String]: If the node already has the greatest config epoch in the cluster.
     @inlinable
-    public func clusterBumpepoch() async throws -> RESPToken.String {
+    public func clusterBumpepoch() async throws -> ByteBuffer {
         try await send(command: CLUSTER.BUMPEPOCH())
     }
 
@@ -792,7 +792,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: A map between named fields and values in the form of <field>:<value> lines separated by newlines composed by the two bytes CRLF
     @inlinable
-    public func clusterInfo() async throws -> RESPToken.String {
+    public func clusterInfo() async throws -> ByteBuffer {
         try await send(command: CLUSTER.INFO())
     }
 
@@ -837,7 +837,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: The node id.
     @inlinable
-    public func clusterMyid() async throws -> RESPToken.String {
+    public func clusterMyid() async throws -> ByteBuffer {
         try await send(command: CLUSTER.MYID())
     }
 
@@ -848,7 +848,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: The node's shard id.
     @inlinable
-    public func clusterMyshardid() async throws -> RESPToken.String {
+    public func clusterMyshardid() async throws -> ByteBuffer {
         try await send(command: CLUSTER.MYSHARDID())
     }
 
@@ -859,7 +859,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the total number of Cluster nodes
     /// - Returns: [String]: The serialized cluster configuration.
     @inlinable
-    public func clusterNodes() async throws -> RESPToken.String {
+    public func clusterNodes() async throws -> ByteBuffer {
         try await send(command: CLUSTER.NODES())
     }
 

--- a/Sources/Valkey/Commands/ConnectionCommands.swift
+++ b/Sources/Valkey/Commands/ConnectionCommands.swift
@@ -69,7 +69,7 @@ extension CLIENT {
     /// Returns the name of the connection.
     @_documentation(visibility: internal)
     public struct GETNAME: ValkeyCommand {
-        public typealias Response = RESPToken.String?
+        public typealias Response = ByteBuffer?
 
         @inlinable public init() {
         }
@@ -150,7 +150,7 @@ extension CLIENT {
     /// Returns information about the connection.
     @_documentation(visibility: internal)
     public struct INFO: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         @inlinable public init() {
         }
@@ -306,7 +306,7 @@ extension CLIENT {
                 }
             }
         }
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         public var clientType: ClientType?
         public var clientId: [Int]
@@ -629,7 +629,7 @@ public struct CLIENT: ValkeyCommand {
 /// Returns the given string.
 @_documentation(visibility: internal)
 public struct ECHO<Message: RESPStringRenderable>: ValkeyCommand {
-    public typealias Response = RESPToken.String
+    public typealias Response = ByteBuffer
 
     public var message: Message
 
@@ -805,7 +805,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The connection name of the current connection
     ///     * [Null]: Connection name was not set
     @inlinable
-    public func clientGetname() async throws -> RESPToken.String? {
+    public func clientGetname() async throws -> ByteBuffer? {
         try await send(command: CLIENT.GETNAME())
     }
 
@@ -862,7 +862,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: A unique string, as described at the CLIENT LIST page, for the current client.
     @inlinable
-    public func clientInfo() async throws -> RESPToken.String {
+    public func clientInfo() async throws -> ByteBuffer {
         try await send(command: CLIENT.INFO())
     }
 
@@ -904,7 +904,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of client connections
     /// - Returns: [String]: Information and statistics about client connections
     @inlinable
-    public func clientList(clientType: CLIENT.LIST.ClientType? = nil, clientId: [Int] = [], username: String? = nil, addr: String? = nil, laddr: String? = nil, skipme: CLIENT.LIST.Skipme? = nil, maxage: Int? = nil) async throws -> RESPToken.String {
+    public func clientList(clientType: CLIENT.LIST.ClientType? = nil, clientId: [Int] = [], username: String? = nil, addr: String? = nil, laddr: String? = nil, skipme: CLIENT.LIST.Skipme? = nil, maxage: Int? = nil) async throws -> ByteBuffer {
         try await send(command: CLIENT.LIST(clientType: clientType, clientId: clientId, username: username, addr: addr, laddr: laddr, skipme: skipme, maxage: maxage))
     }
 
@@ -1022,7 +1022,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: The given string
     @inlinable
-    public func echo<Message: RESPStringRenderable>(message: Message) async throws -> RESPToken.String {
+    public func echo<Message: RESPStringRenderable>(message: Message) async throws -> ByteBuffer {
         try await send(command: ECHO(message: message))
     }
 

--- a/Sources/Valkey/Commands/Custom/SortedSetCustomCommands.swift
+++ b/Sources/Valkey/Commands/Custom/SortedSetCustomCommands.swift
@@ -12,10 +12,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+import NIOCore
+
 /// Sorted set entry
 @_documentation(visibility: internal)
 public struct SortedSetEntry: RESPTokenDecodable, Sendable {
-    public let value: RESPToken.String
+    public let value: ByteBuffer
     public let score: Double
 
     public init(fromRESP token: RESPToken) throws {

--- a/Sources/Valkey/Commands/Custom/StreamCustomCommands.swift
+++ b/Sources/Valkey/Commands/Custom/StreamCustomCommands.swift
@@ -12,17 +12,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+import NIOCore
+
 @_documentation(visibility: internal)
 public struct XREADMessage: RESPTokenDecodable, Sendable {
     public let id: String
-    public let fields: [(key: String, value: RESPToken.String)]
+    public let fields: [(key: String, value: ByteBuffer)]
 
     public init(fromRESP token: RESPToken) throws {
         switch token.value {
         case .array(let array):
             let (id, values) = try array.decodeElements(as: (String, RESPToken.Array).self)
             let keyValuePairs = try values.asMap()
-                .map { try ($0.key.decode(as: String.self), $0.value.decode(as: RESPToken.String.self)) }
+                .map { try ($0.key.decode(as: String.self), $0.value.decode(as: ByteBuffer.self)) }
             self.id = id
             self.fields = keyValuePairs
         default:
@@ -44,7 +46,7 @@ public struct XREADMessage: RESPTokenDecodable, Sendable {
     ///
     /// - Parameter key: The field key to look up.
     /// - Returns: The `RESPToken` value associated with the given key, or `nil` if the key does not exist.
-    public subscript(field key: String) -> RESPToken.String? {
+    public subscript(field key: String) -> ByteBuffer? {
         fields.first(where: { $0.key == key })?.value
     }
 
@@ -55,7 +57,7 @@ public struct XREADMessage: RESPTokenDecodable, Sendable {
     ///
     /// - Parameter key: The field key to retrieve values for.
     /// - Returns: An array of `RESPToken` values associated with the given field key.
-    public subscript(fields key: String) -> [RESPToken.String] {
+    public subscript(fields key: String) -> [ByteBuffer] {
         fields.compactMap {
             if $0.key == key {
                 $0.value
@@ -69,7 +71,7 @@ public struct XREADMessage: RESPTokenDecodable, Sendable {
 @_documentation(visibility: internal)
 public struct XREADGroupMessage: RESPTokenDecodable, Sendable {
     public let id: String
-    public let fields: [(key: String, value: RESPToken.String)]?
+    public let fields: [(key: String, value: ByteBuffer)]?
 
     public init(fromRESP token: RESPToken) throws {
         switch token.value {
@@ -77,7 +79,7 @@ public struct XREADGroupMessage: RESPTokenDecodable, Sendable {
             let (id, values) = try array.decodeElements(as: (String, RESPToken.Array?).self)
             let keyValuePairs = try values.map {
                 try $0.asMap()
-                    .map { try ($0.key.decode(as: String.self), $0.value.decode(as: RESPToken.String.self)) }
+                    .map { try ($0.key.decode(as: String.self), $0.value.decode(as: ByteBuffer.self)) }
             }
             self.id = id
             self.fields = keyValuePairs

--- a/Sources/Valkey/Commands/GenericCommands.swift
+++ b/Sources/Valkey/Commands/GenericCommands.swift
@@ -28,7 +28,7 @@ public enum OBJECT {
     /// Returns the internal encoding of an object.
     @_documentation(visibility: internal)
     public struct ENCODING: ValkeyCommand {
-        public typealias Response = RESPToken.String?
+        public typealias Response = ByteBuffer?
 
         public var key: ValkeyKey
 
@@ -165,7 +165,7 @@ public struct DEL: ValkeyCommand {
 /// Returns a serialized representation of the value stored at a key.
 @_documentation(visibility: internal)
 public struct DUMP: ValkeyCommand {
-    public typealias Response = RESPToken.String?
+    public typealias Response = ByteBuffer?
 
     public var key: ValkeyKey
 
@@ -579,7 +579,7 @@ public struct PTTL: ValkeyCommand {
 /// Returns a random key name from the database.
 @_documentation(visibility: internal)
 public struct RANDOMKEY: ValkeyCommand {
-    public typealias Response = RESPToken.String?
+    public typealias Response = ByteBuffer?
 
     @inlinable public init() {
     }
@@ -852,7 +852,7 @@ public struct TTL: ValkeyCommand {
 /// Determines the type of value stored at a key.
 @_documentation(visibility: internal)
 public struct TYPE: ValkeyCommand {
-    public typealias Response = RESPToken.String?
+    public typealias Response = ByteBuffer?
 
     public var key: ValkeyKey
 
@@ -963,7 +963,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The serialized value.
     ///     * [Null]: Key does not exist.
     @inlinable
-    public func dump(key: ValkeyKey) async throws -> RESPToken.String? {
+    public func dump(key: ValkeyKey) async throws -> ByteBuffer? {
         try await send(command: DUMP(key: key))
     }
 
@@ -1075,7 +1075,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Null]: Key doesn't exist.
     ///     * [String]: Encoding of the object.
     @inlinable
-    public func objectEncoding(key: ValkeyKey) async throws -> RESPToken.String? {
+    public func objectEncoding(key: ValkeyKey) async throws -> ByteBuffer? {
         try await send(command: OBJECT.ENCODING(key: key))
     }
 
@@ -1205,7 +1205,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Null]: When the database is empty.
     ///     * [String]: Random key in db.
     @inlinable
-    public func randomkey() async throws -> RESPToken.String? {
+    public func randomkey() async throws -> ByteBuffer? {
         try await send(command: RANDOMKEY())
     }
 
@@ -1321,7 +1321,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Null]: Key doesn't exist
     ///     * [String]: Type of the key
     @inlinable
-    public func type(key: ValkeyKey) async throws -> RESPToken.String? {
+    public func type(key: ValkeyKey) async throws -> ByteBuffer? {
         try await send(command: TYPE(key: key))
     }
 

--- a/Sources/Valkey/Commands/GeoCommands.swift
+++ b/Sources/Valkey/Commands/GeoCommands.swift
@@ -106,7 +106,7 @@ public struct GEODIST<Member1: RESPStringRenderable, Member2: RESPStringRenderab
             }
         }
     }
-    public typealias Response = RESPToken.String?
+    public typealias Response = ByteBuffer?
 
     public var key: ValkeyKey
     public var member1: Member1
@@ -1012,7 +1012,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Null]: One or both of elements are missing.
     ///     * [String]: Distance as a double (represented as a string) in the specified units.
     @inlinable
-    public func geodist<Member1: RESPStringRenderable, Member2: RESPStringRenderable>(key: ValkeyKey, member1: Member1, member2: Member2, unit: GEODIST<Member1, Member2>.Unit? = nil) async throws -> RESPToken.String? {
+    public func geodist<Member1: RESPStringRenderable, Member2: RESPStringRenderable>(key: ValkeyKey, member1: Member1, member2: Member2, unit: GEODIST<Member1, Member2>.Unit? = nil) async throws -> ByteBuffer? {
         try await send(command: GEODIST(key: key, member1: member1, member2: member2, unit: unit))
     }
 

--- a/Sources/Valkey/Commands/HashCommands.swift
+++ b/Sources/Valkey/Commands/HashCommands.swift
@@ -67,7 +67,7 @@ public struct HEXISTS<Field: RESPStringRenderable>: ValkeyCommand {
 /// Returns the value of a field in a hash.
 @_documentation(visibility: internal)
 public struct HGET<Field: RESPStringRenderable>: ValkeyCommand {
-    public typealias Response = RESPToken.String?
+    public typealias Response = ByteBuffer?
 
     public var key: ValkeyKey
     public var field: Field
@@ -131,7 +131,7 @@ public struct HINCRBY<Field: RESPStringRenderable>: ValkeyCommand {
 /// Increments the floating point value of a field by a number. Uses 0 as initial value if the field doesn't exist.
 @_documentation(visibility: internal)
 public struct HINCRBYFLOAT<Field: RESPStringRenderable>: ValkeyCommand {
-    public typealias Response = RESPToken.String
+    public typealias Response = ByteBuffer
 
     public var key: ValkeyKey
     public var field: Field
@@ -460,7 +460,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The value associated with the field.
     ///     * [Null]: If the field is not present in the hash or key does not exist.
     @inlinable
-    public func hget<Field: RESPStringRenderable>(key: ValkeyKey, field: Field) async throws -> RESPToken.String? {
+    public func hget<Field: RESPStringRenderable>(key: ValkeyKey, field: Field) async throws -> ByteBuffer? {
         try await send(command: HGET(key: key, field: field))
     }
 
@@ -493,7 +493,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: The value of the field after the increment operation.
     @inlinable
-    public func hincrbyfloat<Field: RESPStringRenderable>(key: ValkeyKey, field: Field, increment: Double) async throws -> RESPToken.String {
+    public func hincrbyfloat<Field: RESPStringRenderable>(key: ValkeyKey, field: Field, increment: Double) async throws -> ByteBuffer {
         try await send(command: HINCRBYFLOAT(key: key, field: field, increment: increment))
     }
 

--- a/Sources/Valkey/Commands/ListCommands.swift
+++ b/Sources/Valkey/Commands/ListCommands.swift
@@ -55,7 +55,7 @@ public struct BLMOVE: ValkeyCommand {
             }
         }
     }
-    public typealias Response = RESPToken.String?
+    public typealias Response = ByteBuffer?
 
     public var source: ValkeyKey
     public var destination: ValkeyKey
@@ -168,7 +168,7 @@ public struct BRPOP: ValkeyCommand {
 /// Pops an element from a list, pushes it to another list and returns it. Block until an element is available otherwise. Deletes the list if the last element was popped.
 @_documentation(visibility: internal)
 public struct BRPOPLPUSH: ValkeyCommand {
-    public typealias Response = RESPToken.String?
+    public typealias Response = ByteBuffer?
 
     public var source: ValkeyKey
     public var destination: ValkeyKey
@@ -192,7 +192,7 @@ public struct BRPOPLPUSH: ValkeyCommand {
 /// Returns an element from a list by its index.
 @_documentation(visibility: internal)
 public struct LINDEX: ValkeyCommand {
-    public typealias Response = RESPToken.String?
+    public typealias Response = ByteBuffer?
 
     public var key: ValkeyKey
     public var index: Int
@@ -303,7 +303,7 @@ public struct LMOVE: ValkeyCommand {
             }
         }
     }
-    public typealias Response = RESPToken.String
+    public typealias Response = ByteBuffer
 
     public var source: ValkeyKey
     public var destination: ValkeyKey
@@ -556,7 +556,7 @@ public struct RPOP: ValkeyCommand {
 /// Returns the last element of a list after removing and pushing it to another list. Deletes the list if the last element was popped.
 @_documentation(visibility: internal)
 public struct RPOPLPUSH: ValkeyCommand {
-    public typealias Response = RESPToken.String?
+    public typealias Response = ByteBuffer?
 
     public var source: ValkeyKey
     public var destination: ValkeyKey
@@ -623,7 +623,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The popped element.
     ///     * [Null]: Operation timed-out
     @inlinable
-    public func blmove(source: ValkeyKey, destination: ValkeyKey, wherefrom: BLMOVE.Wherefrom, whereto: BLMOVE.Whereto, timeout: Double) async throws -> RESPToken.String? {
+    public func blmove(source: ValkeyKey, destination: ValkeyKey, wherefrom: BLMOVE.Wherefrom, whereto: BLMOVE.Whereto, timeout: Double) async throws -> ByteBuffer? {
         try await send(command: BLMOVE(source: source, destination: destination, wherefrom: wherefrom, whereto: whereto, timeout: timeout))
     }
 
@@ -682,7 +682,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The element being popped from source and pushed to destination.
     ///     * [Null]: Timeout is reached.
     @inlinable
-    public func brpoplpush(source: ValkeyKey, destination: ValkeyKey, timeout: Double) async throws -> RESPToken.String? {
+    public func brpoplpush(source: ValkeyKey, destination: ValkeyKey, timeout: Double) async throws -> ByteBuffer? {
         try await send(command: BRPOPLPUSH(source: source, destination: destination, timeout: timeout))
     }
 
@@ -695,7 +695,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Null]: Index is out of range
     ///     * [String]: The requested element
     @inlinable
-    public func lindex(key: ValkeyKey, index: Int) async throws -> RESPToken.String? {
+    public func lindex(key: ValkeyKey, index: Int) async throws -> ByteBuffer? {
         try await send(command: LINDEX(key: key, index: index))
     }
 
@@ -731,7 +731,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: The element being popped and pushed.
     @inlinable
-    public func lmove(source: ValkeyKey, destination: ValkeyKey, wherefrom: LMOVE.Wherefrom, whereto: LMOVE.Whereto) async throws -> RESPToken.String {
+    public func lmove(source: ValkeyKey, destination: ValkeyKey, wherefrom: LMOVE.Wherefrom, whereto: LMOVE.Whereto) async throws -> ByteBuffer {
         try await send(command: LMOVE(source: source, destination: destination, wherefrom: wherefrom, whereto: whereto))
     }
 
@@ -872,7 +872,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The element being popped and pushed.
     ///     * [Null]: Source list is empty.
     @inlinable
-    public func rpoplpush(source: ValkeyKey, destination: ValkeyKey) async throws -> RESPToken.String? {
+    public func rpoplpush(source: ValkeyKey, destination: ValkeyKey) async throws -> ByteBuffer? {
         try await send(command: RPOPLPUSH(source: source, destination: destination))
     }
 

--- a/Sources/Valkey/Commands/ScriptingCommands.swift
+++ b/Sources/Valkey/Commands/ScriptingCommands.swift
@@ -42,7 +42,7 @@ public enum FUNCTION {
     /// Dumps all libraries into a serialized binary payload.
     @_documentation(visibility: internal)
     public struct DUMP: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         @inlinable public init() {
         }
@@ -126,7 +126,7 @@ public enum FUNCTION {
     /// Creates a library.
     @_documentation(visibility: internal)
     public struct LOAD<FunctionCode: RESPStringRenderable>: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         public var replace: Bool
         public var functionCode: FunctionCode
@@ -295,7 +295,7 @@ public enum SCRIPT {
     /// Loads a server-side Lua script to the script cache.
     @_documentation(visibility: internal)
     public struct LOAD<Script: RESPStringRenderable>: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         public var script: Script
 
@@ -311,7 +311,7 @@ public enum SCRIPT {
     /// Show server-side Lua script in the script cache.
     @_documentation(visibility: internal)
     public struct SHOW<Sha1: RESPStringRenderable>: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         public var sha1: Sha1
 
@@ -536,7 +536,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of functions
     /// - Returns: [String]: The serialized payload.
     @inlinable
-    public func functionDump() async throws -> RESPToken.String {
+    public func functionDump() async throws -> ByteBuffer {
         try await send(command: FUNCTION.DUMP())
     }
 
@@ -588,7 +588,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1) (considering compilation time is redundant)
     /// - Returns: [String]: The library name that was loaded
     @inlinable
-    public func functionLoad<FunctionCode: RESPStringRenderable>(replace: Bool = false, functionCode: FunctionCode) async throws -> RESPToken.String {
+    public func functionLoad<FunctionCode: RESPStringRenderable>(replace: Bool = false, functionCode: FunctionCode) async throws -> ByteBuffer {
         try await send(command: FUNCTION.LOAD(replace: replace, functionCode: functionCode))
     }
 
@@ -673,7 +673,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) with N being the length in bytes of the script body.
     /// - Returns: [String]: The SHA1 digest of the script added into the script cache
     @inlinable
-    public func scriptLoad<Script: RESPStringRenderable>(script: Script) async throws -> RESPToken.String {
+    public func scriptLoad<Script: RESPStringRenderable>(script: Script) async throws -> ByteBuffer {
         try await send(command: SCRIPT.LOAD(script: script))
     }
 
@@ -684,7 +684,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1).
     /// - Returns: [String]: Lua script if sha1 hash exists in script cache.
     @inlinable
-    public func scriptShow<Sha1: RESPStringRenderable>(sha1: Sha1) async throws -> RESPToken.String {
+    public func scriptShow<Sha1: RESPStringRenderable>(sha1: Sha1) async throws -> ByteBuffer {
         try await send(command: SCRIPT.SHOW(sha1: sha1))
     }
 

--- a/Sources/Valkey/Commands/SentinelCommands.swift
+++ b/Sources/Valkey/Commands/SentinelCommands.swift
@@ -28,7 +28,7 @@ public enum SENTINEL {
     /// Checks for a Sentinel quorum.
     @_documentation(visibility: internal)
     public struct CKQUORUM<PrimaryName: RESPStringRenderable>: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         public var primaryName: PrimaryName
 
@@ -315,7 +315,7 @@ public enum SENTINEL {
     /// Returns the Sentinel instance ID.
     @_documentation(visibility: internal)
     public struct MYID: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         @inlinable public init() {
         }
@@ -523,7 +523,7 @@ extension ValkeyConnectionProtocol {
     /// - Available: 2.8.4
     /// - Returns: [String]: Returns OK if the current Sentinel configuration is able to reach the quorum needed to failover a primary, and the majority needed to authorize the failover.
     @inlinable
-    public func sentinelCkquorum<PrimaryName: RESPStringRenderable>(primaryName: PrimaryName) async throws -> RESPToken.String {
+    public func sentinelCkquorum<PrimaryName: RESPStringRenderable>(primaryName: PrimaryName) async throws -> ByteBuffer {
         try await send(command: SENTINEL.CKQUORUM(primaryName: primaryName))
     }
 
@@ -689,7 +689,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: Node ID of the sentinel instance.
     @inlinable
-    public func sentinelMyid() async throws -> RESPToken.String {
+    public func sentinelMyid() async throws -> ByteBuffer {
         try await send(command: SENTINEL.MYID())
     }
 

--- a/Sources/Valkey/Commands/ServerCommands.swift
+++ b/Sources/Valkey/Commands/ServerCommands.swift
@@ -60,7 +60,7 @@ public enum ACL {
     /// Simulates the execution of a command by a user, without executing the command.
     @_documentation(visibility: internal)
     public struct DRYRUN<Username: RESPStringRenderable, Command: RESPStringRenderable>: ValkeyCommand {
-        public typealias Response = RESPToken.String?
+        public typealias Response = ByteBuffer?
 
         public var username: Username
         public var command: Command
@@ -80,7 +80,7 @@ public enum ACL {
     /// Generates a pseudorandom, secure password that can be used to identify ACL users.
     @_documentation(visibility: internal)
     public struct GENPASS: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         public var bits: Int?
 
@@ -225,7 +225,7 @@ public enum ACL {
     /// Returns the authenticated username of the current connection.
     @_documentation(visibility: internal)
     public struct WHOAMI: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         @inlinable public init() {
         }
@@ -604,7 +604,7 @@ public enum LATENCY {
     /// Returns a human-readable latency analysis report.
     @_documentation(visibility: internal)
     public struct DOCTOR: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         @inlinable public init() {
         }
@@ -617,7 +617,7 @@ public enum LATENCY {
     /// Returns a latency graph for an event.
     @_documentation(visibility: internal)
     public struct GRAPH<Event: RESPStringRenderable>: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         public var event: Event
 
@@ -712,7 +712,7 @@ public enum MEMORY {
     /// Outputs a memory problems report.
     @_documentation(visibility: internal)
     public struct DOCTOR: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         @inlinable public init() {
         }
@@ -738,7 +738,7 @@ public enum MEMORY {
     /// Returns the allocator statistics.
     @_documentation(visibility: internal)
     public struct MALLOCSTATS: ValkeyCommand {
-        public typealias Response = RESPToken.String
+        public typealias Response = ByteBuffer
 
         @inlinable public init() {
         }
@@ -956,7 +956,7 @@ public enum SLOWLOG {
 /// Asynchronously rewrites the append-only file to disk.
 @_documentation(visibility: internal)
 public struct BGREWRITEAOF: ValkeyCommand {
-    public typealias Response = RESPToken.String
+    public typealias Response = ByteBuffer
 
     @inlinable public init() {
     }
@@ -1125,7 +1125,7 @@ public struct FLUSHDB: ValkeyCommand {
 /// Returns information and statistics about the server.
 @_documentation(visibility: internal)
 public struct INFO: ValkeyCommand {
-    public typealias Response = RESPToken.String
+    public typealias Response = ByteBuffer
 
     public var section: [String]
 
@@ -1154,7 +1154,7 @@ public struct LASTSAVE: ValkeyCommand {
 /// Displays computer art and the server version
 @_documentation(visibility: internal)
 public struct LOLWUT: ValkeyCommand {
-    public typealias Response = RESPToken.String
+    public typealias Response = ByteBuffer
 
     public var version: Int?
 
@@ -1259,7 +1259,7 @@ public struct REPLICAOF: ValkeyCommand {
             }
         }
     }
-    public typealias Response = RESPToken.String
+    public typealias Response = ByteBuffer
 
     public var args: Args
 
@@ -1431,7 +1431,7 @@ public struct SLAVEOF: ValkeyCommand {
             }
         }
     }
-    public typealias Response = RESPToken.String
+    public typealias Response = ByteBuffer
 
     public var args: Args
 
@@ -1518,7 +1518,7 @@ extension ValkeyConnectionProtocol {
     ///     * "OK": The given user may successfully execute the given command.
     ///     * [String]: The description of the problem, in case the user is not allowed to run the given command.
     @inlinable
-    public func aclDryrun<Username: RESPStringRenderable, Command: RESPStringRenderable>(username: Username, command: Command, arg: [String] = []) async throws -> RESPToken.String? {
+    public func aclDryrun<Username: RESPStringRenderable, Command: RESPStringRenderable>(username: Username, command: Command, arg: [String] = []) async throws -> ByteBuffer? {
         try await send(command: ACL.DRYRUN(username: username, command: command, arg: arg))
     }
 
@@ -1529,7 +1529,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: Pseudorandom data. By default it contains 64 bytes, representing 256 bits of data. If `bits` was given, the output string length is the number of specified bits (rounded to the next multiple of 4) divided by 4.
     @inlinable
-    public func aclGenpass(bits: Int? = nil) async throws -> RESPToken.String {
+    public func aclGenpass(bits: Int? = nil) async throws -> ByteBuffer {
         try await send(command: ACL.GENPASS(bits: bits))
     }
 
@@ -1637,7 +1637,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: The username of the current connection.
     @inlinable
-    public func aclWhoami() async throws -> RESPToken.String {
+    public func aclWhoami() async throws -> ByteBuffer {
         try await send(command: ACL.WHOAMI())
     }
 
@@ -1648,7 +1648,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: A simple string reply indicating that the rewriting started or is about to start ASAP
     @inlinable
-    public func bgrewriteaof() async throws -> RESPToken.String {
+    public func bgrewriteaof() async throws -> ByteBuffer {
         try await send(command: BGREWRITEAOF())
     }
 
@@ -1910,7 +1910,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: A map of info fields, one field per line in the form of <field>:<value> where the value can be a comma separated map like <key>=<val>. Also contains section header lines starting with `#` and blank lines.
     @inlinable
-    public func info(section: [String] = []) async throws -> RESPToken.String {
+    public func info(section: [String] = []) async throws -> ByteBuffer {
         try await send(command: INFO(section: section))
     }
 
@@ -1932,7 +1932,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: A human readable latency analysis report.
     @inlinable
-    public func latencyDoctor() async throws -> RESPToken.String {
+    public func latencyDoctor() async throws -> ByteBuffer {
         try await send(command: LATENCY.DOCTOR())
     }
 
@@ -1943,7 +1943,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: Latency graph
     @inlinable
-    public func latencyGraph<Event: RESPStringRenderable>(event: Event) async throws -> RESPToken.String {
+    public func latencyGraph<Event: RESPStringRenderable>(event: Event) async throws -> ByteBuffer {
         try await send(command: LATENCY.GRAPH(event: event))
     }
 
@@ -2008,7 +2008,7 @@ extension ValkeyConnectionProtocol {
     /// - Available: 5.0.0
     /// - Returns: [String]: String containing the generative computer art, and a text with the server version.
     @inlinable
-    public func lolwut(version: Int? = nil) async throws -> RESPToken.String {
+    public func lolwut(version: Int? = nil) async throws -> ByteBuffer {
         try await send(command: LOLWUT(version: version))
     }
 
@@ -2019,7 +2019,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: Memory problems report.
     @inlinable
-    public func memoryDoctor() async throws -> RESPToken.String {
+    public func memoryDoctor() async throws -> ByteBuffer {
         try await send(command: MEMORY.DOCTOR())
     }
 
@@ -2041,7 +2041,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: Depends on how much memory is allocated, could be slow
     /// - Returns: [String]: The memory allocator's internal statistics report.
     @inlinable
-    public func memoryMallocStats() async throws -> RESPToken.String {
+    public func memoryMallocStats() async throws -> ByteBuffer {
         try await send(command: MEMORY.MALLOCSTATS())
     }
 
@@ -2156,7 +2156,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: ReplicaOf status.
     @inlinable
-    public func replicaof(args: REPLICAOF.Args) async throws -> RESPToken.String {
+    public func replicaof(args: REPLICAOF.Args) async throws -> ByteBuffer {
         try await send(command: REPLICAOF(args: args))
     }
 
@@ -2201,7 +2201,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: SlaveOf status.
     @inlinable
-    public func slaveof(args: SLAVEOF.Args) async throws -> RESPToken.String {
+    public func slaveof(args: SLAVEOF.Args) async throws -> ByteBuffer {
         try await send(command: SLAVEOF(args: args))
     }
 

--- a/Sources/Valkey/Commands/StreamCommands.swift
+++ b/Sources/Valkey/Commands/StreamCommands.swift
@@ -413,7 +413,7 @@ public struct XADD<Field: RESPStringRenderable, Value: RESPStringRenderable>: Va
             RESPBulkString(value).encode(into: &commandEncoder)
         }
     }
-    public typealias Response = RESPToken.String?
+    public typealias Response = ByteBuffer?
 
     public var key: ValkeyKey
     public var nomkstream: Bool
@@ -871,7 +871,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The ID of the added entry. The ID is the one auto-generated if * is passed as ID argument, otherwise the command just returns the same ID specified by the user during insertion.
     ///     * [Null]: The NOMKSTREAM option is given and the key doesn't exist.
     @inlinable
-    public func xadd<Field: RESPStringRenderable, Value: RESPStringRenderable>(key: ValkeyKey, nomkstream: Bool = false, trim: XADD<Field, Value>.Trim? = nil, idSelector: XADD<Field, Value>.IdSelector, data: [XADD<Field, Value>.Data]) async throws -> RESPToken.String? {
+    public func xadd<Field: RESPStringRenderable, Value: RESPStringRenderable>(key: ValkeyKey, nomkstream: Bool = false, trim: XADD<Field, Value>.Trim? = nil, idSelector: XADD<Field, Value>.IdSelector, data: [XADD<Field, Value>.Data]) async throws -> ByteBuffer? {
         try await send(command: XADD(key: key, nomkstream: nomkstream, trim: trim, idSelector: idSelector, data: data))
     }
 

--- a/Sources/Valkey/Commands/StringCommands.swift
+++ b/Sources/Valkey/Commands/StringCommands.swift
@@ -83,7 +83,7 @@ public struct DECRBY: ValkeyCommand {
 /// Returns the string value of a key.
 @_documentation(visibility: internal)
 public struct GET: ValkeyCommand {
-    public typealias Response = RESPToken.String?
+    public typealias Response = ByteBuffer?
 
     public var key: ValkeyKey
 
@@ -103,7 +103,7 @@ public struct GET: ValkeyCommand {
 /// Returns the string value of a key after deleting the key.
 @_documentation(visibility: internal)
 public struct GETDEL: ValkeyCommand {
-    public typealias Response = RESPToken.String?
+    public typealias Response = ByteBuffer?
 
     public var key: ValkeyKey
 
@@ -150,7 +150,7 @@ public struct GETEX: ValkeyCommand {
             }
         }
     }
-    public typealias Response = RESPToken.String?
+    public typealias Response = ByteBuffer?
 
     public var key: ValkeyKey
     public var expiration: Expiration?
@@ -170,7 +170,7 @@ public struct GETEX: ValkeyCommand {
 /// Returns a substring of the string stored at a key.
 @_documentation(visibility: internal)
 public struct GETRANGE: ValkeyCommand {
-    public typealias Response = RESPToken.String
+    public typealias Response = ByteBuffer
 
     public var key: ValkeyKey
     public var start: Int
@@ -194,7 +194,7 @@ public struct GETRANGE: ValkeyCommand {
 /// Returns the previous string value of a key after setting it to a new value.
 @_documentation(visibility: internal)
 public struct GETSET<Value: RESPStringRenderable>: ValkeyCommand {
-    public typealias Response = RESPToken.String?
+    public typealias Response = ByteBuffer?
 
     public var key: ValkeyKey
     public var value: Value
@@ -252,7 +252,7 @@ public struct INCRBY: ValkeyCommand {
 /// Increment the floating point value of a key by a number. Uses 0 as initial value if the key doesn't exist.
 @_documentation(visibility: internal)
 public struct INCRBYFLOAT: ValkeyCommand {
-    public typealias Response = RESPToken.String
+    public typealias Response = ByteBuffer
 
     public var key: ValkeyKey
     public var increment: Double
@@ -466,7 +466,7 @@ public struct SET<Value: RESPStringRenderable>: ValkeyCommand {
             }
         }
     }
-    public typealias Response = RESPToken.String?
+    public typealias Response = ByteBuffer?
 
     public var key: ValkeyKey
     public var value: Value
@@ -574,7 +574,7 @@ public struct STRLEN: ValkeyCommand {
 /// Returns a substring from a string value.
 @_documentation(visibility: internal)
 public struct SUBSTR: ValkeyCommand {
-    public typealias Response = RESPToken.String
+    public typealias Response = ByteBuffer
 
     public var key: ValkeyKey
     public var start: Int
@@ -638,7 +638,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The value of the key.
     ///     * [Null]: Key does not exist.
     @inlinable
-    public func get(key: ValkeyKey) async throws -> RESPToken.String? {
+    public func get(key: ValkeyKey) async throws -> ByteBuffer? {
         try await send(command: GET(key: key))
     }
 
@@ -651,7 +651,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The value of the key.
     ///     * [Null]: The key does not exist.
     @inlinable
-    public func getdel(key: ValkeyKey) async throws -> RESPToken.String? {
+    public func getdel(key: ValkeyKey) async throws -> ByteBuffer? {
         try await send(command: GETDEL(key: key))
     }
 
@@ -664,7 +664,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The value of the key.
     ///     * [Null]: Key does not exist.
     @inlinable
-    public func getex(key: ValkeyKey, expiration: GETEX.Expiration? = nil) async throws -> RESPToken.String? {
+    public func getex(key: ValkeyKey, expiration: GETEX.Expiration? = nil) async throws -> ByteBuffer? {
         try await send(command: GETEX(key: key, expiration: expiration))
     }
 
@@ -675,7 +675,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the length of the returned string. The complexity is ultimately determined by the returned length, but because creating a substring from an existing string is very cheap, it can be considered O(1) for small strings.
     /// - Returns: [String]: The substring of the string value stored at key, determined by the offsets start and end (both are inclusive).
     @inlinable
-    public func getrange(key: ValkeyKey, start: Int, end: Int) async throws -> RESPToken.String {
+    public func getrange(key: ValkeyKey, start: Int, end: Int) async throws -> ByteBuffer {
         try await send(command: GETRANGE(key: key, start: start, end: end))
     }
 
@@ -689,7 +689,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The old value stored at the key.
     ///     * [Null]: The key does not exist.
     @inlinable
-    public func getset<Value: RESPStringRenderable>(key: ValkeyKey, value: Value) async throws -> RESPToken.String? {
+    public func getset<Value: RESPStringRenderable>(key: ValkeyKey, value: Value) async throws -> ByteBuffer? {
         try await send(command: GETSET(key: key, value: value))
     }
 
@@ -722,7 +722,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Returns: [String]: The value of the key after incrementing it.
     @inlinable
-    public func incrbyfloat(key: ValkeyKey, increment: Double) async throws -> RESPToken.String {
+    public func incrbyfloat(key: ValkeyKey, increment: Double) async throws -> ByteBuffer {
         try await send(command: INCRBYFLOAT(key: key, increment: increment))
     }
 
@@ -802,7 +802,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Null]: `GET` given: The key didn't exist before the `SET`
     ///     * [String]: `GET` given: The previous value of the key
     @inlinable
-    public func set<Value: RESPStringRenderable>(key: ValkeyKey, value: Value, condition: SET<Value>.Condition? = nil, get: Bool = false, expiration: SET<Value>.Expiration? = nil) async throws -> RESPToken.String? {
+    public func set<Value: RESPStringRenderable>(key: ValkeyKey, value: Value, condition: SET<Value>.Condition? = nil, get: Bool = false, expiration: SET<Value>.Expiration? = nil) async throws -> ByteBuffer? {
         try await send(command: SET(key: key, value: value, condition: condition, get: get, expiration: expiration))
     }
 
@@ -861,7 +861,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the length of the returned string. The complexity is ultimately determined by the returned length, but because creating a substring from an existing string is very cheap, it can be considered O(1) for small strings.
     /// - Returns: [String]: The substring of the string value stored at key, determined by the offsets start and end (both are inclusive).
     @inlinable
-    public func substr(key: ValkeyKey, start: Int, end: Int) async throws -> RESPToken.String {
+    public func substr(key: ValkeyKey, start: Int, end: Int) async throws -> ByteBuffer {
         try await send(command: SUBSTR(key: key, start: start, end: end))
     }
 

--- a/Sources/Valkey/RESP/RESPToken.swift
+++ b/Sources/Valkey/RESP/RESPToken.swift
@@ -80,15 +80,6 @@ public struct RESPToken: Hashable, Sendable {
         }
     }
 
-    /// A value type representing a RESP (REdis Serialization Protocol) string token.
-    ///
-    /// Internally it stores a ByteBuffer with the String contents. You can use `String(_:)`
-    /// to convert this to a Swift String.
-    public struct String: Sendable, Hashable {
-        /// String bytes
-        public let buffer: ByteBuffer
-    }
-
     public enum Value: Hashable, Sendable {
         case simpleString(ByteBuffer)
         case simpleError(ByteBuffer)
@@ -598,11 +589,4 @@ extension UInt32 {
         value += UInt32(UInt8.newline)
         return value
     }()
-}
-
-extension String {
-    @inlinable
-    public init(_ respTokenString: RESPToken.String) {
-        self = .init(buffer: respTokenString.buffer)
-    }
 }

--- a/Sources/Valkey/RESP/RESPTokenDecodable.swift
+++ b/Sources/Valkey/RESP/RESPTokenDecodable.swift
@@ -297,18 +297,6 @@ extension ClosedRange: RESPTokenDecodable where Bound: RESPTokenDecodable {
     }
 }
 
-extension RESPToken.String: RESPTokenDecodable {
-    @inlinable
-    public init(fromRESP token: RESPToken) throws {
-        switch token.value {
-        case .bulkString(let buffer), .simpleString(let buffer), .verbatimString(let buffer):
-            self.buffer = buffer
-        default:
-            throw RESPParsingError(code: .unexpectedType, buffer: token.base)
-        }
-    }
-}
-
 extension RESPToken.Array: RESPTokenDecodable {
     @inlinable
     public init(fromRESP token: RESPToken) throws {

--- a/Sources/_ValkeyCommandsBuilder/ValkeyCommandsRender.swift
+++ b/Sources/_ValkeyCommandsBuilder/ValkeyCommandsRender.swift
@@ -678,7 +678,7 @@ private func getResponseType(response: ValkeyCommand.ReplySchema.Response) -> St
                 "String"
             }
         } else {
-            "RESPToken.String"
+            "ByteBuffer"
         }
     case .integer:
         "Int"

--- a/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
+++ b/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
@@ -30,8 +30,8 @@ struct ClusterIntegrationTests {
             try await Self.withKey(connection: client) { key in
                 _ = try await client.set(key: key, value: "Hello")
 
-                let response: RESPToken.String? = try await client.get(key: key)
-                #expect(response.map { String($0) } == "Hello")
+                let response = try await client.get(key: key)
+                #expect(response.map { String(buffer: $0) } == "Hello")
             }
         }
     }

--- a/Tests/IntegrationTests/ValkeyTests.swift
+++ b/Tests/IntegrationTests/ValkeyTests.swift
@@ -103,9 +103,9 @@ struct GeneratedCommands {
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
                 _ = try await connection.set(key: key, value: "Hello")
-                let response = try await connection.get(key: key).map { String($0) }
+                let response = try await connection.get(key: key).map { String(buffer: $0) }
                 #expect(response == "Hello")
-                let response2 = try await connection.get(key: "sdf65fsdf").map { String($0) }
+                let response2 = try await connection.get(key: "sdf65fsdf").map { String(buffer: $0) }
                 #expect(response2 == nil)
             }
         }
@@ -118,9 +118,9 @@ struct GeneratedCommands {
         logger.logLevel = .debug
         try await withValkeyClient(.hostname(valkeyHostname, port: 6379), logger: logger) { valkeyClient in
             _ = try await valkeyClient.set(key: "sdf", value: "Hello")
-            let response = try await valkeyClient.get(key: "sdf").map { String($0) }
+            let response = try await valkeyClient.get(key: "sdf").map { String(buffer: $0) }
             #expect(response == "Hello")
-            let response2 = try await valkeyClient.get(key: "sdf65fsdf").map { String($0) }
+            let response2 = try await valkeyClient.get(key: "sdf65fsdf").map { String(buffer: $0) }
             #expect(response2 == nil)
         }
     }
@@ -134,7 +134,7 @@ struct GeneratedCommands {
             try await withKey(connection: connection) { key in
                 let buffer = ByteBuffer(repeating: 12, count: 256)
                 _ = try await connection.set(key: key, value: buffer)
-                let response = try await connection.get(key: key)?.buffer
+                let response = try await connection.get(key: key)
                 #expect(response == buffer)
             }
         }
@@ -148,7 +148,7 @@ struct GeneratedCommands {
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
                 _ = try await connection.set(key: key, value: "Hello", expiration: .unixTimeMilliseconds(.now + 1))
-                let response = try await connection.get(key: key).map { String($0) }
+                let response = try await connection.get(key: key).map { String(buffer: $0) }
                 #expect(response == "Hello")
                 try await Task.sleep(for: .seconds(2))
                 let response2 = try await connection.get(key: key)
@@ -168,7 +168,7 @@ struct GeneratedCommands {
                     SET(key: key, value: "Pipelined Hello"),
                     GET(key: key)
                 )
-                try #expect(responses.1.get().map { String($0) } == "Pipelined Hello")
+                try #expect(responses.1.get().map { String(buffer: $0) } == "Pipelined Hello")
             }
         }
     }
@@ -184,7 +184,7 @@ struct GeneratedCommands {
                     SET(key: key, value: "Pipelined Hello"),
                     GET(key: key)
                 )
-                try #expect(responses.1.get().map { String($0) } == "Pipelined Hello")
+                try #expect(responses.1.get().map { String(buffer: $0) } == "Pipelined Hello")
             }
         }
     }
@@ -201,7 +201,7 @@ struct GeneratedCommands {
                     INCR(key: key),
                     GET(key: key)
                 )
-                #expect(try responses.2.get().map { String($0) } == "101")
+                #expect(try responses.2.get().map { String(buffer: $0) } == "101")
             }
         }
     }
@@ -339,7 +339,7 @@ struct GeneratedCommands {
                     group.addTask {
                         try await withKey(connection: connection) { key in
                             _ = try await connection.set(key: key, value: key.rawValue)
-                            let response = try await connection.get(key: key).map { String($0) }
+                            let response = try await connection.get(key: key).map { String(buffer: $0) }
                             #expect(response == key.rawValue)
                         }
                     }
@@ -365,7 +365,7 @@ struct GeneratedCommands {
                                 SET(key: key, value: value),
                                 GET(key: key)
                             )
-                            try #expect(responses.1.get().map { String($0) } == value)
+                            try #expect(responses.1.get().map { String(buffer: $0) } == value)
                         }
                     }
                 }
@@ -400,7 +400,7 @@ struct GeneratedCommands {
             logger: logger
         ) { connection in
             let user = try await connection.aclWhoami()
-            #expect(String(user) == "johnsmith")
+            #expect(String(buffer: user) == "johnsmith")
         }
     }
 
@@ -650,7 +650,7 @@ struct GeneratedCommands {
                             try await withKey(connection: connection) { key in
                                 _ = try await connection.set(key: key, value: "Hello")
                                 let response = try await connection.get(key: key)
-                                #expect(response.map { String($0) } == "Hello")
+                                #expect(response.map { String(buffer: $0) } == "Hello")
                             }
 
                             await #expect(throws: Never.self) { try await iterator.next()?.message == "goodbye" }
@@ -691,7 +691,7 @@ struct GeneratedCommands {
                     }
                     try await group.waitForAll()
                     try await valkeyClient.withConnection { connection in
-                        let value = try await connection.get(key: key).map { String($0) }
+                        let value = try await connection.get(key: key).map { String(buffer: $0) }
                         #expect(value == "1000")
                         _ = try await connection.del(key: [key])
                     }

--- a/Tests/ValkeyTests/CommandTests.swift
+++ b/Tests/ValkeyTests/CommandTests.swift
@@ -198,12 +198,12 @@ struct CommandTests {
                 group.addTask {
                     var result = try await connection.zpopmin(key: "key")
                     #expect(result[0].score == 1)
-                    #expect(String(result[0].value) == "one")
+                    #expect(String(buffer: result[0].value) == "one")
                     result = try await connection.zpopmin(key: "key", count: 2)
                     #expect(result[0].score == 2)
-                    #expect(String(result[0].value) == "two")
+                    #expect(String(buffer: result[0].value) == "two")
                     #expect(result[1].score == 3)
-                    #expect(String(result[1].value) == "three")
+                    #expect(String(buffer: result[1].value) == "three")
                 }
                 group.addTask {
                     var outbound = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
@@ -238,13 +238,13 @@ struct CommandTests {
                     var result = try await connection.zmpop(key: ["key", "key2"], where: .max)
                     #expect(result?.key == ValkeyKey(rawValue: "key"))
                     #expect(result?.values[0].score == 3)
-                    #expect((result?.values[0].value).map { String($0) } == "three")
+                    #expect((result?.values[0].value).map { String(buffer: $0) } == "three")
                     result = try await connection.zmpop(key: ["key", "key2"], where: .max, count: 2)
                     #expect(result?.key == ValkeyKey(rawValue: "key2"))
                     #expect(result?.values[0].score == 5)
-                    #expect((result?.values[0].value).map { String($0) } == "five")
+                    #expect((result?.values[0].value).map { String(buffer: $0) } == "five")
                     #expect(result?.values[1].score == 4)
-                    #expect((result?.values[1].value).map { String($0) } == "four")
+                    #expect((result?.values[1].value).map { String(buffer: $0) } == "four")
                 }
                 group.addTask {
                     var outbound = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
@@ -291,14 +291,14 @@ struct CommandTests {
                     var result = try await connection.zrange(key: "key", start: "4", stop: "10", sortby: .byscore, withscores: true)
                         .decode(as: [SortedSetEntry].self)
                     #expect(result[0].score == 4)
-                    #expect(String(result[0].value) == "four")
+                    #expect(String(buffer: result[0].value) == "four")
                     result = try await connection.zrange(key: "key", start: "2", stop: "3", sortby: .byscore, withscores: true).decode(
                         as: [SortedSetEntry].self
                     )
                     #expect(result[0].score == 2)
-                    #expect(String(result[0].value) == "two")
+                    #expect(String(buffer: result[0].value) == "two")
                     #expect(result[1].score == 3)
-                    #expect(String(result[1].value) == "three")
+                    #expect(String(buffer: result[1].value) == "three")
                 }
                 group.addTask {
                     var outbound = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
@@ -381,13 +381,13 @@ struct CommandTests {
             let stream2 = try #require(result.streams.first { $0.key == "key2" })
             #expect(stream1.key == "key1")
             #expect(stream1.messages[0].id == "event1")
-            #expect(stream1.messages[0][field: "field1"].map { String($0) } == "value1")
+            #expect(stream1.messages[0][field: "field1"].map { String(buffer: $0) } == "value1")
             #expect(stream2.key == "key2")
             #expect(stream2.messages[0].id == "event2")
-            #expect(stream2.messages[0][field: "field2"].map { String($0) } == "value2")
+            #expect(stream2.messages[0][field: "field2"].map { String(buffer: $0) } == "value2")
             #expect(stream2.messages[1].id == "event3")
-            #expect(stream2.messages[1][field: "field3"].map { String($0) } == "value3")
-            #expect(stream2.messages[1][field: "field4"].map { String($0) } == "value4")
+            #expect(stream2.messages[1][field: "field3"].map { String(buffer: $0) } == "value3")
+            #expect(stream2.messages[1][field: "field4"].map { String(buffer: $0) } == "value4")
         }
 
         @Test
@@ -432,7 +432,7 @@ struct CommandTests {
             #expect(stream1.key == "key1")
             #expect(stream1.messages[0].id == "event1")
             #expect(stream1.messages[0].fields?[0].key == "field1")
-            #expect(stream1.messages[0].fields.map { String($0[0].value) } == "value1")
+            #expect(stream1.messages[0].fields.map { String(buffer: $0[0].value) } == "value1")
             #expect(stream1.messages[1].id == "event2")
             #expect(stream1.messages[1].fields == nil)
         }
@@ -517,11 +517,11 @@ struct CommandTests {
                 #expect(messages[0].id == "1749464199407-0")
                 #expect(messages[0].fields.count == 1)
                 #expect(messages[0].fields[0].key == "f")
-                #expect(String(messages[0].fields[0].value) == "v")
+                #expect(String(buffer: messages[0].fields[0].value) == "v")
                 #expect(messages[1].id == "1749464199408-0")
                 #expect(messages[1].fields.count == 1)
                 #expect(messages[1].fields[0].key == "f2")
-                #expect(String(messages[1].fields[0].value) == "v2")
+                #expect(String(buffer: messages[1].fields[0].value) == "v2")
             default:
                 Issue.record("Expected `messages` case")
             }

--- a/Tests/ValkeyTests/ValkeyConnectionTests.swift
+++ b/Tests/ValkeyTests/ValkeyConnectionTests.swift
@@ -30,7 +30,7 @@ struct ConnectionTests {
         let connection = try await ValkeyConnection.setupChannelAndConnect(channel, configuration: .init(), logger: logger)
         try await channel.processHello()
 
-        async let fooResult = connection.get(key: "foo").map { String($0) }
+        async let fooResult = connection.get(key: "foo").map { String(buffer: $0) }
 
         let outbound = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
         #expect(outbound == RESPToken(.command(["GET", "foo"])).base)
@@ -210,7 +210,7 @@ struct ConnectionTests {
         try await channel.writeInbound(RESPToken(.simpleString("OK")).base)
         try await channel.writeInbound(RESPToken(.bulkString("bar")).base)
 
-        #expect(try await results.1.get().map { String($0) } == "bar")
+        #expect(try await results.1.get().map { String(buffer: $0) } == "bar")
     }
 
     @Test
@@ -332,7 +332,7 @@ struct ConnectionTests {
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 await #expect(throws: ValkeyClientError(.cancelled)) {
-                    _ = try await connection.get(key: "foo").map { String($0) }
+                    _ = try await connection.get(key: "foo").map { String(buffer: $0) }
                 }
             }
             _ = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
@@ -354,7 +354,7 @@ struct ConnectionTests {
             group.cancelAll()
             group.addTask {
                 await #expect(throws: ValkeyClientError(.cancelled)) {
-                    _ = try await connection.get(key: "foo").map { String($0) }
+                    _ = try await connection.get(key: "foo").map { String(buffer: $0) }
                 }
             }
         }
@@ -373,13 +373,13 @@ struct ConnectionTests {
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 await #expect(throws: ValkeyClientError(.connectionClosedDueToCancellation)) {
-                    _ = try await connection.get(key: "foo").map { String($0) }
+                    _ = try await connection.get(key: "foo").map { String(buffer: $0) }
                 }
             }
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
                     await #expect(throws: ValkeyClientError(.cancelled)) {
-                        _ = try await connection.get(key: "foo").map { String($0) }
+                        _ = try await connection.get(key: "foo").map { String(buffer: $0) }
                     }
                 }
                 // wait for outbound write from both tasks

--- a/Tests/ValkeyTests/ValkeySubscriptionTests.swift
+++ b/Tests/ValkeyTests/ValkeySubscriptionTests.swift
@@ -168,7 +168,7 @@ struct SubscriptionTests {
         let outbound = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
         #expect(outbound == RESPToken(.command(["GET", "foo"])).base)
         try await channel.writeInbound(RESPToken(.bulkString("Bar")).base)
-        #expect(try await fooResult.map { String($0) } == "Bar")
+        #expect(try await fooResult.map { String(buffer: $0) } == "Bar")
 
         #expect(await connection.isSubscriptionsEmpty())
     }
@@ -550,7 +550,7 @@ struct SubscriptionTests {
                     var iterator = subscription.makeAsyncIterator()
                     try #expect(await iterator.next() == .init(channel: "test", message: "Testing!"))
                     let value = try await connection.get(key: "foo")
-                    #expect(value.map { String($0) } == "bar")
+                    #expect(value.map { String(buffer: $0) } == "bar")
                     try #expect(await iterator.next() == .init(channel: "test", message: "Testing2!"))
                 }
             }


### PR DESCRIPTION
When we know a command returns a String but we don't want to convert to a String straight away we can return a `RESPString`.
