### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,8 +29,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.29.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.23.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.8.0"),
-
-        //.package(url: "https://github.com/swiftlang/swift-docc-plugin.git", from: "1.4.5"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Remove commented out docc plugin to allow SPI documentation generation.

As discussed here: https://discord.com/channels/844491846452379649/844491846914539554/1405807664390344804