### PR TITLE
Add `@discardableResult` to commands that are not readonly

### DIFF
--- a/Sources/Valkey/Commands/BitmapCommands.swift
+++ b/Sources/Valkey/Commands/BitmapCommands.swift
@@ -492,6 +492,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Array]: The result of the subcommand at the same position
     ///     * [Array]: In case OVERFLOW FAIL was given and overflows or underflows detected
     @inlinable
+    @discardableResult
     public func bitfield(_ key: ValkeyKey, operations: [BITFIELD.Operation] = []) async throws -> RESPToken.Array {
         try await send(command: BITFIELD(key, operations: operations))
     }
@@ -514,6 +515,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N)
     /// - Response: [Integer]: The size of the string stored in the destination key, that is equal to the size of the longest input string.
     @inlinable
+    @discardableResult
     public func bitop(operation: BITOP.Operation, destkey: ValkeyKey, keys: [ValkeyKey]) async throws -> Int {
         try await send(command: BITOP(operation: operation, destkey: destkey, keys: keys))
     }
@@ -551,6 +553,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: The original bit value stored at offset.
     @inlinable
+    @discardableResult
     public func setbit(_ key: ValkeyKey, offset: Int, value: Int) async throws -> Int {
         try await send(command: SETBIT(key, offset: offset, value: value))
     }

--- a/Sources/Valkey/Commands/ClusterCommands.swift
+++ b/Sources/Valkey/Commands/ClusterCommands.swift
@@ -687,6 +687,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: If the epoch was incremented.
     ///     * [String]: If the node already has the greatest config epoch in the cluster.
     @inlinable
+    @discardableResult
     public func clusterBumpepoch() async throws -> ByteBuffer {
         try await send(command: CLUSTER.BUMPEPOCH())
     }
@@ -698,6 +699,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of failure reports
     /// - Response: [Integer]: The number of active failure reports for the node.
     @inlinable
+    @discardableResult
     public func clusterCountFailureReports<NodeId: RESPStringRenderable>(nodeId: NodeId) async throws -> Int {
         try await send(command: CLUSTER.COUNTFAILUREREPORTS(nodeId: nodeId))
     }
@@ -709,6 +711,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Integer]: The number of keys in the specified hash slot.
     @inlinable
+    @discardableResult
     public func clusterCountkeysinslot(slot: Int) async throws -> Int {
         try await send(command: CLUSTER.COUNTKEYSINSLOT(slot: slot))
     }
@@ -770,6 +773,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of requested keys
     /// - Response: [Array]: An array with up to count elements.
     @inlinable
+    @discardableResult
     public func clusterGetkeysinslot(slot: Int, count: Int) async throws -> RESPToken.Array {
         try await send(command: CLUSTER.GETKEYSINSLOT(slot: slot, count: count))
     }
@@ -781,6 +785,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Helpful text about subcommands.
     @inlinable
+    @discardableResult
     public func clusterHelp() async throws -> RESPToken.Array {
         try await send(command: CLUSTER.HELP())
     }
@@ -792,6 +797,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: A map between named fields and values in the form of <field>:<value> lines separated by newlines composed by the two bytes CRLF
     @inlinable
+    @discardableResult
     public func clusterInfo() async throws -> ByteBuffer {
         try await send(command: CLUSTER.INFO())
     }
@@ -803,6 +809,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of bytes in the key
     /// - Response: [Integer]: The hash slot number for the specified key
     @inlinable
+    @discardableResult
     public func clusterKeyslot<Key: RESPStringRenderable>(_ key: Key) async throws -> Int {
         try await send(command: CLUSTER.KEYSLOT(key))
     }
@@ -814,6 +821,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the total number of Cluster nodes
     /// - Response: [Array]: An array of cluster links and their attributes.
     @inlinable
+    @discardableResult
     public func clusterLinks() async throws -> RESPToken.Array {
         try await send(command: CLUSTER.LINKS())
     }
@@ -837,6 +845,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: The node id.
     @inlinable
+    @discardableResult
     public func clusterMyid() async throws -> ByteBuffer {
         try await send(command: CLUSTER.MYID())
     }
@@ -848,6 +857,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: The node's shard id.
     @inlinable
+    @discardableResult
     public func clusterMyshardid() async throws -> ByteBuffer {
         try await send(command: CLUSTER.MYSHARDID())
     }
@@ -859,6 +869,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the total number of Cluster nodes
     /// - Response: [String]: The serialized cluster configuration.
     @inlinable
+    @discardableResult
     public func clusterNodes() async throws -> ByteBuffer {
         try await send(command: CLUSTER.NODES())
     }
@@ -870,6 +881,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of replicas.
     /// - Response: [Array]: A list of replica nodes replicating from the specified primary node provided in the same format used by CLUSTER NODES.
     @inlinable
+    @discardableResult
     public func clusterReplicas<NodeId: RESPStringRenderable>(nodeId: NodeId) async throws -> RESPToken.Array {
         try await send(command: CLUSTER.REPLICAS(nodeId: nodeId))
     }
@@ -933,6 +945,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the total number of cluster nodes
     /// - Response: [Array]: A nested list of a map of hash ranges and shard nodes describing individual shards.
     @inlinable
+    @discardableResult
     public func clusterShards() async throws -> CLUSTER.SHARDS.Response {
         try await send(command: CLUSTER.SHARDS())
     }
@@ -945,6 +958,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of replicas.
     /// - Response: [Array]: A list of replica nodes replicating from the specified primary node provided in the same format used by CLUSTER NODES.
     @inlinable
+    @discardableResult
     public func clusterSlaves<NodeId: RESPStringRenderable>(nodeId: NodeId) async throws -> RESPToken.Array {
         try await send(command: CLUSTER.SLAVES(nodeId: nodeId))
     }
@@ -956,6 +970,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the total number of slots based on arguments. O(N*log(N)) with ORDERBY subcommand.
     /// - Response: [Array]: Array of nested arrays, where the inner array element represents a slot and its respective usage statistics.
     @inlinable
+    @discardableResult
     public func clusterSlotStats(filter: CLUSTER.SLOTSTATS.Filter) async throws -> RESPToken.Array {
         try await send(command: CLUSTER.SLOTSTATS(filter: filter))
     }
@@ -970,6 +985,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the total number of Cluster nodes
     /// - Response: [Array]: Nested list of slot ranges with networking information.
     @inlinable
+    @discardableResult
     public func clusterSlots() async throws -> RESPToken.Array {
         try await send(command: CLUSTER.SLOTS())
     }

--- a/Sources/Valkey/Commands/ConnectionCommands.swift
+++ b/Sources/Valkey/Commands/ConnectionCommands.swift
@@ -808,6 +808,7 @@ extension ValkeyConnectionProtocol {
     /// - Available: 2.4.0
     /// - Complexity: Depends on subcommand.
     @inlinable
+    @discardableResult
     public func client() async throws -> CLIENT.Response {
         try await send(command: CLIENT())
     }
@@ -841,6 +842,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The connection name of the current connection
     ///     * [Null]: Connection name was not set
     @inlinable
+    @discardableResult
     public func clientGetname() async throws -> ByteBuffer? {
         try await send(command: CLIENT.GETNAME())
     }
@@ -855,6 +857,7 @@ extension ValkeyConnectionProtocol {
     ///     * -1: Client tracking is not enabled.
     ///     * [Integer]: ID of the client we are redirecting the notifications to.
     @inlinable
+    @discardableResult
     public func clientGetredir() async throws -> Int {
         try await send(command: CLIENT.GETREDIR())
     }
@@ -866,6 +869,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Helpful text about subcommands.
     @inlinable
+    @discardableResult
     public func clientHelp() async throws -> RESPToken.Array {
         try await send(command: CLIENT.HELP())
     }
@@ -877,6 +881,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Integer]: The id of the client
     @inlinable
+    @discardableResult
     public func clientId() async throws -> Int {
         try await send(command: CLIENT.ID())
     }
@@ -898,6 +903,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: A unique string, as described at the CLIENT LIST page, for the current client.
     @inlinable
+    @discardableResult
     public func clientInfo() async throws -> ByteBuffer {
         try await send(command: CLIENT.INFO())
     }
@@ -920,6 +926,7 @@ extension ValkeyConnectionProtocol {
     ///     * "OK": When called in 3 argument format.
     ///     * [Integer]: When called in filter/value format, the number of clients killed.
     @inlinable
+    @discardableResult
     public func clientKill(filter: CLIENT.KILL.Filter) async throws -> Int? {
         try await send(command: CLIENT.KILL(filter: filter))
     }
@@ -940,6 +947,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of client connections
     /// - Response: [String]: Information and statistics about client connections
     @inlinable
+    @discardableResult
     public func clientList(
         clientType: CLIENT.LIST.ClientType? = nil,
         clientIds: [Int] = [],
@@ -1052,6 +1060,7 @@ extension ValkeyConnectionProtocol {
     /// - Available: 6.2.0
     /// - Complexity: O(1)
     @inlinable
+    @discardableResult
     public func clientTrackinginfo() async throws -> RESPToken.Map {
         try await send(command: CLIENT.TRACKINGINFO())
     }
@@ -1065,6 +1074,7 @@ extension ValkeyConnectionProtocol {
     ///     * 0: If the client was unblocked successfully.
     ///     * 1: If the client wasn't unblocked.
     @inlinable
+    @discardableResult
     public func clientUnblock(clientId: Int, unblockType: CLIENT.UNBLOCK.UnblockType? = nil) async throws -> Int {
         try await send(command: CLIENT.UNBLOCK(clientId: clientId, unblockType: unblockType))
     }
@@ -1086,6 +1096,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: The given string
     @inlinable
+    @discardableResult
     public func echo<Message: RESPStringRenderable>(message: Message) async throws -> ByteBuffer {
         try await send(command: ECHO(message: message))
     }
@@ -1099,6 +1110,7 @@ extension ValkeyConnectionProtocol {
     ///     * 6.2.0: `protover` made optional; when called without arguments the command reports the current connection's context.
     /// - Complexity: O(1)
     @inlinable
+    @discardableResult
     public func hello(arguments: HELLO.Arguments? = nil) async throws -> RESPToken.Map {
         try await send(command: HELLO(arguments: arguments))
     }
@@ -1112,6 +1124,7 @@ extension ValkeyConnectionProtocol {
     ///     * "PONG": Default reply.
     ///     * [String]: Relay of given `message`.
     @inlinable
+    @discardableResult
     public func ping(message: String? = nil) async throws -> PING.Response {
         try await send(command: PING(message: message))
     }
@@ -1133,6 +1146,7 @@ extension ValkeyConnectionProtocol {
     /// - Available: 6.2.0
     /// - Complexity: O(1)
     @inlinable
+    @discardableResult
     public func reset() async throws -> String {
         try await send(command: RESET())
     }

--- a/Sources/Valkey/Commands/GenericCommands.swift
+++ b/Sources/Valkey/Commands/GenericCommands.swift
@@ -1009,6 +1009,7 @@ extension ValkeyConnectionProtocol {
     ///     * 1: Source was copied.
     ///     * 0: Source was not copied when the destination key already exists
     @inlinable
+    @discardableResult
     public func copy(source: ValkeyKey, destination: ValkeyKey, destinationDb: Int? = nil, replace: Bool = false) async throws -> Int {
         try await send(command: COPY(source: source, destination: destination, destinationDb: destinationDb, replace: replace))
     }
@@ -1020,6 +1021,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of keys that will be removed. When a key to remove holds a value other than a string, the individual complexity for this key is O(M) where M is the number of elements in the list, set, sorted set or hash. Removing a single key that holds a string value is O(1).
     /// - Response: [Integer]: The number of keys that were removed.
     @inlinable
+    @discardableResult
     public func del(keys: [ValkeyKey]) async throws -> Int {
         try await send(command: DEL(keys: keys))
     }
@@ -1061,6 +1063,7 @@ extension ValkeyConnectionProtocol {
     ///     * 0: The timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments.
     ///     * 1: The timeout was set.
     @inlinable
+    @discardableResult
     public func expire(_ key: ValkeyKey, seconds: Int, condition: EXPIRE.Condition? = nil) async throws -> Int {
         try await send(command: EXPIRE(key, seconds: seconds, condition: condition))
     }
@@ -1076,6 +1079,7 @@ extension ValkeyConnectionProtocol {
     ///     * 1: The timeout was set.
     ///     * 0: The timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments.
     @inlinable
+    @discardableResult
     public func expireat(_ key: ValkeyKey, unixTimeSeconds: Date, condition: EXPIREAT.Condition? = nil) async throws -> Int {
         try await send(command: EXPIREAT(key, unixTimeSeconds: unixTimeSeconds, condition: condition))
     }
@@ -1119,6 +1123,7 @@ extension ValkeyConnectionProtocol {
     ///     * "OK": Success.
     ///     * "NOKEY": No keys were found in the source instance.
     @inlinable
+    @discardableResult
     public func migrate<Host: RESPStringRenderable>(
         host: Host,
         port: Int,
@@ -1154,6 +1159,7 @@ extension ValkeyConnectionProtocol {
     ///     * 1: Key was moved.
     ///     * 0: Key wasn't moved. When key already exists in the destination database, or it does not exist in the source database
     @inlinable
+    @discardableResult
     public func move(_ key: ValkeyKey, db: Int) async throws -> Int {
         try await send(command: MOVE(key, db: db))
     }
@@ -1189,6 +1195,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Helpful text about subcommands.
     @inlinable
+    @discardableResult
     public func objectHelp() async throws -> RESPToken.Array {
         try await send(command: OBJECT.HELP())
     }
@@ -1224,6 +1231,7 @@ extension ValkeyConnectionProtocol {
     ///     * 0: Key does not exist or does not have an associated timeout.
     ///     * 1: The timeout has been removed.
     @inlinable
+    @discardableResult
     public func persist(_ key: ValkeyKey) async throws -> Int {
         try await send(command: PERSIST(key))
     }
@@ -1239,6 +1247,7 @@ extension ValkeyConnectionProtocol {
     ///     * 0: The timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments.
     ///     * 1: The timeout was set.
     @inlinable
+    @discardableResult
     public func pexpire(_ key: ValkeyKey, milliseconds: Int, condition: PEXPIRE.Condition? = nil) async throws -> Int {
         try await send(command: PEXPIRE(key, milliseconds: milliseconds, condition: condition))
     }
@@ -1254,6 +1263,7 @@ extension ValkeyConnectionProtocol {
     ///     * 1: The timeout was set.
     ///     * 0: The timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments.
     @inlinable
+    @discardableResult
     public func pexpireat(_ key: ValkeyKey, unixTimeMilliseconds: Date, condition: PEXPIREAT.Condition? = nil) async throws -> Int {
         try await send(command: PEXPIREAT(key, unixTimeMilliseconds: unixTimeMilliseconds, condition: condition))
     }
@@ -1322,6 +1332,7 @@ extension ValkeyConnectionProtocol {
     ///     * 1: Key was renamed to newkey.
     ///     * 0: New key already exists.
     @inlinable
+    @discardableResult
     public func renamenx(_ key: ValkeyKey, newkey: ValkeyKey) async throws -> Int {
         try await send(command: RENAMENX(key, newkey: newkey))
     }
@@ -1380,6 +1391,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Integer]: When the store option is specified the command returns the number of sorted elements in the destination list.
     ///     * [Array]: When not passing the store option the command returns a list of sorted elements.
     @inlinable
+    @discardableResult
     public func sort(
         _ key: ValkeyKey,
         byPattern: String? = nil,
@@ -1459,6 +1471,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1) for each key removed regardless of its size. Then the command does O(N) work in a different thread in order to reclaim memory, where N is the number of allocations the deleted objects where composed of.
     /// - Response: [Integer]: The number of keys that were unlinked.
     @inlinable
+    @discardableResult
     public func unlink(keys: [ValkeyKey]) async throws -> Int {
         try await send(command: UNLINK(keys: keys))
     }
@@ -1470,6 +1483,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Integer]: The number of replicas reached by all the writes performed in the context of the current connection.
     @inlinable
+    @discardableResult
     public func wait(numreplicas: Int, timeout: Int) async throws -> Int {
         try await send(command: WAIT(numreplicas: numreplicas, timeout: timeout))
     }
@@ -1481,6 +1495,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Number of local and remote AOF files in sync.
     @inlinable
+    @discardableResult
     public func waitaof(numlocal: Int, numreplicas: Int, timeout: Int) async throws -> RESPToken.Array {
         try await send(command: WAITAOF(numlocal: numlocal, numreplicas: numreplicas, timeout: timeout))
     }

--- a/Sources/Valkey/Commands/GeoCommands.swift
+++ b/Sources/Valkey/Commands/GeoCommands.swift
@@ -1112,6 +1112,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(log(N)) for each item added, where N is the number of elements in the sorted set.
     /// - Response: [Integer]: When used without optional arguments, the number of elements added to the sorted set (excluding score updates).  If the CH option is specified, the number of elements that were changed (added or updated).
     @inlinable
+    @discardableResult
     public func geoadd<Member: RESPStringRenderable>(
         _ key: ValkeyKey,
         condition: GEOADD<Member>.Condition? = nil,
@@ -1172,6 +1173,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
     /// - Response: Array of matched members information.
     @inlinable
+    @discardableResult
     public func georadius(
         _ key: ValkeyKey,
         longitude: Double,
@@ -1213,6 +1215,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
     /// - Response: Array of matched members information.
     @inlinable
+    @discardableResult
     public func georadiusbymember<Member: RESPStringRenderable>(
         _ key: ValkeyKey,
         member: Member,
@@ -1359,6 +1362,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N+log(M)) where N is the number of elements in the grid-aligned bounding box area around the shape provided as the filter and M is the number of items inside the shape
     /// - Response: [Integer]: The number of elements in the resulting set.
     @inlinable
+    @discardableResult
     public func geosearchstore(
         destination: ValkeyKey,
         source: ValkeyKey,

--- a/Sources/Valkey/Commands/HashCommands.swift
+++ b/Sources/Valkey/Commands/HashCommands.swift
@@ -441,6 +441,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of fields to be removed.
     /// - Response: [Integer]: The number of fields that were removed from the hash.
     @inlinable
+    @discardableResult
     public func hdel<Field: RESPStringRenderable>(_ key: ValkeyKey, fields: [Field]) async throws -> Int {
         try await send(command: HDEL(key, fields: fields))
     }
@@ -489,6 +490,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Integer]: The value of the field after the increment operation.
     @inlinable
+    @discardableResult
     public func hincrby<Field: RESPStringRenderable>(_ key: ValkeyKey, field: Field, increment: Int) async throws -> Int {
         try await send(command: HINCRBY(key, field: field, increment: increment))
     }
@@ -500,6 +502,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: The value of the field after the increment operation.
     @inlinable
+    @discardableResult
     public func hincrbyfloat<Field: RESPStringRenderable>(_ key: ValkeyKey, field: Field, increment: Double) async throws -> ByteBuffer {
         try await send(command: HINCRBYFLOAT(key, field: field, increment: increment))
     }
@@ -589,6 +592,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1) for each field/value pair added, so O(N) to add N field/value pairs when the command is called with multiple field/value pairs.
     /// - Response: [Integer]: The number of fields that were added
     @inlinable
+    @discardableResult
     public func hset<Field: RESPStringRenderable, Value: RESPStringRenderable>(_ key: ValkeyKey, datas: [HSET<Field, Value>.Data]) async throws -> Int
     {
         try await send(command: HSET(key, datas: datas))
@@ -603,6 +607,7 @@ extension ValkeyConnectionProtocol {
     ///     * 0: The field is a new field in the hash and value was set.
     ///     * 1: The field already exists in the hash and no operation was performed.
     @inlinable
+    @discardableResult
     public func hsetnx<Field: RESPStringRenderable, Value: RESPStringRenderable>(_ key: ValkeyKey, field: Field, value: Value) async throws -> Int {
         try await send(command: HSETNX(key, field: field, value: value))
     }

--- a/Sources/Valkey/Commands/HyperloglogCommands.swift
+++ b/Sources/Valkey/Commands/HyperloglogCommands.swift
@@ -90,6 +90,7 @@ extension ValkeyConnectionProtocol {
     ///     * 1: If at least 1 HyperLogLog internal register was altered.
     ///     * 0: If no HyperLogLog internal register were altered.
     @inlinable
+    @discardableResult
     public func pfadd(_ key: ValkeyKey, elements: [String] = []) async throws -> Int {
         try await send(command: PFADD(key, elements: elements))
     }

--- a/Sources/Valkey/Commands/ListCommands.swift
+++ b/Sources/Valkey/Commands/ListCommands.swift
@@ -630,6 +630,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The popped element.
     ///     * [Null]: Operation timed-out
     @inlinable
+    @discardableResult
     public func blmove(
         source: ValkeyKey,
         destination: ValkeyKey,
@@ -649,6 +650,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Null]: Operation timed-out
     ///     * [Array]: The key from which elements were popped and the popped elements
     @inlinable
+    @discardableResult
     public func blmpop(timeout: Double, keys: [ValkeyKey], where: BLMPOP.Where, count: Int? = nil) async throws -> RESPToken.Array? {
         try await send(command: BLMPOP(timeout: timeout, keys: keys, where: `where`, count: count))
     }
@@ -664,6 +666,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Null]: No element could be popped and timeout expired
     ///     * [Array]: The key from which the element was popped and the value of the popped element
     @inlinable
+    @discardableResult
     public func blpop(keys: [ValkeyKey], timeout: Double) async throws -> RESPToken.Array? {
         try await send(command: BLPOP(keys: keys, timeout: timeout))
     }
@@ -679,6 +682,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Null]: No element could be popped and the timeout expired.
     ///     * [Array]: The name of the key where an element was popped
     @inlinable
+    @discardableResult
     public func brpop(keys: [ValkeyKey], timeout: Double) async throws -> RESPToken.Array? {
         try await send(command: BRPOP(keys: keys, timeout: timeout))
     }
@@ -695,6 +699,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The element being popped from source and pushed to destination.
     ///     * [Null]: Timeout is reached.
     @inlinable
+    @discardableResult
     public func brpoplpush(source: ValkeyKey, destination: ValkeyKey, timeout: Double) async throws -> ByteBuffer? {
         try await send(command: BRPOPLPUSH(source: source, destination: destination, timeout: timeout))
     }
@@ -722,6 +727,7 @@ extension ValkeyConnectionProtocol {
     ///     * 0: In case key doesn't exist.
     ///     * -1: When the pivot wasn't found.
     @inlinable
+    @discardableResult
     public func linsert<Pivot: RESPStringRenderable, Element: RESPStringRenderable>(
         _ key: ValkeyKey,
         where: LINSERT<Pivot, Element>.Where,
@@ -749,6 +755,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: The element being popped and pushed.
     @inlinable
+    @discardableResult
     public func lmove(source: ValkeyKey, destination: ValkeyKey, wherefrom: LMOVE.Wherefrom, whereto: LMOVE.Whereto) async throws -> ByteBuffer {
         try await send(command: LMOVE(source: source, destination: destination, wherefrom: wherefrom, whereto: whereto))
     }
@@ -762,6 +769,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Null]: If no element could be popped.
     ///     * [Array]: List key from which elements were popped.
     @inlinable
+    @discardableResult
     public func lmpop(keys: [ValkeyKey], where: LMPOP.Where, count: Int? = nil) async throws -> LMPOP.Response {
         try await send(command: LMPOP(keys: keys, where: `where`, count: count))
     }
@@ -778,6 +786,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: In case `count` argument was not given, the value of the first element.
     ///     * [Array]: In case `count` argument was given, a list of popped elements
     @inlinable
+    @discardableResult
     public func lpop(_ key: ValkeyKey, count: Int? = nil) async throws -> RESPToken? {
         try await send(command: LPOP(key, count: count))
     }
@@ -811,6 +820,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.
     /// - Response: [Integer]: Length of the list after the push operations.
     @inlinable
+    @discardableResult
     public func lpush<Element: RESPStringRenderable>(_ key: ValkeyKey, elements: [Element]) async throws -> Int {
         try await send(command: LPUSH(key, elements: elements))
     }
@@ -824,6 +834,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.
     /// - Response: [Integer]: The length of the list after the push operation.
     @inlinable
+    @discardableResult
     public func lpushx<Element: RESPStringRenderable>(_ key: ValkeyKey, elements: [Element]) async throws -> Int {
         try await send(command: LPUSHX(key, elements: elements))
     }
@@ -846,6 +857,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N+M) where N is the length of the list and M is the number of elements removed.
     /// - Response: [Integer]: The number of removed elements.
     @inlinable
+    @discardableResult
     public func lrem<Element: RESPStringRenderable>(_ key: ValkeyKey, count: Int, element: Element) async throws -> Int {
         try await send(command: LREM(key, count: count, element: element))
     }
@@ -882,6 +894,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: When 'COUNT' was not given, the value of the last element.
     ///     * [Array]: When 'COUNT' was given, list of popped elements.
     @inlinable
+    @discardableResult
     public func rpop(_ key: ValkeyKey, count: Int? = nil) async throws -> RESPToken? {
         try await send(command: RPOP(key, count: count))
     }
@@ -896,6 +909,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The element being popped and pushed.
     ///     * [Null]: Source list is empty.
     @inlinable
+    @discardableResult
     public func rpoplpush(source: ValkeyKey, destination: ValkeyKey) async throws -> ByteBuffer? {
         try await send(command: RPOPLPUSH(source: source, destination: destination))
     }
@@ -909,6 +923,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.
     /// - Response: [Integer]: Length of the list after the push operations.
     @inlinable
+    @discardableResult
     public func rpush<Element: RESPStringRenderable>(_ key: ValkeyKey, elements: [Element]) async throws -> Int {
         try await send(command: RPUSH(key, elements: elements))
     }
@@ -922,6 +937,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.
     /// - Response: [Integer]: Length of the list after the push operation.
     @inlinable
+    @discardableResult
     public func rpushx<Element: RESPStringRenderable>(_ key: ValkeyKey, elements: [Element]) async throws -> Int {
         try await send(command: RPUSHX(key, elements: elements))
     }

--- a/Sources/Valkey/Commands/PubsubCommands.swift
+++ b/Sources/Valkey/Commands/PubsubCommands.swift
@@ -245,6 +245,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N+M) where N is the number of clients subscribed to the receiving channel and M is the total number of subscribed patterns (by any client).
     /// - Response: [Integer]: The number of clients that received the message. Note that in a Cluster, only clients that are connected to the same node as the publishing client are included in the count.
     @inlinable
+    @discardableResult
     public func publish<Channel: RESPStringRenderable, Message: RESPStringRenderable>(channel: Channel, message: Message) async throws -> Int {
         try await send(command: PUBLISH(channel: channel, message: message))
     }
@@ -256,6 +257,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of active channels, and assuming constant time pattern matching (relatively short channels and patterns)
     /// - Response: [Array]: A list of active channels, optionally matching the specified pattern.
     @inlinable
+    @discardableResult
     public func pubsubChannels(pattern: String? = nil) async throws -> RESPToken.Array {
         try await send(command: PUBSUB.CHANNELS(pattern: pattern))
     }
@@ -267,6 +269,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Helpful text about subcommands.
     @inlinable
+    @discardableResult
     public func pubsubHelp() async throws -> RESPToken.Array {
         try await send(command: PUBSUB.HELP())
     }
@@ -278,6 +281,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Integer]: The number of patterns all the clients are subscribed to.
     @inlinable
+    @discardableResult
     public func pubsubNumpat() async throws -> Int {
         try await send(command: PUBSUB.NUMPAT())
     }
@@ -289,6 +293,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) for the NUMSUB subcommand, where N is the number of requested channels
     /// - Response: [Array]: The number of subscribers per channel, each even element (including 0th) is channel name, each odd element is the number of subscribers.
     @inlinable
+    @discardableResult
     public func pubsubNumsub(channels: [String] = []) async throws -> RESPToken.Array {
         try await send(command: PUBSUB.NUMSUB(channels: channels))
     }
@@ -300,6 +305,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of active shard channels, and assuming constant time pattern matching (relatively short shard channels).
     /// - Response: [Array]: A list of active channels, optionally matching the specified pattern.
     @inlinable
+    @discardableResult
     public func pubsubShardchannels(pattern: String? = nil) async throws -> RESPToken.Array {
         try await send(command: PUBSUB.SHARDCHANNELS(pattern: pattern))
     }
@@ -311,6 +317,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) for the SHARDNUMSUB subcommand, where N is the number of requested shard channels
     /// - Response: [Array]: The number of subscribers per shard channel, each even element (including 0th) is channel name, each odd element is the number of subscribers.
     @inlinable
+    @discardableResult
     public func pubsubShardnumsub(shardchannels: [String] = []) async throws -> RESPToken.Array {
         try await send(command: PUBSUB.SHARDNUMSUB(shardchannels: shardchannels))
     }
@@ -322,6 +329,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of clients subscribed to the receiving shard channel.
     /// - Response: [Integer]: The number of clients that received the message. Note that in a Cluster, only clients that are connected to the same node as the publishing client are included in the count.
     @inlinable
+    @discardableResult
     public func spublish<Shardchannel: RESPStringRenderable, Message: RESPStringRenderable>(
         shardchannel: Shardchannel,
         message: Message

--- a/Sources/Valkey/Commands/ScriptingCommands.swift
+++ b/Sources/Valkey/Commands/ScriptingCommands.swift
@@ -460,6 +460,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: Depends on the script that is executed.
     /// - Response: Return value depends on the script that is executed
     @inlinable
+    @discardableResult
     public func eval<Script: RESPStringRenderable>(script: Script, keys: [ValkeyKey] = [], args: [String] = []) async throws -> RESPToken {
         try await send(command: EVAL(script: script, keys: keys, args: args))
     }
@@ -471,6 +472,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: Depends on the script that is executed.
     /// - Response: Return value depends on the script that is executed
     @inlinable
+    @discardableResult
     public func evalsha<Sha1: RESPStringRenderable>(sha1: Sha1, keys: [ValkeyKey] = [], args: [String] = []) async throws -> RESPToken {
         try await send(command: EVALSHA(sha1: sha1, keys: keys, args: args))
     }
@@ -504,6 +506,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: Depends on the function that is executed.
     /// - Response: Return value depends on the function that is executed
     @inlinable
+    @discardableResult
     public func fcall<Function: RESPStringRenderable>(function: Function, keys: [ValkeyKey] = [], args: [String] = []) async throws -> RESPToken {
         try await send(command: FCALL(function: function, keys: keys, args: args))
     }
@@ -536,6 +539,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of functions
     /// - Response: [String]: The serialized payload.
     @inlinable
+    @discardableResult
     public func functionDump() async throws -> ByteBuffer {
         try await send(command: FUNCTION.DUMP())
     }
@@ -557,6 +561,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Helpful text about subcommands.
     @inlinable
+    @discardableResult
     public func functionHelp() async throws -> RESPToken.Array {
         try await send(command: FUNCTION.HELP())
     }
@@ -577,6 +582,7 @@ extension ValkeyConnectionProtocol {
     /// - Available: 7.0.0
     /// - Complexity: O(N) where N is the number of functions
     @inlinable
+    @discardableResult
     public func functionList(libraryNamePattern: String? = nil, withcode: Bool = false) async throws -> RESPToken.Array {
         try await send(command: FUNCTION.LIST(libraryNamePattern: libraryNamePattern, withcode: withcode))
     }
@@ -588,6 +594,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1) (considering compilation time is redundant)
     /// - Response: [String]: The library name that was loaded
     @inlinable
+    @discardableResult
     public func functionLoad<FunctionCode: RESPStringRenderable>(replace: Bool = false, functionCode: FunctionCode) async throws -> ByteBuffer {
         try await send(command: FUNCTION.LOAD(replace: replace, functionCode: functionCode))
     }
@@ -611,6 +618,7 @@ extension ValkeyConnectionProtocol {
     /// - Available: 7.0.0
     /// - Complexity: O(1)
     @inlinable
+    @discardableResult
     public func functionStats() async throws -> RESPToken.Map {
         try await send(command: FUNCTION.STATS())
     }
@@ -632,6 +640,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) with N being the number of scripts to check (so checking a single script is an O(1) operation).
     /// - Response: [Array]: An array of integers that correspond to the specified SHA1 digest arguments.
     @inlinable
+    @discardableResult
     public func scriptExists<Sha1: RESPStringRenderable>(sha1s: [Sha1]) async throws -> RESPToken.Array {
         try await send(command: SCRIPT.EXISTS(sha1s: sha1s))
     }
@@ -655,6 +664,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Helpful text about subcommands.
     @inlinable
+    @discardableResult
     public func scriptHelp() async throws -> RESPToken.Array {
         try await send(command: SCRIPT.HELP())
     }
@@ -676,6 +686,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) with N being the length in bytes of the script body.
     /// - Response: [String]: The SHA1 digest of the script added into the script cache
     @inlinable
+    @discardableResult
     public func scriptLoad<Script: RESPStringRenderable>(script: Script) async throws -> ByteBuffer {
         try await send(command: SCRIPT.LOAD(script: script))
     }
@@ -687,6 +698,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1).
     /// - Response: [String]: Lua script if sha1 hash exists in script cache.
     @inlinable
+    @discardableResult
     public func scriptShow<Sha1: RESPStringRenderable>(sha1: Sha1) async throws -> ByteBuffer {
         try await send(command: SCRIPT.SHOW(sha1: sha1))
     }

--- a/Sources/Valkey/Commands/SentinelCommands.swift
+++ b/Sources/Valkey/Commands/SentinelCommands.swift
@@ -523,6 +523,7 @@ extension ValkeyConnectionProtocol {
     /// - Available: 2.8.4
     /// - Response: [String]: Returns OK if the current Sentinel configuration is able to reach the quorum needed to failover a primary, and the majority needed to authorize the failover.
     @inlinable
+    @discardableResult
     public func sentinelCkquorum<PrimaryName: RESPStringRenderable>(primaryName: PrimaryName) async throws -> ByteBuffer {
         try await send(command: SENTINEL.CKQUORUM(primaryName: primaryName))
     }
@@ -538,6 +539,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Map]: When 'SENTINEL-CONFIG GET' is called, returns a map.
     ///     * "OK": When 'SENTINEL-CONFIG SET' is called, returns OK on success.
     @inlinable
+    @discardableResult
     public func sentinelConfig(action: SENTINEL.CONFIG.Action) async throws -> RESPToken.Map? {
         try await send(command: SENTINEL.CONFIG(action: action))
     }
@@ -551,6 +553,7 @@ extension ValkeyConnectionProtocol {
     ///     * "OK": The configuration update was successful.
     ///     * [Map]: List of configurable time parameters and their values (milliseconds).
     @inlinable
+    @discardableResult
     public func sentinelDebug(datas: [SENTINEL.DEBUG.Data] = []) async throws -> RESPToken.Map? {
         try await send(command: SENTINEL.DEBUG(datas: datas))
     }
@@ -584,6 +587,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: IP addr or hostname.
     @inlinable
+    @discardableResult
     public func sentinelGetMasterAddrByName<PrimaryName: RESPStringRenderable>(primaryName: PrimaryName) async throws -> RESPToken.Array {
         try await send(command: SENTINEL.GETMASTERADDRBYNAME(primaryName: primaryName))
     }
@@ -595,6 +599,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: IP addr or hostname.
     @inlinable
+    @discardableResult
     public func sentinelGetPrimaryAddrByName<PrimaryName: RESPStringRenderable>(primaryName: PrimaryName) async throws -> RESPToken.Array {
         try await send(command: SENTINEL.GETPRIMARYADDRBYNAME(primaryName: primaryName))
     }
@@ -606,6 +611,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Helpful text about subcommands.
     @inlinable
+    @discardableResult
     public func sentinelHelp() async throws -> RESPToken.Array {
         try await send(command: SENTINEL.HELP())
     }
@@ -617,6 +623,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of instances
     /// - Response: [Array]: This is actually a map, the odd entries are a primary name, and the even entries are the last cached INFO output from that primary and all its replicas.
     @inlinable
+    @discardableResult
     public func sentinelInfoCache<Nodename: RESPStringRenderable>(nodenames: [Nodename]) async throws -> RESPToken.Array {
         try await send(command: SENTINEL.INFOCACHE(nodenames: nodenames))
     }
@@ -631,6 +638,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Array]: Primary is up.
     ///     * [Array]: Primary is down.
     @inlinable
+    @discardableResult
     public func sentinelIsMasterDownByAddr<Ip: RESPStringRenderable, Runid: RESPStringRenderable>(
         ip: Ip,
         port: Int,
@@ -649,6 +657,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Array]: Primary is up.
     ///     * [Array]: Primary is down.
     @inlinable
+    @discardableResult
     public func sentinelIsPrimaryDownByAddr<Ip: RESPStringRenderable, Runid: RESPStringRenderable>(
         ip: Ip,
         port: Int,
@@ -666,6 +675,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Map]: The state and info of the specified primary.
     @inlinable
+    @discardableResult
     public func sentinelMaster<PrimaryName: RESPStringRenderable>(primaryName: PrimaryName) async throws -> RESPToken.Map {
         try await send(command: SENTINEL.MASTER(primaryName: primaryName))
     }
@@ -678,6 +688,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of primaries
     /// - Response: [Array]: List of monitored primaries, and their states.
     @inlinable
+    @discardableResult
     public func sentinelMasters() async throws -> RESPToken.Array {
         try await send(command: SENTINEL.MASTERS())
     }
@@ -699,6 +710,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: Node ID of the sentinel instance.
     @inlinable
+    @discardableResult
     public func sentinelMyid() async throws -> ByteBuffer {
         try await send(command: SENTINEL.MYID())
     }
@@ -709,6 +721,7 @@ extension ValkeyConnectionProtocol {
     /// - Available: 2.8.4
     /// - Response: [Array]: List of pending scripts.
     @inlinable
+    @discardableResult
     public func sentinelPendingScripts() async throws -> RESPToken.Array {
         try await send(command: SENTINEL.PENDINGSCRIPTS())
     }
@@ -720,6 +733,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of primaries
     /// - Response: [Array]: List of monitored primaries, and their states.
     @inlinable
+    @discardableResult
     public func sentinelPrimaries() async throws -> RESPToken.Array {
         try await send(command: SENTINEL.PRIMARIES())
     }
@@ -731,6 +745,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Map]: The state and info of the specified primary.
     @inlinable
+    @discardableResult
     public func sentinelPrimary<PrimaryName: RESPStringRenderable>(primaryName: PrimaryName) async throws -> RESPToken.Map {
         try await send(command: SENTINEL.PRIMARY(primaryName: primaryName))
     }
@@ -752,6 +767,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of replicas
     /// - Response: [Array]: List of replicas for this primary, and their state.
     @inlinable
+    @discardableResult
     public func sentinelReplicas<PrimaryName: RESPStringRenderable>(primaryName: PrimaryName) async throws -> RESPToken.Array {
         try await send(command: SENTINEL.REPLICAS(primaryName: primaryName))
     }
@@ -763,6 +779,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of monitored primaries
     /// - Response: [Integer]: The number of primaries that were reset.
     @inlinable
+    @discardableResult
     public func sentinelReset(pattern: String) async throws -> Int {
         try await send(command: SENTINEL.RESET(pattern: pattern))
     }
@@ -774,6 +791,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of Sentinels
     /// - Response: [Array]: List of sentinel instances, and their state.
     @inlinable
+    @discardableResult
     public func sentinelSentinels<PrimaryName: RESPStringRenderable>(primaryName: PrimaryName) async throws -> RESPToken.Array {
         try await send(command: SENTINEL.SENTINELS(primaryName: primaryName))
     }
@@ -799,6 +817,7 @@ extension ValkeyConnectionProtocol {
     ///     * "OK": The simulated flag was set.
     ///     * [Array]: Supported simulates flags. Returned in case `HELP` was used.
     @inlinable
+    @discardableResult
     public func sentinelSimulateFailure(modes: [SENTINEL.SIMULATEFAILURE.Mode] = []) async throws -> RESPToken.Array? {
         try await send(command: SENTINEL.SIMULATEFAILURE(modes: modes))
     }
@@ -811,6 +830,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of replicas.
     /// - Response: [Array]: List of monitored replicas, and their state.
     @inlinable
+    @discardableResult
     public func sentinelSlaves<PrimaryName: RESPStringRenderable>(primaryName: PrimaryName) async throws -> RESPToken.Array {
         try await send(command: SENTINEL.SLAVES(primaryName: primaryName))
     }

--- a/Sources/Valkey/Commands/ServerCommands.swift
+++ b/Sources/Valkey/Commands/ServerCommands.swift
@@ -1486,6 +1486,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Array]: In case `category` was not given, a list of existing ACL categories
     ///     * [Array]: In case `category` was given, list of commands that fall under the provided ACL category.
     @inlinable
+    @discardableResult
     public func aclCat(category: String? = nil) async throws -> RESPToken.Array {
         try await send(command: ACL.CAT(category: category))
     }
@@ -1497,6 +1498,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1) amortized time considering the typical user.
     /// - Response: [Integer]: The number of users that were deleted.
     @inlinable
+    @discardableResult
     public func aclDeluser<Username: RESPStringRenderable>(usernames: [Username]) async throws -> Int {
         try await send(command: ACL.DELUSER(usernames: usernames))
     }
@@ -1510,6 +1512,7 @@ extension ValkeyConnectionProtocol {
     ///     * "OK": The given user may successfully execute the given command.
     ///     * [String]: The description of the problem, in case the user is not allowed to run the given command.
     @inlinable
+    @discardableResult
     public func aclDryrun<Username: RESPStringRenderable, Command: RESPStringRenderable>(
         username: Username,
         command: Command,
@@ -1525,6 +1528,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: Pseudorandom data. By default it contains 64 bytes, representing 256 bits of data. If `bits` was given, the output string length is the number of specified bits (rounded to the next multiple of 4) divided by 4.
     @inlinable
+    @discardableResult
     public func aclGenpass(bits: Int? = nil) async throws -> ByteBuffer {
         try await send(command: ACL.GENPASS(bits: bits))
     }
@@ -1541,6 +1545,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Map]: A set of ACL rule definitions for the user.
     ///     * [Null]: If user does not exist
     @inlinable
+    @discardableResult
     public func aclGetuser<Username: RESPStringRenderable>(username: Username) async throws -> RESPToken.Map? {
         try await send(command: ACL.GETUSER(username: username))
     }
@@ -1552,6 +1557,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: A list of subcommands and their description.
     @inlinable
+    @discardableResult
     public func aclHelp() async throws -> RESPToken.Array {
         try await send(command: ACL.HELP())
     }
@@ -1563,6 +1569,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N). Where N is the number of configured users.
     /// - Response: [Array]: A list of currently active ACL rules.
     @inlinable
+    @discardableResult
     public func aclList() async throws -> RESPToken.Array {
         try await send(command: ACL.LIST())
     }
@@ -1588,6 +1595,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Array]: In case `RESET` was not given, a list of recent ACL security events.
     ///     * "OK": In case `RESET` was given, OK indicates ACL log was cleared.
     @inlinable
+    @discardableResult
     public func aclLog(operation: ACL.LOG.Operation? = nil) async throws -> RESPToken.Array? {
         try await send(command: ACL.LOG(operation: operation))
     }
@@ -1622,6 +1630,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N). Where N is the number of configured users.
     /// - Response: [Array]: List of existing ACL users.
     @inlinable
+    @discardableResult
     public func aclUsers() async throws -> RESPToken.Array {
         try await send(command: ACL.USERS())
     }
@@ -1633,6 +1642,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: The username of the current connection.
     @inlinable
+    @discardableResult
     public func aclWhoami() async throws -> ByteBuffer {
         try await send(command: ACL.WHOAMI())
     }
@@ -1644,6 +1654,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: A simple string reply indicating that the rewriting started or is about to start ASAP
     @inlinable
+    @discardableResult
     public func bgrewriteaof() async throws -> ByteBuffer {
         try await send(command: BGREWRITEAOF())
     }
@@ -1657,6 +1668,7 @@ extension ValkeyConnectionProtocol {
     ///     * 8.1.0: Added the `CANCEL` option.
     /// - Complexity: O(1)
     @inlinable
+    @discardableResult
     public func bgsave(operation: BGSAVE.Operation? = nil) async throws -> String {
         try await send(command: BGSAVE(operation: operation))
     }
@@ -1667,6 +1679,7 @@ extension ValkeyConnectionProtocol {
     /// - Available: 2.8.13
     /// - Complexity: O(N) where N is the total number of commands
     @inlinable
+    @discardableResult
     public func command() async throws -> COMMAND.Response {
         try await send(command: COMMAND())
     }
@@ -1678,6 +1691,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Integer]: Number of total commands in this server.
     @inlinable
+    @discardableResult
     public func commandCount() async throws -> Int {
         try await send(command: COMMAND.COUNT())
     }
@@ -1689,6 +1703,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of commands to look up
     /// - Response: [Map]: A map where each key is a command name, and each value is the documentary information
     @inlinable
+    @discardableResult
     public func commandDocs(commandNames: [String] = []) async throws -> RESPToken.Map {
         try await send(command: COMMAND.DOCS(commandNames: commandNames))
     }
@@ -1700,6 +1715,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of arguments to the command
     /// - Response: [Array]: List of keys from the given command.
     @inlinable
+    @discardableResult
     public func commandGetkeys<Command: RESPStringRenderable>(command: Command, args: [String] = []) async throws -> RESPToken.Array {
         try await send(command: COMMAND.GETKEYS(command: command, args: args))
     }
@@ -1711,6 +1727,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of arguments to the command
     /// - Response: [Array]: List of keys from the given command and their usage flags.
     @inlinable
+    @discardableResult
     public func commandGetkeysandflags<Command: RESPStringRenderable>(command: Command, args: [String] = []) async throws -> RESPToken.Array {
         try await send(command: COMMAND.GETKEYSANDFLAGS(command: command, args: args))
     }
@@ -1722,6 +1739,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Helpful text about subcommands.
     @inlinable
+    @discardableResult
     public func commandHelp() async throws -> RESPToken.Array {
         try await send(command: COMMAND.HELP())
     }
@@ -1737,6 +1755,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Array]: Command does not exist.
     ///     * [Array]: Command info array output.
     @inlinable
+    @discardableResult
     public func commandInfo(commandNames: [String] = []) async throws -> RESPToken.Array {
         try await send(command: COMMAND.INFO(commandNames: commandNames))
     }
@@ -1748,6 +1767,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the total number of commands
     /// - Response: [Array]: Command name.
     @inlinable
+    @discardableResult
     public func commandList(filterby: COMMAND.LIST.Filterby? = nil) async throws -> RESPToken.Array {
         try await send(command: COMMAND.LIST(filterby: filterby))
     }
@@ -1759,6 +1779,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of entries returned
     /// - Response: [Array]: Entries from the command log in chronological order.
     @inlinable
+    @discardableResult
     public func commandlogGet(count: Int, type: COMMANDLOG.GET._Type) async throws -> RESPToken.Array {
         try await send(command: COMMANDLOG.GET(count: count, type: type))
     }
@@ -1770,6 +1791,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Helpful text about subcommands.
     @inlinable
+    @discardableResult
     public func commandlogHelp() async throws -> RESPToken.Array {
         try await send(command: COMMANDLOG.HELP())
     }
@@ -1781,6 +1803,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Integer]: Number of entries in the command log.
     @inlinable
+    @discardableResult
     public func commandlogLen(type: COMMANDLOG.LEN._Type) async throws -> Int {
         try await send(command: COMMANDLOG.LEN(type: type))
     }
@@ -1803,6 +1826,7 @@ extension ValkeyConnectionProtocol {
     ///     * 7.0.0: Added the ability to pass multiple pattern parameters in one call
     /// - Complexity: O(N) when N is the number of configuration parameters provided
     @inlinable
+    @discardableResult
     public func configGet<Parameter: RESPStringRenderable>(parameters: [Parameter]) async throws -> RESPToken.Map {
         try await send(command: CONFIG.GET(parameters: parameters))
     }
@@ -1814,6 +1838,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Helpful text about subcommands.
     @inlinable
+    @discardableResult
     public func configHelp() async throws -> RESPToken.Array {
         try await send(command: CONFIG.HELP())
     }
@@ -1906,6 +1931,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: A map of info fields, one field per line in the form of <field>:<value> where the value can be a comma separated map like <key>=<val>. Also contains section header lines starting with `#` and blank lines.
     @inlinable
+    @discardableResult
     public func info(sections: [String] = []) async throws -> ByteBuffer {
         try await send(command: INFO(sections: sections))
     }
@@ -1917,6 +1943,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Integer]: UNIX TIME of the last DB save executed with success.
     @inlinable
+    @discardableResult
     public func lastsave() async throws -> Int {
         try await send(command: LASTSAVE())
     }
@@ -1928,6 +1955,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: A human readable latency analysis report.
     @inlinable
+    @discardableResult
     public func latencyDoctor() async throws -> ByteBuffer {
         try await send(command: LATENCY.DOCTOR())
     }
@@ -1939,6 +1967,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: Latency graph
     @inlinable
+    @discardableResult
     public func latencyGraph<Event: RESPStringRenderable>(event: Event) async throws -> ByteBuffer {
         try await send(command: LATENCY.GRAPH(event: event))
     }
@@ -1950,6 +1979,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Helpful text about subcommands.
     @inlinable
+    @discardableResult
     public func latencyHelp() async throws -> RESPToken.Array {
         try await send(command: LATENCY.HELP())
     }
@@ -1961,6 +1991,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of commands with latency information being retrieved.
     /// - Response: [Map]: A map where each key is a command name, and each value is a map with the total calls, and an inner map of the histogram time buckets.
     @inlinable
+    @discardableResult
     public func latencyHistogram(commands: [String] = []) async throws -> RESPToken.Map {
         try await send(command: LATENCY.HISTOGRAM(commands: commands))
     }
@@ -1972,6 +2003,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: An array where each element is a two elements array representing the timestamp and the latency of the event.
     @inlinable
+    @discardableResult
     public func latencyHistory<Event: RESPStringRenderable>(event: Event) async throws -> RESPToken.Array {
         try await send(command: LATENCY.HISTORY(event: event))
     }
@@ -1983,6 +2015,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: An array where each element is an array representing the event name, timestamp, latest and all-time latency measurements.
     @inlinable
+    @discardableResult
     public func latencyLatest() async throws -> RESPToken.Array {
         try await send(command: LATENCY.LATEST())
     }
@@ -1994,6 +2027,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Integer]: Number of event time series that were reset.
     @inlinable
+    @discardableResult
     public func latencyReset(events: [String] = []) async throws -> Int {
         try await send(command: LATENCY.RESET(events: events))
     }
@@ -2015,6 +2049,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: Memory problems report.
     @inlinable
+    @discardableResult
     public func memoryDoctor() async throws -> ByteBuffer {
         try await send(command: MEMORY.DOCTOR())
     }
@@ -2026,6 +2061,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Helpful text about subcommands.
     @inlinable
+    @discardableResult
     public func memoryHelp() async throws -> RESPToken.Array {
         try await send(command: MEMORY.HELP())
     }
@@ -2037,6 +2073,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: Depends on how much memory is allocated, could be slow
     /// - Response: [String]: The memory allocator's internal statistics report.
     @inlinable
+    @discardableResult
     public func memoryMallocStats() async throws -> ByteBuffer {
         try await send(command: MEMORY.MALLOCSTATS())
     }
@@ -2058,6 +2095,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Map]: Memory usage details.
     @inlinable
+    @discardableResult
     public func memoryStats() async throws -> RESPToken.Map {
         try await send(command: MEMORY.STATS())
     }
@@ -2082,6 +2120,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Helpful text about subcommands.
     @inlinable
+    @discardableResult
     public func moduleHelp() async throws -> RESPToken.Array {
         try await send(command: MODULE.HELP())
     }
@@ -2093,6 +2132,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of loaded modules.
     /// - Response: [Array]: Returns information about the modules loaded to the server.
     @inlinable
+    @discardableResult
     public func moduleList() async throws -> RESPToken.Array {
         try await send(command: MODULE.LIST())
     }
@@ -2133,6 +2173,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [MONITOR](https://valkey.io/commands/monitor)
     /// - Available: 1.0.0
     @inlinable
+    @discardableResult
     public func monitor() async throws -> MONITOR.Response {
         try await send(command: MONITOR())
     }
@@ -2142,6 +2183,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [PSYNC](https://valkey.io/commands/psync)
     /// - Available: 2.8.0
     @inlinable
+    @discardableResult
     public func psync<Replicationid: RESPStringRenderable>(replicationid: Replicationid, offset: Int) async throws -> RESPToken {
         try await send(command: PSYNC(replicationid: replicationid, offset: offset))
     }
@@ -2153,6 +2195,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: ReplicaOf status.
     @inlinable
+    @discardableResult
     public func replicaof(args: REPLICAOF.Args) async throws -> ByteBuffer {
         try await send(command: REPLICAOF(args: args))
     }
@@ -2163,6 +2206,7 @@ extension ValkeyConnectionProtocol {
     /// - Available: 2.8.12
     /// - Complexity: O(1)
     @inlinable
+    @discardableResult
     public func role() async throws -> RESPToken.Array {
         try await send(command: ROLE())
     }
@@ -2198,6 +2242,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: SlaveOf status.
     @inlinable
+    @discardableResult
     public func slaveof(args: SLAVEOF.Args) async throws -> ByteBuffer {
         try await send(command: SLAVEOF(args: args))
     }
@@ -2212,6 +2257,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of entries returned
     /// - Response: [Array]: Entries from the slow log in chronological order.
     @inlinable
+    @discardableResult
     public func slowlogGet(count: Int? = nil) async throws -> RESPToken.Array {
         try await send(command: SLOWLOG.GET(count: count))
     }
@@ -2224,6 +2270,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Helpful text about subcommands.
     @inlinable
+    @discardableResult
     public func slowlogHelp() async throws -> RESPToken.Array {
         try await send(command: SLOWLOG.HELP())
     }
@@ -2236,6 +2283,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Integer]: Number of entries in the slow log.
     @inlinable
+    @discardableResult
     public func slowlogLen() async throws -> Int {
         try await send(command: SLOWLOG.LEN())
     }
@@ -2266,6 +2314,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [SYNC](https://valkey.io/commands/sync)
     /// - Available: 1.0.0
     @inlinable
+    @discardableResult
     public func sync() async throws -> SYNC.Response {
         try await send(command: SYNC())
     }
@@ -2277,6 +2326,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Array containing two elements: Unix time in seconds and microseconds.
     @inlinable
+    @discardableResult
     public func time() async throws -> RESPToken.Array {
         try await send(command: TIME())
     }

--- a/Sources/Valkey/Commands/SetCommands.swift
+++ b/Sources/Valkey/Commands/SetCommands.swift
@@ -384,6 +384,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.
     /// - Response: [Integer]: Number of elements that were added to the set, not including all the elements already present in the set.
     @inlinable
+    @discardableResult
     public func sadd<Member: RESPStringRenderable>(_ key: ValkeyKey, members: [Member]) async throws -> Int {
         try await send(command: SADD(key, members: members))
     }
@@ -417,6 +418,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the total number of elements in all given sets.
     /// - Response: [Integer]: Number of the elements in the resulting set.
     @inlinable
+    @discardableResult
     public func sdiffstore(destination: ValkeyKey, keys: [ValkeyKey]) async throws -> Int {
         try await send(command: SDIFFSTORE(destination: destination, keys: keys))
     }
@@ -450,6 +452,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N*M) worst case where N is the cardinality of the smallest set and M is the number of sets.
     /// - Response: [Integer]: Number of the elements in the result set.
     @inlinable
+    @discardableResult
     public func sinterstore(destination: ValkeyKey, keys: [ValkeyKey]) async throws -> Int {
         try await send(command: SINTERSTORE(destination: destination, keys: keys))
     }
@@ -498,6 +501,7 @@ extension ValkeyConnectionProtocol {
     ///     * 1: Element is moved.
     ///     * 0: The element is not a member of source and no operation was performed.
     @inlinable
+    @discardableResult
     public func smove<Member: RESPStringRenderable>(source: ValkeyKey, destination: ValkeyKey, member: Member) async throws -> Int {
         try await send(command: SMOVE(source: source, destination: destination, member: member))
     }
@@ -514,6 +518,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The removed member when 'COUNT' is not given.
     ///     * [Array]: List to the removed members when 'COUNT' is given.
     @inlinable
+    @discardableResult
     public func spop(_ key: ValkeyKey, count: Int? = nil) async throws -> SPOP.Response {
         try await send(command: SPOP(key, count: count))
     }
@@ -544,6 +549,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of members to be removed.
     /// - Response: [Integer]: Number of members that were removed from the set, not including non existing members.
     @inlinable
+    @discardableResult
     public func srem<Member: RESPStringRenderable>(_ key: ValkeyKey, members: [Member]) async throws -> Int {
         try await send(command: SREM(key, members: members))
     }
@@ -577,6 +583,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the total number of elements in all given sets.
     /// - Response: [Integer]: Number of the elements in the resulting set.
     @inlinable
+    @discardableResult
     public func sunionstore(destination: ValkeyKey, keys: [ValkeyKey]) async throws -> Int {
         try await send(command: SUNIONSTORE(destination: destination, keys: keys))
     }

--- a/Sources/Valkey/Commands/SortedSetCommands.swift
+++ b/Sources/Valkey/Commands/SortedSetCommands.swift
@@ -1240,6 +1240,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Null]: Timeout reached and no elements were popped.
     ///     * [Array]: The keyname and the popped members.
     @inlinable
+    @discardableResult
     public func bzmpop(timeout: Double, keys: [ValkeyKey], where: BZMPOP.Where, count: Int? = nil) async throws -> BZMPOP.Response {
         try await send(command: BZMPOP(timeout: timeout, keys: keys, where: `where`, count: count))
     }
@@ -1255,6 +1256,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Null]: Timeout reached and no elements were popped.
     ///     * [Array]: The keyname, popped member, and its score.
     @inlinable
+    @discardableResult
     public func bzpopmax(keys: [ValkeyKey], timeout: Double) async throws -> BZPOPMAX.Response {
         try await send(command: BZPOPMAX(keys: keys, timeout: timeout))
     }
@@ -1270,6 +1272,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Null]: Timeout reached and no elements were popped.
     ///     * [Array]: The keyname, popped member, and its score.
     @inlinable
+    @discardableResult
     public func bzpopmin(keys: [ValkeyKey], timeout: Double) async throws -> BZPOPMIN.Response {
         try await send(command: BZPOPMIN(keys: keys, timeout: timeout))
     }
@@ -1289,6 +1292,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Integer]: The number of new or updated members (when the `CH` option is used)
     ///     * [Double]: The updated score of the member (when the `INCR` option is used)
     @inlinable
+    @discardableResult
     public func zadd<Member: RESPStringRenderable>(
         _ key: ValkeyKey,
         condition: ZADD<Member>.Condition? = nil,
@@ -1342,6 +1346,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(L + (N-K)log(N)) worst case where L is the total number of elements in all the sets, N is the size of the first set, and K is the size of the result set.
     /// - Response: [Integer]: Number of elements in the resulting sorted set at `destination`
     @inlinable
+    @discardableResult
     public func zdiffstore(destination: ValkeyKey, keys: [ValkeyKey]) async throws -> Int {
         try await send(command: ZDIFFSTORE(destination: destination, keys: keys))
     }
@@ -1353,6 +1358,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(log(N)) where N is the number of elements in the sorted set.
     /// - Response: [Double]: The new score of `member`
     @inlinable
+    @discardableResult
     public func zincrby<Member: RESPStringRenderable>(_ key: ValkeyKey, increment: Int, member: Member) async throws -> Double {
         try await send(command: ZINCRBY(key, increment: increment, member: member))
     }
@@ -1393,6 +1399,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N*K)+O(M*log(M)) worst case with N being the smallest input sorted set, K being the number of input sorted sets and M being the number of elements in the resulting sorted set.
     /// - Response: [Integer]: Number of elements in the resulting sorted set.
     @inlinable
+    @discardableResult
     public func zinterstore(
         destination: ValkeyKey,
         keys: [ValkeyKey],
@@ -1422,6 +1429,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Null]: No element could be popped.
     ///     * [Array]: Name of the key that elements were popped.
     @inlinable
+    @discardableResult
     public func zmpop(keys: [ValkeyKey], where: ZMPOP.Where, count: Int? = nil) async throws -> ZMPOP.Response {
         try await send(command: ZMPOP(keys: keys, where: `where`, count: count))
     }
@@ -1448,6 +1456,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Array]: List of popped elements and scores when 'COUNT' isn't specified.
     ///     * [Array]: List of popped elements and scores when 'COUNT' is specified.
     @inlinable
+    @discardableResult
     public func zpopmax(_ key: ValkeyKey, count: Int? = nil) async throws -> ZPOPMAX.Response {
         try await send(command: ZPOPMAX(key, count: count))
     }
@@ -1461,6 +1470,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Array]: List of popped elements and scores when 'COUNT' isn't specified.
     ///     * [Array]: List of popped elements and scores when 'COUNT' is specified.
     @inlinable
+    @discardableResult
     public func zpopmin(_ key: ValkeyKey, count: Int? = nil) async throws -> ZPOPMIN.Response {
         try await send(command: ZPOPMIN(key, count: count))
     }
@@ -1549,6 +1559,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements stored into the destination key.
     /// - Response: [Integer]: Number of elements in the resulting sorted set.
     @inlinable
+    @discardableResult
     public func zrangestore<Min: RESPStringRenderable, Max: RESPStringRenderable>(
         dst: ValkeyKey,
         src: ValkeyKey,
@@ -1586,6 +1597,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(M*log(N)) with N being the number of elements in the sorted set and M the number of elements to be removed.
     /// - Response: [Integer]: The number of members removed from the sorted set, not including non existing members.
     @inlinable
+    @discardableResult
     public func zrem<Member: RESPStringRenderable>(_ key: ValkeyKey, members: [Member]) async throws -> Int {
         try await send(command: ZREM(key, members: members))
     }
@@ -1597,6 +1609,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements removed by the operation.
     /// - Response: [Integer]: Number of elements removed.
     @inlinable
+    @discardableResult
     public func zremrangebylex<Min: RESPStringRenderable, Max: RESPStringRenderable>(_ key: ValkeyKey, min: Min, max: Max) async throws -> Int {
         try await send(command: ZREMRANGEBYLEX(key, min: min, max: max))
     }
@@ -1608,6 +1621,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements removed by the operation.
     /// - Response: [Integer]: Number of elements removed.
     @inlinable
+    @discardableResult
     public func zremrangebyrank(_ key: ValkeyKey, start: Int, stop: Int) async throws -> Int {
         try await send(command: ZREMRANGEBYRANK(key, start: start, stop: stop))
     }
@@ -1619,6 +1633,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements removed by the operation.
     /// - Response: [Integer]: Number of elements removed.
     @inlinable
+    @discardableResult
     public func zremrangebyscore(_ key: ValkeyKey, min: Double, max: Double) async throws -> Int {
         try await send(command: ZREMRANGEBYSCORE(key, min: min, max: max))
     }
@@ -1749,6 +1764,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N)+O(M log(M)) with N being the sum of the sizes of the input sorted sets, and M being the number of elements in the resulting sorted set.
     /// - Response: [Integer]: The number of elements in the resulting sorted set.
     @inlinable
+    @discardableResult
     public func zunionstore(
         destination: ValkeyKey,
         keys: [ValkeyKey],

--- a/Sources/Valkey/Commands/StreamCommands.swift
+++ b/Sources/Valkey/Commands/StreamCommands.swift
@@ -920,6 +920,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1) for each message ID processed.
     /// - Response: [Integer]: The command returns the number of messages successfully acknowledged. Certain message IDs may no longer be part of the PEL (for example because they have already been acknowledged), and XACK will not count them as successfully acknowledged.
     @inlinable
+    @discardableResult
     public func xack<Group: RESPStringRenderable, Id: RESPStringRenderable>(_ key: ValkeyKey, group: Group, ids: [Id]) async throws -> Int {
         try await send(command: XACK(key, group: group, ids: ids))
     }
@@ -936,6 +937,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The ID of the added entry. The ID is the one auto-generated if * is passed as ID argument, otherwise the command just returns the same ID specified by the user during insertion.
     ///     * [Null]: The NOMKSTREAM option is given and the key doesn't exist.
     @inlinable
+    @discardableResult
     public func xadd<Field: RESPStringRenderable, Value: RESPStringRenderable>(
         _ key: ValkeyKey,
         nomkstream: Bool = false,
@@ -957,6 +959,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Array]: Claimed stream entries (with data, if `JUSTID` was not given).
     ///     * [Array]: Claimed stream entries (without data, if `JUSTID` was given).
     @inlinable
+    @discardableResult
     public func xautoclaim<
         Group: RESPStringRenderable,
         Consumer: RESPStringRenderable,
@@ -983,6 +986,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(log N) with N being the number of messages in the PEL of the consumer group.
     /// - Response: Stream entries with IDs matching the specified range.
     @inlinable
+    @discardableResult
     public func xclaim<Group: RESPStringRenderable, Consumer: RESPStringRenderable, MinIdleTime: RESPStringRenderable, Id: RESPStringRenderable>(
         _ key: ValkeyKey,
         group: Group,
@@ -1020,6 +1024,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1) for each single item to delete in the stream, regardless of the stream size.
     /// - Response: [Integer]: The number of entries actually deleted
     @inlinable
+    @discardableResult
     public func xdel<Id: RESPStringRenderable>(_ key: ValkeyKey, ids: [Id]) async throws -> Int {
         try await send(command: XDEL(key, ids: ids))
     }
@@ -1049,6 +1054,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: The number of created consumers (0 or 1)
     @inlinable
+    @discardableResult
     public func xgroupCreateconsumer<Group: RESPStringRenderable, Consumer: RESPStringRenderable>(
         _ key: ValkeyKey,
         group: Group,
@@ -1064,6 +1070,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Integer]: The number of pending messages that were yet associated with such a consumer
     @inlinable
+    @discardableResult
     public func xgroupDelconsumer<Group: RESPStringRenderable, Consumer: RESPStringRenderable>(
         _ key: ValkeyKey,
         group: Group,
@@ -1079,6 +1086,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N) where N is the number of entries in the group's pending entries list (PEL).
     /// - Response: The number of destroyed consumer groups (0 or 1)
     @inlinable
+    @discardableResult
     public func xgroupDestroy<Group: RESPStringRenderable>(_ key: ValkeyKey, group: Group) async throws -> Int {
         try await send(command: XGROUP.DESTROY(key, group: group))
     }
@@ -1090,6 +1098,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Helpful text about subcommands.
     @inlinable
+    @discardableResult
     public func xgroupHelp() async throws -> RESPToken.Array {
         try await send(command: XGROUP.HELP())
     }
@@ -1143,6 +1152,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Array]: Helpful text about subcommands.
     @inlinable
+    @discardableResult
     public func xinfoHelp() async throws -> RESPToken.Array {
         try await send(command: XINFO.HELP())
     }
@@ -1234,6 +1244,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Null]: If BLOCK option is specified and the timeout expired
     ///     * [Map]: A map of key-value elements when each element composed of key name and the entries reported for that key
     @inlinable
+    @discardableResult
     public func xreadgroup<Group: RESPStringRenderable, Consumer: RESPStringRenderable, Id: RESPStringRenderable>(
         groupBlock: XREADGROUP<Group, Consumer, Id>.GroupBlock,
         count: Int? = nil,
@@ -1288,6 +1299,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(N), with N being the number of evicted entries. Constant times are very small however, since entries are organized in macro nodes containing multiple entries that can be released with a single deallocation.
     /// - Response: [Integer]: The number of entries deleted from the stream.
     @inlinable
+    @discardableResult
     public func xtrim<Threshold: RESPStringRenderable>(_ key: ValkeyKey, trim: XTRIM<Threshold>.Trim) async throws -> Int {
         try await send(command: XTRIM(key, trim: trim))
     }

--- a/Sources/Valkey/Commands/StringCommands.swift
+++ b/Sources/Valkey/Commands/StringCommands.swift
@@ -624,6 +624,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1). The amortized time complexity is O(1) assuming the appended value is small and the already present value is of any size, since the dynamic string library used by the server will double the free space available on every reallocation.
     /// - Response: [Integer]: The length of the string after the append operation.
     @inlinable
+    @discardableResult
     public func append<Value: RESPStringRenderable>(_ key: ValkeyKey, value: Value) async throws -> Int {
         try await send(command: APPEND(key, value: value))
     }
@@ -635,6 +636,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Integer]: The value of the key after decrementing it.
     @inlinable
+    @discardableResult
     public func decr(_ key: ValkeyKey) async throws -> Int {
         try await send(command: DECR(key))
     }
@@ -646,6 +648,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Integer]: The value of the key after decrementing it.
     @inlinable
+    @discardableResult
     public func decrby(_ key: ValkeyKey, decrement: Int) async throws -> Int {
         try await send(command: DECRBY(key, decrement: decrement))
     }
@@ -672,6 +675,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The value of the key.
     ///     * [Null]: The key does not exist.
     @inlinable
+    @discardableResult
     public func getdel(_ key: ValkeyKey) async throws -> ByteBuffer? {
         try await send(command: GETDEL(key))
     }
@@ -685,6 +689,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The value of the key.
     ///     * [Null]: Key does not exist.
     @inlinable
+    @discardableResult
     public func getex(_ key: ValkeyKey, expiration: GETEX.Expiration? = nil) async throws -> ByteBuffer? {
         try await send(command: GETEX(key, expiration: expiration))
     }
@@ -710,6 +715,7 @@ extension ValkeyConnectionProtocol {
     ///     * [String]: The old value stored at the key.
     ///     * [Null]: The key does not exist.
     @inlinable
+    @discardableResult
     public func getset<Value: RESPStringRenderable>(_ key: ValkeyKey, value: Value) async throws -> ByteBuffer? {
         try await send(command: GETSET(key, value: value))
     }
@@ -721,6 +727,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Integer]: The value of key after the increment
     @inlinable
+    @discardableResult
     public func incr(_ key: ValkeyKey) async throws -> Int {
         try await send(command: INCR(key))
     }
@@ -732,6 +739,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [Integer]: The value of the key after incrementing it.
     @inlinable
+    @discardableResult
     public func incrby(_ key: ValkeyKey, increment: Int) async throws -> Int {
         try await send(command: INCRBY(key, increment: increment))
     }
@@ -743,6 +751,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1)
     /// - Response: [String]: The value of the key after incrementing it.
     @inlinable
+    @discardableResult
     public func incrbyfloat(_ key: ValkeyKey, increment: Double) async throws -> ByteBuffer {
         try await send(command: INCRBYFLOAT(key, increment: increment))
     }
@@ -798,6 +807,7 @@ extension ValkeyConnectionProtocol {
     ///     * 0: No key was set (at least one key already existed).
     ///     * 1: All the keys were set.
     @inlinable
+    @discardableResult
     public func msetnx<Value: RESPStringRenderable>(datas: [MSETNX<Value>.Data]) async throws -> Int {
         try await send(command: MSETNX(datas: datas))
     }
@@ -830,6 +840,7 @@ extension ValkeyConnectionProtocol {
     ///     * [Null]: `GET` given: The key didn't exist before the `SET`
     ///     * [String]: `GET` given: The previous value of the key
     @inlinable
+    @discardableResult
     public func set<Value: RESPStringRenderable>(
         _ key: ValkeyKey,
         value: Value,
@@ -861,6 +872,7 @@ extension ValkeyConnectionProtocol {
     ///     * 0: The key was set.
     ///     * 1: The key was not set.
     @inlinable
+    @discardableResult
     public func setnx<Value: RESPStringRenderable>(_ key: ValkeyKey, value: Value) async throws -> Int {
         try await send(command: SETNX(key, value: value))
     }
@@ -872,6 +884,7 @@ extension ValkeyConnectionProtocol {
     /// - Complexity: O(1), not counting the time taken to copy the new string in place. Usually, this string is very small so the amortized complexity is O(1). Otherwise, complexity is O(M) with M being the length of the value argument.
     /// - Response: [Integer]: Length of the string after it was modified by the command.
     @inlinable
+    @discardableResult
     public func setrange<Value: RESPStringRenderable>(_ key: ValkeyKey, offset: Int, value: Value) async throws -> Int {
         try await send(command: SETRANGE(key, offset: offset, value: value))
     }

--- a/Sources/Valkey/Commands/TransactionsCommands.swift
+++ b/Sources/Valkey/Commands/TransactionsCommands.swift
@@ -105,6 +105,7 @@ extension ValkeyConnection {
     ///     * [Array]: Each element being the reply to each of the commands in the atomic transaction.
     ///     * [Null]: The transaction was aborted because a `WATCH`ed key was touched
     @inlinable
+    @discardableResult
     public func exec() async throws -> RESPToken.Array? {
         try await send(command: EXEC())
     }

--- a/Sources/ValkeyBloom/BloomCommands.swift
+++ b/Sources/ValkeyBloom/BloomCommands.swift
@@ -270,6 +270,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [BF.ADD](https://valkey.io/commands/bf.add)
     /// - Complexity: O(N), where N is the number of hash functions used by the bloom filter.
     @inlinable
+    @discardableResult
     public func bfAdd<Value: RESPStringRenderable>(_ key: ValkeyKey, value: Value) async throws -> RESPToken {
         try await send(command: BF.ADD(key, value: value))
     }
@@ -279,6 +280,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [BF.CARD](https://valkey.io/commands/bf.card)
     /// - Complexity: O(1)
     @inlinable
+    @discardableResult
     public func bfCard(_ key: ValkeyKey) async throws -> BF.CARD.Response {
         try await send(command: BF.CARD(key))
     }
@@ -288,6 +290,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [BF.EXISTS](https://valkey.io/commands/bf.exists)
     /// - Complexity: O(N), where N is the number of hash functions used by the bloom filter.
     @inlinable
+    @discardableResult
     public func bfExists<Value: RESPStringRenderable>(_ key: ValkeyKey, value: Value) async throws -> RESPToken {
         try await send(command: BF.EXISTS(key, value: value))
     }
@@ -297,6 +300,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [BF.INFO](https://valkey.io/commands/bf.info)
     /// - Complexity: O(1)
     @inlinable
+    @discardableResult
     public func bfInfo(_ key: ValkeyKey, sortby: BF.INFO.Sortby? = nil) async throws -> BF.INFO.Response {
         try await send(command: BF.INFO(key, sortby: sortby))
     }
@@ -306,6 +310,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [BF.INSERT](https://valkey.io/commands/bf.insert)
     /// - Complexity: O(N * K), where N is the number of hash functions used by the bloom filter and K is the number of items being added
     @inlinable
+    @discardableResult
     public func bfInsert(
         _ key: ValkeyKey,
         capacity: Int? = nil,
@@ -339,6 +344,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [BF.LOAD](https://valkey.io/commands/bf.load)
     /// - Complexity: O(N), where N is the capacity
     @inlinable
+    @discardableResult
     public func bfLoad<Dump: RESPStringRenderable>(_ key: ValkeyKey, dump: Dump) async throws -> RESPToken {
         try await send(command: BF.LOAD(key, dump: dump))
     }
@@ -348,6 +354,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [BF.MADD](https://valkey.io/commands/bf.madd)
     /// - Complexity: O(N * K), where N is the number of hash functions used by the bloom filter and K is the number of items being added
     @inlinable
+    @discardableResult
     public func bfMadd<Value: RESPStringRenderable>(_ key: ValkeyKey, values: [Value]) async throws -> RESPToken {
         try await send(command: BF.MADD(key, values: values))
     }
@@ -357,6 +364,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [BF.MEXISTS](https://valkey.io/commands/bf.mexists)
     /// - Complexity: O(K * N), where N is the number of hash functions used by the bloom filter and K is the number of items
     @inlinable
+    @discardableResult
     public func bfMexists<Value: RESPStringRenderable>(_ key: ValkeyKey, values: [Value]) async throws -> RESPToken {
         try await send(command: BF.MEXISTS(key, values: values))
     }
@@ -366,6 +374,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [BF.RESERVE](https://valkey.io/commands/bf.reserve)
     /// - Complexity: O(1)
     @inlinable
+    @discardableResult
     public func bfReserve(
         _ key: ValkeyKey,
         errorRate: Double,

--- a/Sources/ValkeyJSON/JsonCommands.swift
+++ b/Sources/ValkeyJSON/JsonCommands.swift
@@ -489,6 +489,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.ARRAPPEND](https://valkey.io/commands/json.arrappend)
     /// - Complexity: O(N) where N is the number of vaules
     @inlinable
+    @discardableResult
     public func jsonArrappend<Path: RESPStringRenderable, Json: RESPStringRenderable>(
         _ key: ValkeyKey,
         path: Path,
@@ -502,6 +503,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.ARRINDEX](https://valkey.io/commands/json.arrindex)
     /// - Complexity: O(N), where N is the length of the array.
     @inlinable
+    @discardableResult
     public func jsonArrindex<Path: RESPStringRenderable, JsonScalar: RESPStringRenderable>(
         _ key: ValkeyKey,
         path: Path,
@@ -517,6 +519,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.ARRINSERT](https://valkey.io/commands/json.arrinsert)
     /// - Complexity: O(N) where N is the length of the array.
     @inlinable
+    @discardableResult
     public func jsonArrinsert<Path: RESPStringRenderable, Json: RESPStringRenderable>(
         _ key: ValkeyKey,
         path: Path,
@@ -531,6 +534,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.ARRLEN](https://valkey.io/commands/json.arrlen)
     /// - Complexity: O(N) where N is the number of json arrays matched at the path.
     @inlinable
+    @discardableResult
     public func jsonArrlen(_ key: ValkeyKey, path: String? = nil) async throws -> JSON.ARRLEN.Response {
         try await send(command: JSON.ARRLEN(key, path: path))
     }
@@ -540,6 +544,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.ARRPOP](https://valkey.io/commands/json.arrpop)
     /// - Complexity: O(N) where N is the number of jsons arrays matched by the path.
     @inlinable
+    @discardableResult
     public func jsonArrpop(_ key: ValkeyKey, path: String? = nil, index: Int? = nil) async throws -> JSON.ARRPOP.Response {
         try await send(command: JSON.ARRPOP(key, path: path, index: index))
     }
@@ -549,6 +554,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.ARRTRIM](https://valkey.io/commands/json.arrtrim)
     /// - Complexity: O(N) where N is the number of json arrays matched by the path.
     @inlinable
+    @discardableResult
     public func jsonArrtrim<Path: RESPStringRenderable>(_ key: ValkeyKey, path: Path, start: Int, end: Int) async throws -> RESPToken {
         try await send(command: JSON.ARRTRIM(key, path: path, start: start, end: end))
     }
@@ -558,6 +564,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.CLEAR](https://valkey.io/commands/json.clear)
     /// - Complexity: O(N) where N is the number of json arrays/objects matched by the path.
     @inlinable
+    @discardableResult
     public func jsonClear(_ key: ValkeyKey, path: String? = nil) async throws -> JSON.CLEAR.Response {
         try await send(command: JSON.CLEAR(key, path: path))
     }
@@ -567,6 +574,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.DEBUG](https://valkey.io/commands/json.debug)
     /// - Complexity: O(1)
     @inlinable
+    @discardableResult
     public func jsonDebug<SubcommandArguments: RESPStringRenderable>(subcommandArguments: SubcommandArguments) async throws -> RESPToken {
         try await send(command: JSON.DEBUG(subcommandArguments: subcommandArguments))
     }
@@ -576,6 +584,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.DEL](https://valkey.io/commands/json.del)
     /// - Complexity: O(N) where N is the number of json values matched by the path.
     @inlinable
+    @discardableResult
     public func jsonDel(_ key: ValkeyKey, path: String? = nil) async throws -> JSON.DEL.Response {
         try await send(command: JSON.DEL(key, path: path))
     }
@@ -584,6 +593,7 @@ extension ValkeyConnectionProtocol {
     ///
     /// - Documentation: [JSON.FORGET](https://valkey.io/commands/json.forget)
     @inlinable
+    @discardableResult
     public func jsonForget() async throws -> JSON.FORGET.Response {
         try await send(command: JSON.FORGET())
     }
@@ -593,6 +603,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.GET](https://valkey.io/commands/json.get)
     /// - Complexity: O(N) where N is the number of paths
     @inlinable
+    @discardableResult
     public func jsonGet(
         _ key: ValkeyKey,
         indentNewlineSpace: String? = nil,
@@ -607,6 +618,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.MGET](https://valkey.io/commands/json.mget)
     /// - Complexity: O(N) where N is the number of keys
     @inlinable
+    @discardableResult
     public func jsonMget<Path: RESPStringRenderable>(keys: [ValkeyKey], path: Path) async throws -> RESPToken {
         try await send(command: JSON.MGET(keys: keys, path: path))
     }
@@ -616,6 +628,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.MSET](https://valkey.io/commands/json.mset)
     /// - Complexity: O(N) where N is the number of keys
     @inlinable
+    @discardableResult
     public func jsonMset<Path: RESPStringRenderable, Json: RESPStringRenderable>(datas: [JSON.MSET<Path, Json>.Data]) async throws -> RESPToken {
         try await send(command: JSON.MSET(datas: datas))
     }
@@ -625,6 +638,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.NUMINCRBY](https://valkey.io/commands/json.numincrby)
     /// - Complexity: O(N) where N is the number of json values matched by the path.
     @inlinable
+    @discardableResult
     public func jsonNumincrby<Path: RESPStringRenderable>(_ key: ValkeyKey, path: Path, number: Int) async throws -> RESPToken {
         try await send(command: JSON.NUMINCRBY(key, path: path, number: number))
     }
@@ -634,6 +648,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.NUMMULTBY](https://valkey.io/commands/json.nummultby)
     /// - Complexity: O(N) where N is the number of json values matched by the path.
     @inlinable
+    @discardableResult
     public func jsonNummultby<Path: RESPStringRenderable>(_ key: ValkeyKey, path: Path, number: Int) async throws -> RESPToken {
         try await send(command: JSON.NUMMULTBY(key, path: path, number: number))
     }
@@ -643,6 +658,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.OBJKEYS](https://valkey.io/commands/json.objkeys)
     /// - Complexity: O(N) where N is the number of json objects matched by the path.
     @inlinable
+    @discardableResult
     public func jsonObjkeys(_ key: ValkeyKey, path: String? = nil) async throws -> JSON.OBJKEYS.Response {
         try await send(command: JSON.OBJKEYS(key, path: path))
     }
@@ -652,6 +668,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.OBJLEN](https://valkey.io/commands/json.objlen)
     /// - Complexity: O(N) where N is the number of json objects matched by the path.
     @inlinable
+    @discardableResult
     public func jsonObjlen(_ key: ValkeyKey, path: String? = nil) async throws -> JSON.OBJLEN.Response {
         try await send(command: JSON.OBJLEN(key, path: path))
     }
@@ -661,6 +678,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.RESP](https://valkey.io/commands/json.resp)
     /// - Complexity: O(N) where N is the number of json values matched by the path.
     @inlinable
+    @discardableResult
     public func jsonResp(_ key: ValkeyKey, path: String? = nil) async throws -> JSON.RESP.Response {
         try await send(command: JSON.RESP(key, path: path))
     }
@@ -670,6 +688,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.SET](https://valkey.io/commands/json.set)
     /// - Complexity: O(N) where N is the number of json values matched by the path.
     @inlinable
+    @discardableResult
     public func jsonSet<Path: RESPStringRenderable, Json: RESPStringRenderable>(
         _ key: ValkeyKey,
         path: Path,
@@ -684,6 +703,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.STRAPPEND](https://valkey.io/commands/json.strappend)
     /// - Complexity: O(N) where N is the number of string values matched by the path.
     @inlinable
+    @discardableResult
     public func jsonStrappend<JsonString: RESPStringRenderable>(
         _ key: ValkeyKey,
         path: String? = nil,
@@ -697,6 +717,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.STRLEN](https://valkey.io/commands/json.strlen)
     /// - Complexity: O(N) where N is the number of string values matched by the path.
     @inlinable
+    @discardableResult
     public func jsonStrlen(_ key: ValkeyKey, path: String? = nil) async throws -> JSON.STRLEN.Response {
         try await send(command: JSON.STRLEN(key, path: path))
     }
@@ -706,6 +727,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.TOGGLE](https://valkey.io/commands/json.toggle)
     /// - Complexity: O(N) where N is the number of json boolean values matched by the path.
     @inlinable
+    @discardableResult
     public func jsonToggle(_ key: ValkeyKey, path: String? = nil) async throws -> JSON.TOGGLE.Response {
         try await send(command: JSON.TOGGLE(key, path: path))
     }
@@ -715,6 +737,7 @@ extension ValkeyConnectionProtocol {
     /// - Documentation: [JSON.TYPE](https://valkey.io/commands/json.type)
     /// - Complexity: O(N) where N is the number of json values matched by the path.
     @inlinable
+    @discardableResult
     public func jsonType(_ key: ValkeyKey, path: String? = nil) async throws -> JSON.TYPE.Response {
         try await send(command: JSON.TYPE(key, path: path))
     }

--- a/Sources/_ValkeyCommandsBuilder/ValkeyCommandsRender.swift
+++ b/Sources/_ValkeyCommandsBuilder/ValkeyCommandsRender.swift
@@ -446,6 +446,9 @@ extension String {
                 parametersString = "_ \(parametersString)"
             }
             self.append("    @inlinable\n")
+            if command.commandFlags?.contains("READONLY") != true, returnType != "" {
+                self.append("    @discardableResult\n")
+            }
             self.append("    public func \(name.swiftFunction)\(genericTypeParameters)(\(parametersString)) async throws\(returnType) {\n")
             let commandArguments: [String] =
                 if let firstArgument = arguments.first, firstArgument.shouldRemoveArgumentLabel == true {

--- a/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
+++ b/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
@@ -28,7 +28,7 @@ struct ClusterIntegrationTests {
         let firstNodePort = ClusterIntegrationTests.firstNodePort ?? 6379
         try await Self.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort, tls: false)]) { (client, logger) in
             try await Self.withKey(connection: client) { key in
-                _ = try await client.set(key, value: "Hello")
+                try await client.set(key, value: "Hello")
 
                 let response = try await client.get(key)
                 #expect(response.map { String(buffer: $0) } == "Hello")
@@ -48,7 +48,7 @@ struct ClusterIntegrationTests {
         } catch {
             result = .failure(error)
         }
-        _ = try await connection.del(keys: [key])
+        try await connection.del(keys: [key])
         return try result.get()
     }
 

--- a/Tests/IntegrationTests/ValkeyTests.swift
+++ b/Tests/IntegrationTests/ValkeyTests.swift
@@ -88,7 +88,7 @@ struct GeneratedCommands {
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
-                _ = try await connection.set(key, value: "Hello")
+                try await connection.set(key, value: "Hello")
                 let response = try await connection.send(command: GET(key: key))
                 #expect(response == "Hello")
             }
@@ -102,7 +102,7 @@ struct GeneratedCommands {
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
-                _ = try await connection.set(key, value: "Hello")
+                try await connection.set(key, value: "Hello")
                 let response = try await connection.get(key).map { String(buffer: $0) }
                 #expect(response == "Hello")
                 let response2 = try await connection.get("sdf65fsdf").map { String(buffer: $0) }
@@ -117,7 +117,7 @@ struct GeneratedCommands {
         var logger = Logger(label: "Valkey")
         logger.logLevel = .debug
         try await withValkeyClient(.hostname(valkeyHostname, port: 6379), logger: logger) { valkeyClient in
-            _ = try await valkeyClient.set("sdf", value: "Hello")
+            try await valkeyClient.set("sdf", value: "Hello")
             let response = try await valkeyClient.get("sdf").map { String(buffer: $0) }
             #expect(response == "Hello")
             let response2 = try await valkeyClient.get("sdf65fsdf").map { String(buffer: $0) }
@@ -133,7 +133,7 @@ struct GeneratedCommands {
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
                 let buffer = ByteBuffer(repeating: 12, count: 256)
-                _ = try await connection.set(key, value: buffer)
+                try await connection.set(key, value: buffer)
                 let response = try await connection.get(key)
                 #expect(response == buffer)
             }
@@ -163,7 +163,7 @@ struct GeneratedCommands {
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
-                _ = try await connection.set(key, value: "Hello", expiration: .unixTimeMilliseconds(.now + 1))
+                try await connection.set(key, value: "Hello", expiration: .unixTimeMilliseconds(.now + 1))
                 let response = try await connection.get(key).map { String(buffer: $0) }
                 #expect(response == "Hello")
                 try await Task.sleep(for: .seconds(2))
@@ -247,7 +247,7 @@ struct GeneratedCommands {
                     }
                     group.addTask {
                         await stream2.first { _ in true }
-                        _ = try await connection2.set("testWatch", value: "value1")
+                        try await connection2.set("testWatch", value: "value1")
                         cont.yield()
                     }
                     try await group.waitForAll()
@@ -263,8 +263,8 @@ struct GeneratedCommands {
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
-                _ = try await connection.rpush(key, elements: ["Hello"])
-                _ = try await connection.rpush(key, elements: ["Good", "Bye"])
+                try await connection.rpush(key, elements: ["Hello"])
+                try await connection.rpush(key, elements: ["Good", "Bye"])
                 let values = try await connection.lrange(key, start: 0, stop: -1).decode(as: [String].self)
                 #expect(values == ["Hello", "Good", "Bye"])
             }
@@ -293,9 +293,9 @@ struct GeneratedCommands {
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
-                _ = try await connection.lpush(key, elements: ["a"])
-                _ = try await connection.lpush(key, elements: ["c"])
-                _ = try await connection.lpush(key, elements: ["b"])
+                try await connection.lpush(key, elements: ["a"])
+                try await connection.lpush(key, elements: ["c"])
+                try await connection.lpush(key, elements: ["b"])
                 let list = try await connection.sort(key, sorting: true).decode(as: [String].self)
                 #expect(list == ["a", "b", "c"])
             }
@@ -310,10 +310,10 @@ struct GeneratedCommands {
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
                 try await withKey(connection: connection) { key2 in
-                    _ = try await connection.lpush(key, elements: ["a"])
-                    _ = try await connection.lpush(key2, elements: ["b"])
-                    _ = try await connection.lpush(key2, elements: ["c"])
-                    _ = try await connection.lpush(key2, elements: ["d"])
+                    try await connection.lpush(key, elements: ["a"])
+                    try await connection.lpush(key2, elements: ["b"])
+                    try await connection.lpush(key2, elements: ["c"])
+                    try await connection.lpush(key2, elements: ["d"])
                     let rt1 = try await connection.lmpop(keys: [key, key2], where: .right)
                     let (element) = try rt1?.values.decodeElements(as: (String).self)
                     #expect(rt1?.key == key)
@@ -338,8 +338,8 @@ struct GeneratedCommands {
         logger.logLevel = .trace
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
-                _ = try await connection.set(key, value: "Hello")
-                await #expect(throws: ValkeyClientError.self) { _ = try await connection.rpop(key) }
+                try await connection.set(key, value: "Hello")
+                await #expect(throws: ValkeyClientError.self) { try await connection.rpop(key) }
             }
         }
     }
@@ -354,7 +354,7 @@ struct GeneratedCommands {
                 for _ in 0..<100 {
                     group.addTask {
                         try await withKey(connection: connection) { key in
-                            _ = try await connection.set(key, value: key)
+                            try await connection.set(key, value: key)
                             let response = try await connection.get(key).map { ValkeyKey($0) }
                             #expect(response == key)
                         }
@@ -396,7 +396,7 @@ struct GeneratedCommands {
         var logger = Logger(label: "Valkey")
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname), logger: logger) { connection in
-            _ = try await connection.aclSetuser(username: "johnsmith", rules: ["on", ">3guygsf43", "+ACL|WHOAMI"])
+            try await connection.aclSetuser(username: "johnsmith", rules: ["on", ">3guygsf43", "+ACL|WHOAMI"])
         }
         try await withValkeyConnection(
             .hostname(valkeyHostname),
@@ -414,7 +414,7 @@ struct GeneratedCommands {
         var logger = Logger(label: "testAuthenticationFailure")
         logger.logLevel = .trace
         try await withValkeyConnection(.hostname(valkeyHostname), logger: logger) { connection in
-            _ = try await connection.aclSetuser(username: "johnsmith", rules: ["on", ">3guygsf43", "+ACL|WHOAMI"])
+            try await connection.aclSetuser(username: "johnsmith", rules: ["on", ">3guygsf43", "+ACL|WHOAMI"])
         }
         await #expect(throws: ValkeyClientError(.commandError, message: "WRONGPASS invalid username-password pair or user is disabled.")) {
             _ = try await ValkeyConnection.connect(
@@ -447,8 +447,8 @@ struct GeneratedCommands {
                 }
                 try await client.withConnection { connection in
                     await stream.first { _ in true }
-                    _ = try await connection.publish(channel: "testSubscriptions", message: "hello")
-                    _ = try await connection.publish(channel: "testSubscriptions", message: "goodbye")
+                    try await connection.publish(channel: "testSubscriptions", message: "hello")
+                    try await connection.publish(channel: "testSubscriptions", message: "goodbye")
                 }
                 try await group.waitForAll()
             }
@@ -486,9 +486,9 @@ struct GeneratedCommands {
                 }
                 try await client.withConnection { connection in
                     await stream.first { _ in true }
-                    _ = try await connection.publish(channel: "testDoubleSubscription", message: "hello")
-                    _ = try await connection.publish(channel: "testDoubleSubscription", message: "world")
-                    _ = try await connection.publish(channel: "testDoubleSubscription", message: "!")
+                    try await connection.publish(channel: "testDoubleSubscription", message: "hello")
+                    try await connection.publish(channel: "testDoubleSubscription", message: "world")
+                    try await connection.publish(channel: "testDoubleSubscription", message: "!")
                 }
                 try await group.waitForAll()
             }
@@ -520,8 +520,8 @@ struct GeneratedCommands {
                 }
                 try await client.withConnection { connection in
                     await stream.first { _ in true }
-                    _ = try await connection.publish(channel: "testTwoDifferentSubscriptions", message: "hello")
-                    _ = try await connection.publish(channel: "testTwoDifferentSubscriptions2", message: "goodbye")
+                    try await connection.publish(channel: "testTwoDifferentSubscriptions", message: "hello")
+                    try await connection.publish(channel: "testTwoDifferentSubscriptions2", message: "goodbye")
                 }
                 try await group.waitForAll()
             }
@@ -551,9 +551,9 @@ struct GeneratedCommands {
                 }
                 try await client.withConnection { connection in
                     _ = await stream.first { _ in true }
-                    _ = try await connection.publish(channel: "multi1", message: "1")
-                    _ = try await connection.publish(channel: "multi2", message: "2")
-                    _ = try await connection.publish(channel: "multi3", message: "3")
+                    try await connection.publish(channel: "multi1", message: "1")
+                    try await connection.publish(channel: "multi2", message: "2")
+                    try await connection.publish(channel: "multi3", message: "3")
                 }
                 try await group.waitForAll()
             }
@@ -582,8 +582,8 @@ struct GeneratedCommands {
                 }
                 try await client.withConnection { connection in
                     await stream.first { _ in true }
-                    _ = try await connection.publish(channel: "pattern.1", message: "hello")
-                    _ = try await connection.publish(channel: "pattern.abc", message: "goodbye")
+                    try await connection.publish(channel: "pattern.1", message: "hello")
+                    try await connection.publish(channel: "pattern.abc", message: "goodbye")
                 }
                 try await group.waitForAll()
             }
@@ -618,8 +618,8 @@ struct GeneratedCommands {
                 }
                 try await client.withConnection { connection in
                     await stream.first { _ in true }
-                    _ = try await connection.publish(channel: "PatternChannelSubscriptions1", message: "hello")
-                    _ = try await connection.publish(channel: "PatternChannelSubscriptions2", message: "goodbye")
+                    try await connection.publish(channel: "PatternChannelSubscriptions1", message: "hello")
+                    try await connection.publish(channel: "PatternChannelSubscriptions2", message: "goodbye")
                 }
                 try await group.waitForAll()
             }
@@ -647,8 +647,8 @@ struct GeneratedCommands {
                 }
                 try await client.withConnection { connection in
                     await stream.first { _ in true }
-                    _ = try await connection.spublish(shardchannel: "shard", message: "hello")
-                    _ = try await connection.spublish(shardchannel: "shard", message: "goodbye")
+                    try await connection.spublish(shardchannel: "shard", message: "hello")
+                    try await connection.spublish(shardchannel: "shard", message: "goodbye")
                 }
                 try await group.waitForAll()
             }
@@ -672,7 +672,7 @@ struct GeneratedCommands {
                             await #expect(throws: Never.self) { try await iterator.next().map { String(buffer: $0.message) } == "hello" }
                             // test we can send commands on subscription connection
                             try await withKey(connection: connection) { key in
-                                _ = try await connection.set(key, value: "Hello")
+                                try await connection.set(key, value: "Hello")
                                 let response = try await connection.get(key)
                                 #expect(response.map { String(buffer: $0) } == "Hello")
                             }
@@ -684,8 +684,8 @@ struct GeneratedCommands {
                 }
                 try await valkeyClient.withConnection { connection in
                     await stream.first { _ in true }
-                    _ = try await connection.publish(channel: "testSubscriptions", message: "hello")
-                    _ = try await connection.publish(channel: "testSubscriptions", message: "goodbye")
+                    try await connection.publish(channel: "testSubscriptions", message: "hello")
+                    try await connection.publish(channel: "testSubscriptions", message: "goodbye")
                 }
                 try await group.next()
                 group.cancelAll()
@@ -708,8 +708,8 @@ struct GeneratedCommands {
                     }
                     for _ in 0..<1000 {
                         group.addTask {
-                            try await valkeyClient.withConnection { connection in
-                                _ = try await connection.incr(key)
+                            _ = try await valkeyClient.withConnection { connection in
+                                try await connection.incr(key)
                             }
                         }
                     }
@@ -717,7 +717,7 @@ struct GeneratedCommands {
                     try await valkeyClient.withConnection { connection in
                         let value = try await connection.get(key).map { String(buffer: $0) }
                         #expect(value == "1000")
-                        _ = try await connection.del(keys: [key])
+                        try await connection.del(keys: [key])
                     }
                 }
                 group.cancelAll()
@@ -734,8 +734,8 @@ struct GeneratedCommands {
             try await withKey(connection: connection) { key in
                 _ = try await connection.configSet(datas: [.init(parameter: "notify-keyspace-events", value: "KE$")])
                 try await connection.subscribe(to: ["__keyspace@0__:\(key)"]) { subscription in
-                    _ = try await connection.set(key, value: "1")
-                    _ = try await connection.incrby(key, increment: 20)
+                    try await connection.set(key, value: "1")
+                    try await connection.incrby(key, increment: 20)
                     var iterator = subscription.makeAsyncIterator()
                     var value = try await iterator.next()
                     #expect(value?.channel == "__keyspace@0__:\(key)")
@@ -792,7 +792,7 @@ struct GeneratedCommands {
                 }
                 await stream.first { _ in true }
                 _ = try await connection.get("foo")
-                _ = try await connection.set("foo", value: "baz")
+                try await connection.set("foo", value: "baz")
 
                 try await group.waitForAll()
             }

--- a/Tests/ValkeyTests/CommandTests.swift
+++ b/Tests/ValkeyTests/CommandTests.swift
@@ -34,8 +34,8 @@ struct CommandTests {
 
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
-                    _ = try await connection.replicaof(args: .hostPort(.init(host: "127.0.0.1", port: 18000)))
-                    _ = try await connection.replicaof(args: .noOne)
+                    try await connection.replicaof(args: .hostPort(.init(host: "127.0.0.1", port: 18000)))
+                    try await connection.replicaof(args: .noOne)
                 }
                 group.addTask {
                     var outbound = try await channel.waitForOutboundWrite(as: ByteBuffer.self)


### PR DESCRIPTION
The logic being these commands write to the database somehow, so you are probably calling them for the change to the database and not the return type. eg `SET`, `LPUSH`.