### PR TITLE
Rework connection creation

### DIFF
--- a/Sources/Valkey/Connection/ValkeyConnection+ConnectionPool.swift
+++ b/Sources/Valkey/Connection/ValkeyConnection+ConnectionPool.swift
@@ -47,7 +47,7 @@ struct ValkeyKeepAliveBehavior: ConnectionKeepAliveBehavior {
 
 /// Connection id generator for Valkey connection pool
 @available(valkeySwift 1.0, *)
-final class ConnectionIDGenerator: ConnectionIDGeneratorProtocol {
+package final class ConnectionIDGenerator: ConnectionIDGeneratorProtocol {
     static let globalGenerator = ConnectionIDGenerator()
 
     private let atomic: Atomic<Int>
@@ -56,7 +56,7 @@ final class ConnectionIDGenerator: ConnectionIDGeneratorProtocol {
         self.atomic = .init(0)
     }
 
-    func next() -> Int {
+    package func next() -> Int {
         self.atomic.wrappingAdd(1, ordering: .relaxed).oldValue
     }
 }

--- a/Sources/Valkey/Connection/ValkeyConnection.swift
+++ b/Sources/Valkey/Connection/ValkeyConnection.swift
@@ -39,15 +39,15 @@ public final actor ValkeyConnection: ValkeyConnectionProtocol, Sendable {
     let channel: any Channel
     @usableFromInline
     let channelHandler: ValkeyChannelHandler
-    let configuration: ValkeyClientConfiguration
+    let configuration: ValkeyConnectionConfiguration
     let isClosed: Atomic<Bool>
 
     /// Initialize connection
-    private init(
+    init(
         channel: any Channel,
         connectionID: ID,
         channelHandler: ValkeyChannelHandler,
-        configuration: ValkeyClientConfiguration,
+        configuration: ValkeyConnectionConfiguration,
         logger: Logger
     ) {
         self.unownedExecutor = channel.eventLoop.executor.asUnownedSerialExecutor()
@@ -60,7 +60,7 @@ public final actor ValkeyConnection: ValkeyConnectionProtocol, Sendable {
     }
 
     /// Connect to Valkey database and return connection
-    /// 
+    ///
     /// - Parameters:
     ///   - address: Internet address of database
     ///   - connectionID: Connection identifier
@@ -73,7 +73,7 @@ public final actor ValkeyConnection: ValkeyConnectionProtocol, Sendable {
         address: ValkeyServerAddress,
         connectionID: ID,
         name: String? = nil,
-        configuration: ValkeyClientConfiguration,
+        configuration: ValkeyConnectionConfiguration,
         eventLoop: EventLoop = MultiThreadedEventLoopGroup.singleton.any(),
         logger: Logger
     ) async throws -> ValkeyConnection {
@@ -194,7 +194,7 @@ public final actor ValkeyConnection: ValkeyConnectionProtocol, Sendable {
         address: ValkeyServerAddress,
         connectionID: ID,
         eventLoop: EventLoop,
-        configuration: ValkeyClientConfiguration,
+        configuration: ValkeyConnectionConfiguration,
         clientName: String?,
         logger: Logger
     ) -> EventLoopFuture<ValkeyConnection> {
@@ -218,7 +218,7 @@ public final actor ValkeyConnection: ValkeyConnectionProtocol, Sendable {
 
         let connect = bootstrap.channelInitializer { channel in
             do {
-                try self._setupChannel(channel, configuration: configuration, clientName: clientName, logger: logger)
+                try self._setupChannel(channel, configuration: configuration, logger: logger)
                 return eventLoop.makeSucceededVoidFuture()
             } catch {
                 return eventLoop.makeFailedFuture(error)
@@ -253,26 +253,29 @@ public final actor ValkeyConnection: ValkeyConnectionProtocol, Sendable {
 
     package static func setupChannelAndConnect(
         _ channel: any Channel,
-        configuration: ValkeyClientConfiguration = .init(),
-        clientName: String? = nil,
+        configuration: ValkeyConnectionConfiguration = .init(),
         logger: Logger
     ) async throws -> ValkeyConnection {
         if !channel.eventLoop.inEventLoop {
             return try await channel.eventLoop.flatSubmit {
-                self._setupChannelAndConnect(channel, configuration: configuration, clientName: clientName, logger: logger)
+                self._setupChannelAndConnect(channel, configuration: configuration, logger: logger)
             }.get()
         }
-        return try await self._setupChannelAndConnect(channel, configuration: configuration, clientName: clientName, logger: logger).get()
+        return try await self._setupChannelAndConnect(channel, configuration: configuration, logger: logger).get()
     }
 
     private static func _setupChannelAndConnect(
         _ channel: any Channel,
-        configuration: ValkeyClientConfiguration,
-        clientName: String? = nil,
+        tlsSetting: TLSSetting = .disable,
+        configuration: ValkeyConnectionConfiguration,
         logger: Logger
     ) -> EventLoopFuture<ValkeyConnection> {
         do {
-            let handler = try self._setupChannel(channel, configuration: configuration, clientName: clientName, logger: logger)
+            let handler = try self._setupChannel(
+                channel,
+                configuration: configuration,
+                logger: logger
+            )
             let connection = ValkeyConnection(
                 channel: channel,
                 connectionID: 0,
@@ -288,11 +291,16 @@ public final actor ValkeyConnection: ValkeyConnectionProtocol, Sendable {
         }
     }
 
+    @usableFromInline
+    enum TLSSetting {
+        case enable(NIOSSLContext, serverName: String?)
+        case disable
+    }
+
     @discardableResult
-    private static func _setupChannel(
+    static func _setupChannel(
         _ channel: any Channel,
-        configuration: ValkeyClientConfiguration,
-        clientName: String?,
+        configuration: ValkeyConnectionConfiguration,
         logger: Logger
     ) throws -> ValkeyChannelHandler {
         channel.eventLoop.assertInEventLoop()
@@ -304,12 +312,7 @@ public final actor ValkeyConnection: ValkeyConnectionProtocol, Sendable {
             break
         }
         let valkeyChannelHandler = ValkeyChannelHandler(
-            configuration: .init(
-                authentication: configuration.authentication,
-                connectionTimeout: .init(configuration.connectionTimeout),
-                blockingCommandTimeout: .init(configuration.blockingCommandTimeout),
-                clientName: clientName
-            ),
+            configuration: .init(configuration),
             eventLoop: channel.eventLoop,
             logger: logger
         )

--- a/Sources/Valkey/Connection/ValkeyConnectionConfiguration.swift
+++ b/Sources/Valkey/Connection/ValkeyConnectionConfiguration.swift
@@ -1,0 +1,142 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the valkey-swift project
+//
+// Copyright (c) 2025 the valkey-swift authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See valkey-swift/CONTRIBUTORS.txt for the list of valkey-swift authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOSSL
+
+/// A configuration object that defines how to connect to a Valkey server.
+///
+/// `ValkeyConnectionConfiguration` allows you to customize various aspects of the connection,
+/// including authentication credentials, timeouts, and TLS security settings.
+///
+/// Example usage:
+/// ```swift
+/// // Basic configuration
+/// let config = ValkeyConnectionConfiguration()
+///
+/// // Configuration with authentication
+/// let authConfig = ValkeyConnectionConfiguration(
+///     authentication: .init(username: "user", password: "pass"),
+///     commandTimeout: .seconds(60)
+/// )
+///
+/// // Configuration with TLS
+/// let sslContext = try NIOSSLContext(configuration: .makeClientConfiguration())
+/// let secureConfig = ValkeyConnectionConfiguration(
+///     authentication: .init(username: "user", password: "pass"),
+///     tls: .enable(sslContext, tlsServerName: "your-valkey-server.com")
+/// )
+/// ```
+public struct ValkeyConnectionConfiguration: Sendable {
+    /// Configuration for TLS (Transport Layer Security) encryption.
+    ///
+    /// This structure allows you to enable or disable encrypted connections to the Valkey server.
+    /// When enabled, it requires an `NIOSSLContext` and optionally a server name for SNI (Server Name Indication).
+    public struct TLS: Sendable {
+        enum Base {
+            case disable
+            case enable(NIOSSLContext, String?)
+        }
+        let base: Base
+
+        /// Disables TLS for the connection.
+        ///
+        /// Use this option when connecting to a Valkey server that doesn't require encryption.
+        public static var disable: Self { .init(base: .disable) }
+        
+        /// Enables TLS for the connection.
+        ///
+        /// - Parameters:
+        ///   - sslContext: The SSL context used to establish the secure connection
+        ///   - tlsServerName: Optional server name for SNI (Server Name Indication)
+        /// - Returns: A configured TLS instance
+        public static func enable(_ sslContext: NIOSSLContext, tlsServerName: String?) throws -> Self {
+            .init(base: .enable(sslContext, tlsServerName))
+        }
+    }
+
+    /// Authentication credentials for accessing a Valkey server.
+    ///
+    /// Use this structure to provide username and password credentials when the server
+    /// requires authentication for access.
+    public struct Authentication: Sendable {
+        /// The username for authentication
+        public var username: String
+        /// The password for authentication
+        public var password: String
+
+        /// Creates a new authentication configuration.
+        ///
+        /// - Parameters:
+        ///   - username: The username for server authentication
+        ///   - password: The password for server authentication
+        public init(username: String, password: String) {
+            self.username = username
+            self.password = password
+        }
+    }
+
+    /// Optional authentication credentials for accessing the Valkey server.
+    /// Set this property when connecting to a server that requires authentication.
+    public var authentication: Authentication?
+    
+    /// TLS configuration for the connection.
+    /// Use `.disable` for unencrypted connections or `.enable(...)` for secure connections.
+    public var tls: TLS
+
+    /// The maximum time to wait for a response to a command before considering the connection dead.
+    ///
+    /// This timeout applies to all standard commands sent to the Valkey server.
+    /// Default value is 30 seconds.
+    public var commandTimeout: Duration
+    
+    /// The maximum time to wait for a response to blocking commands.
+    ///
+    /// This timeout applies specifically to blocking commands (like BLPOP, BRPOP, etc.)
+    /// that may wait for conditions to be met before returning.
+    /// Default value is 120 seconds.
+    public var blockingCommandTimeout: Duration
+
+    /// The client name to identify this connection to the Valkey server.
+    ///
+    /// When specified, this name will be sent to the server using the `HELLO` command
+    /// during connection initialization. This can be useful for debugging and monitoring purposes,
+    /// allowing you to identify different clients connected to the server.
+    /// Default value is `nil` (no client name is set).
+    public var clientName: String?
+
+    /// Creates a new Valkey connection configuration.
+    ///
+    /// Use this initializer to create a configuration object that can be used to establish
+    /// a connection to a Valkey server with the specified parameters.
+    ///
+    /// - Parameters:
+    ///   - authentication: Optional credentials for accessing the Valkey server. Set to `nil` for unauthenticated access.
+    ///   - commandTimeout: Maximum time to wait for a response to standard commands. Defaults to 30 seconds.
+    ///   - blockingCommandTimeout: Maximum time to wait for a response to blocking commands. Defaults to 120 seconds.
+    ///   - tls: TLS configuration for secure connections. Defaults to `.disable` for unencrypted connections.
+    ///   - clientName: Optional name to identify this client connection on the server. Defaults to `nil`.
+    public init(
+        authentication: Authentication? = nil,
+        commandTimeout: Duration = .seconds(30),
+        blockingCommandTimeout: Duration = .seconds(120),
+        tls: TLS = .disable,
+        clientName: String? = nil
+    ) {
+        self.authentication = authentication
+        self.commandTimeout = commandTimeout
+        self.blockingCommandTimeout = blockingCommandTimeout
+        self.tls = tls
+        self.clientName = clientName
+    }
+}

--- a/Sources/Valkey/SSLContextCache.swift
+++ b/Sources/Valkey/SSLContextCache.swift
@@ -1,0 +1,136 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the valkey-swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the valkey-swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of valkey-swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOSSL
+import Synchronization
+
+@usableFromInline
+package protocol ValkeySSLContextProvider: Sendable {
+
+    func getSSLContext() async throws -> NIOSSLContext
+
+}
+
+@available(valkeySwift 1.0, *)
+final class SSLContextCache: ValkeySSLContextProvider {
+
+    let tlsConfiguration: TLSConfiguration
+    let stateLock = Mutex(State.initialized)
+
+    enum State: ~Copyable {
+        case initialized
+        case producing([ValkeyPromise<NIOSSLContext>])
+        case cached(NIOSSLContext)
+        case failed(any Error)
+    }
+
+    init(tlsConfiguration: TLSConfiguration) {
+        self.tlsConfiguration = tlsConfiguration
+    }
+
+    func getSSLContext() async throws -> NIOSSLContext {
+        enum Action {
+            case produce
+            case succeed(NIOSSLContext)
+            case fail(any Error)
+            case wait
+        }
+
+        return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<NIOSSLContext, any Error>) in
+            let action = self.stateLock.withLock { state -> Action in
+                switch consume state {
+                case .initialized:
+                    state = .producing([.swift(continuation)])
+                    return .produce
+
+                case .cached(let context):
+                    state = .cached(context)
+                    return .succeed(context)
+
+                case .failed(let error):
+                    state = .failed(error)
+                    return .fail(error)
+
+                case .producing(var continuations):
+                    continuations.append(.swift(continuation))
+                    state = .producing(continuations)
+                    return .wait
+                }
+            }
+
+            switch action {
+            case .wait:
+                break
+
+            case .produce:
+                // TBD: we might want to consider moving this off the concurrent executor
+                self.reportProduceSSLContextResult(
+                    Result(catching: { try NIOSSLContext(configuration: tlsConfiguration) }),
+                    for: tlsConfiguration
+                )
+
+            case .succeed(let context):
+                continuation.resume(returning: context)
+
+            case .fail(let error):
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+
+    private func reportProduceSSLContextResult(_ result: Result<NIOSSLContext, any Error>, for tlsConfiguration: TLSConfiguration) {
+        enum Action {
+            case fail(any Error, [ValkeyPromise<NIOSSLContext>])
+            case succeed(NIOSSLContext, [ValkeyPromise<NIOSSLContext>])
+            case none
+        }
+
+        let action = self.stateLock.withLock { state -> Action in
+            switch consume state {
+            case .initialized:
+                preconditionFailure("Invalid state: initialized")
+
+            case .cached(let cached):
+                state = .cached(cached)
+                return .none
+
+            case .failed(let error):
+                state = .failed(error)
+                return .none
+
+            case .producing(let continuations):
+                switch result {
+                case .success(let context):
+                    state = .cached(context)
+                    return .succeed(context, continuations)
+
+                case .failure(let failure):
+                    state = .failed(failure)
+                    return .fail(failure, continuations)
+                }
+            }
+        }
+
+        switch action {
+        case .none:
+            break
+
+        case .succeed(let context, let continuations):
+            for continuation in continuations { continuation.succeed(context) }
+
+        case .fail(let error, let continuations):
+            for continuation in continuations { continuation.fail(error) }
+        }
+    }
+}

--- a/Sources/Valkey/ValkeyConnectionFactory.swift
+++ b/Sources/Valkey/ValkeyConnectionFactory.swift
@@ -1,0 +1,122 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the valkey-swift open source project
+//
+// Copyright (c) 2025 Apple Inc. and the valkey-swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of valkey-swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import NIOCore
+import NIOSSL
+import Synchronization
+
+@available(valkeySwift 1.0, *)
+package final class ValkeyConnectionFactory: Sendable {
+
+    enum Mode: Sendable {
+        case `default`
+        case custom(@Sendable (ValkeyServerAddress, any EventLoop) async throws -> Channel)
+    }
+
+    let mode: Mode
+    let configuration: ValkeyClientConfiguration
+    let cache: SSLContextCache?
+
+    package init(configuration: ValkeyClientConfiguration) {
+        self.configuration = configuration
+        self.mode = .default
+        switch configuration.tls.base {
+        case .enable(let tlsConfiguration, _):
+            self.cache = SSLContextCache(tlsConfiguration: tlsConfiguration)
+        case .disable:
+            self.cache = nil
+        }
+    }
+
+    package init(
+        configuration: ValkeyClientConfiguration,
+        customHandler: (@Sendable (ValkeyServerAddress, any EventLoop) async throws -> any Channel)?
+    ) {
+        self.configuration = configuration
+        if let customHandler {
+            self.mode = .custom(customHandler)
+        } else {
+            self.mode = .default
+        }
+        switch configuration.tls.base {
+        case .enable(let tlsConfiguration, _):
+            self.cache = SSLContextCache(tlsConfiguration: tlsConfiguration)
+        case .disable:
+            self.cache = nil
+        }
+    }
+
+    package func makeConnection(
+        address: ValkeyServerAddress,
+        connectionID: Int,
+        eventLoop: any EventLoop,
+        logger: Logger
+    ) async throws -> ValkeyConnection {
+        switch self.mode {
+        case .default:
+            let connectionConfig = try await self.makeConnectionConfiguration()
+            return try await ValkeyConnection.connect(
+                address: address,
+                connectionID: connectionID,
+                configuration: connectionConfig,
+                eventLoop: eventLoop,
+                logger: logger
+            )
+
+        case .custom(let customHandler):
+            async let connectionConfigPromise = self.makeConnectionConfiguration()
+            let channel = try await customHandler(address, eventLoop)
+            let connectionConfig = try await connectionConfigPromise
+
+            let connection = try await eventLoop.submit {
+                let channelHandler = try ValkeyConnection._setupChannel(
+                    channel,
+                    configuration: connectionConfig,
+                    logger: logger
+                )
+                return ValkeyConnection(
+                    channel: channel,
+                    connectionID: connectionID,
+                    channelHandler: channelHandler,
+                    configuration: connectionConfig,
+                    logger: logger
+                )
+            }.get()
+
+            return connection
+        }
+    }
+
+    func makeConnectionConfiguration() async throws -> ValkeyConnectionConfiguration {
+        let tls: ValkeyConnectionConfiguration.TLS =
+            switch self.configuration.tls.base {
+            case .disable:
+                .disable
+            case .enable(_, let clientName):
+                try await .enable(self.cache!.getSSLContext(), tlsServerName: clientName)
+            }
+
+        return ValkeyConnectionConfiguration(
+            authentication: self.configuration.authentication.flatMap {
+                .init(username: $0.username, password: $0.password)
+            },
+            commandTimeout: self.configuration.commandTimeout,
+            blockingCommandTimeout: self.configuration.blockingCommandTimeout,
+            tls: tls,
+            clientName: nil,
+        )
+    }
+}
+

--- a/Tests/ValkeyTests/ValkeyConnectionTests.swift
+++ b/Tests/ValkeyTests/ValkeyConnectionTests.swift
@@ -87,10 +87,11 @@ struct ConnectionTests {
     @available(valkeySwift 1.0, *)
     func testConnectionCreationHelloClientName() async throws {
         let channel = NIOAsyncTestingChannel()
+        let configuration = ValkeyConnectionConfiguration(clientName: "Testing")
         let logger = Logger(label: "test")
         _ = try await ValkeyConnection.setupChannelAndConnect(
             channel,
-            clientName: "Testing",
+            configuration: configuration,
             logger: logger
         )
 


### PR DESCRIPTION
This is basically #117 without connected state
Changes

- Separate ValkeyConnectionConfiguration and ValkeyClientConfiguration
- ValkeyClientConfiguration now uses TLSConfiguration as its currency type for SSL
- Adds a ValkeyConnectionFactory that we can use to overwrite connection establishment, which will make testing - ValkeyClient and ValkeyClusterClient much easier
- Allows users to provide their own Channels for Valkey to use
