### PR TITLE
Fix LMOVE empty source array bug

### DIFF
--- a/Sources/Valkey/Commands/ListCommands.swift
+++ b/Sources/Valkey/Commands/ListCommands.swift
@@ -303,7 +303,7 @@ public struct LMOVE: ValkeyCommand {
             }
         }
     }
-    public typealias Response = ByteBuffer
+    public typealias Response = ByteBuffer?
 
     public var source: ValkeyKey
     public var destination: ValkeyKey
@@ -753,11 +753,11 @@ extension ValkeyClientProtocol {
     /// - Documentation: [LMOVE](https://valkey.io/commands/lmove)
     /// - Available: 6.2.0
     /// - Complexity: O(1)
-    /// - Response: [String]: The element being popped and pushed.
+    /// - Response: [String]: The element being popped and pushed. If the source array was empty, an empty buffer is returned.
     @inlinable
     @discardableResult
     public func lmove(source: ValkeyKey, destination: ValkeyKey, wherefrom: LMOVE.Wherefrom, whereto: LMOVE.Whereto) async throws -> ByteBuffer {
-        try await execute(LMOVE(source: source, destination: destination, wherefrom: wherefrom, whereto: whereto))
+        try await execute(LMOVE(source: source, destination: destination, wherefrom: wherefrom, whereto: whereto)) ?? ByteBuffer()
     }
 
     /// Returns multiple elements from a list after removing them. Deletes the list if the last element was popped.

--- a/Tests/IntegrationTests/ValkeyTests.swift
+++ b/Tests/IntegrationTests/ValkeyTests.swift
@@ -365,6 +365,38 @@ struct GeneratedCommands {
     }
 
     @available(valkeySwift 1.0, *)
+    @Test
+    func testLmove() async throws {
+        var logger = Logger(label: "Valkey")
+        logger.logLevel = .trace
+        try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
+            try await withKey(connection: connection) { key in
+                try await withKey(connection: connection) { key2 in
+                    let rtEmpty = try await connection.lmove(source: key, destination: key2, wherefrom: .right, whereto: .left)
+                    #expect(rtEmpty == ByteBuffer())
+                    try await connection.lpush(key, elements: ["a"])
+                    try await connection.lpush(key, elements: ["b"])
+                    try await connection.lpush(key, elements: ["c"])
+                    try await connection.lpush(key, elements: ["d"])
+                    let list1Before = try await connection.lrange(key, start: 0, stop: -1).decode(as: [String].self)
+                    #expect(list1Before == ["d", "c", "b", "a"])
+                    let list2Before = try await connection.lrange(key2, start: 0, stop: -1).decode(as: [String].self)
+                    #expect(list2Before == [])
+                    for expectedValue in ["a", "b", "c", "d"] {
+                        var rt = try await connection.lmove(source: key, destination: key2, wherefrom: .right, whereto: .left)
+                        let value = rt.readString(length: 1)
+                        #expect(value == expectedValue)
+                    }
+                    let list1After = try await connection.lrange(key, start: 0, stop: -1).decode(as: [String].self)
+                    #expect(list1After == [])
+                    let list2After = try await connection.lrange(key2, start: 0, stop: -1).decode(as: [String].self)
+                    #expect(list2After == ["d", "c", "b", "a"])
+                }
+            }
+        }
+    }
+
+    @available(valkeySwift 1.0, *)
     @Test("Test command error is thrown")
     func testCommandError() async throws {
         var logger = Logger(label: "Valkey")


### PR DESCRIPTION
Fixes the issue https://github.com/valkey-io/valkey-swift/issues/184

Note: for backwards compatibility, I have not changed the `lmove` API. However, this PR does change the `Response` type of the `LMOVE` struct, which is a breaking change.

I am hoping to hear from the maintainers as to how flexible you all are with breaking changes, given the very early age of the package (also it being a version 0 package). If you all are open to it, it may be desirable to change the `lmove` API to be optional in this PR.

Please let me know what you think. I would love to be able to remove the workarounds I have in my current code for this.