### PR TITLE
Call CLIENT SETINFO on initialisation of connection

### DIFF
--- a/Sources/Valkey/Connection/ValkeyChannelHandler+stateMachine.swift
+++ b/Sources/Valkey/Connection/ValkeyChannelHandler+stateMachine.swift
@@ -225,7 +225,7 @@ extension ValkeyChannelHandler {
                 case .nio(let promise):
                     self = .connected(state)
                     return .waitForPromise(promise)
-                case .swift, .ignore:
+                case .swift, .forget:
                     preconditionFailure("Connected state cannot be setup with a Swift continuation")
                 }
             case .active(let state):

--- a/Sources/Valkey/Connection/ValkeyChannelHandler+stateMachine.swift
+++ b/Sources/Valkey/Connection/ValkeyChannelHandler+stateMachine.swift
@@ -225,7 +225,7 @@ extension ValkeyChannelHandler {
                 case .nio(let promise):
                     self = .connected(state)
                     return .waitForPromise(promise)
-                case .swift:
+                case .swift, .ignore:
                     preconditionFailure("Connected state cannot be setup with a Swift continuation")
                 }
             case .active(let state):

--- a/Sources/Valkey/Connection/ValkeyChannelHandler.swift
+++ b/Sources/Valkey/Connection/ValkeyChannelHandler.swift
@@ -20,7 +20,7 @@ import NIOCore
 enum ValkeyPromise<T: Sendable>: Sendable {
     case nio(EventLoopPromise<T>)
     case swift(CheckedContinuation<T, any Error>)
-    case ignore
+    case forget
 
     func succeed(_ t: T) {
         switch self {
@@ -28,7 +28,7 @@ enum ValkeyPromise<T: Sendable>: Sendable {
             eventLoopPromise.succeed(t)
         case .swift(let checkedContinuation):
             checkedContinuation.resume(returning: t)
-        case .ignore:
+        case .forget:
             break
         }
     }
@@ -39,7 +39,7 @@ enum ValkeyPromise<T: Sendable>: Sendable {
             eventLoopPromise.fail(e)
         case .swift(let checkedContinuation):
             checkedContinuation.resume(throwing: e)
-        case .ignore:
+        case .forget:
             break
         }
     }
@@ -167,7 +167,7 @@ final class ValkeyChannelHandler: ChannelInboundHandler {
     func writeAndForget<Command: ValkeyCommand>(command: Command, requestID: Int) {
         self.eventLoop.assertInEventLoop()
         let pendingCommand = PendingCommand(
-            promise: .ignore,
+            promise: .forget,
             requestID: requestID,
             deadline: .now() + self.configuration.commandTimeout
         )

--- a/Sources/Valkey/Connection/ValkeyConnection.swift
+++ b/Sources/Valkey/Connection/ValkeyConnection.swift
@@ -146,8 +146,8 @@ public final actor ValkeyConnection: ValkeyClientProtocol, Sendable {
 
     func initialHandshake() async throws {
         try await self.channelHandler.waitOnActive().get()
-        self.executeAndForget(command: CLIENT.SETINFO(attr: .libname("valkey-swift")))
-        self.executeAndForget(command: CLIENT.SETINFO(attr: .libver("0.1.0")))
+        self.executeAndForget(command: CLIENT.SETINFO(attr: .libname(valkeySwiftLibraryName)))
+        self.executeAndForget(command: CLIENT.SETINFO(attr: .libver(valkeySwiftLibraryVersion)))
     }
 
     /// Send RESP command to Valkey connection

--- a/Sources/Valkey/Connection/ValkeyConnection.swift
+++ b/Sources/Valkey/Connection/ValkeyConnection.swift
@@ -132,7 +132,7 @@ public final actor ValkeyConnection: ValkeyClientProtocol, Sendable {
                 }
             }
         let connection = try await future.get()
-        try await connection.waitOnActive()
+        try await connection.initialHandshake()
         return connection
     }
 
@@ -144,8 +144,10 @@ public final actor ValkeyConnection: ValkeyClientProtocol, Sendable {
         self.channel.close(mode: .all, promise: nil)
     }
 
-    func waitOnActive() async throws {
+    func initialHandshake() async throws {
         try await self.channelHandler.waitOnActive().get()
+        self.executeAndForget(command: CLIENT.SETINFO(attr: .libname("valkey-swift")))
+        self.executeAndForget(command: CLIENT.SETINFO(attr: .libver("0.1.0")))
     }
 
     /// Send RESP command to Valkey connection
@@ -170,6 +172,10 @@ public final actor ValkeyConnection: ValkeyClientProtocol, Sendable {
         } onCancel: {
             self.cancel(requestID: requestID)
         }
+    }
+
+    func executeAndForget<Command: ValkeyCommand>(command: Command) {
+        self.channelHandler.writeAndForget(command: command, requestID: Self.requestIDGenerator.next())
     }
 
     /// Pipeline a series of commands to Valkey connection

--- a/Sources/Valkey/ValkeyConnectionFactory.swift
+++ b/Sources/Valkey/ValkeyConnectionFactory.swift
@@ -94,7 +94,7 @@ package final class ValkeyConnectionFactory: Sendable {
                     logger: logger
                 )
             }.get()
-            try await connection.waitOnActive()
+            try await connection.initialHandshake()
             return connection
         }
     }

--- a/Sources/Valkey/Version.swift
+++ b/Sources/Valkey/Version.swift
@@ -1,0 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the valkey-swift open source project
+//
+// Copyright (c) 2025 the valkey-swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of valkey-swift project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+package let valkeySwiftLibraryName = "valkey-swift"
+package let valkeySwiftLibraryVersion = "0.1.0"

--- a/Tests/IntegrationTests/ValkeyTests.swift
+++ b/Tests/IntegrationTests/ValkeyTests.swift
@@ -859,4 +859,16 @@ struct GeneratedCommands {
             }
         }
     }
+
+    @available(valkeySwift 1.0, *)
+    @Test
+    func testClientInfo() async throws {
+        var logger = Logger(label: "Valkey")
+        logger.logLevel = .trace
+        try await withValkeyClient(.hostname(valkeyHostname, port: 6379), logger: logger) { client in
+            let clients = try await String(buffer: client.clientList())
+            #expect(clients.firstRange(of: "lib-name=\(valkeySwiftLibraryName)") != nil)
+            #expect(clients.firstRange(of: "lib-ver=\(valkeySwiftLibraryVersion)") != nil)
+        }
+    }
 }


### PR DESCRIPTION
This also adds a new fire and forget API along with a ValkeyPromise type `.forget` where we don't care about the result (to avoid extra allocations). 