### PR TITLE
Add static name to Valkey commands

### DIFF
--- a/Sources/Valkey/Commands/BitmapCommands.swift
+++ b/Sources/Valkey/Commands/BitmapCommands.swift
@@ -82,6 +82,8 @@ public struct BITCOUNT: ValkeyCommand {
     }
     public typealias Response = Int
 
+    @inlinable public static var name: String { "BITCOUNT" }
+
     public var key: ValkeyKey
     public var range: Range?
 
@@ -247,6 +249,8 @@ public struct BITFIELD: ValkeyCommand {
     }
     public typealias Response = RESPToken.Array
 
+    @inlinable public static var name: String { "BITFIELD" }
+
     public var key: ValkeyKey
     public var operations: [Operation]
 
@@ -286,6 +290,8 @@ public struct BITFIELDRO: ValkeyCommand {
         }
     }
     public typealias Response = [Int]
+
+    @inlinable public static var name: String { "BITFIELD_RO" }
 
     public var key: ValkeyKey
     public var getBlocks: [GetBlock]
@@ -327,6 +333,8 @@ public struct BITOP: ValkeyCommand {
         }
     }
     public typealias Response = Int
+
+    @inlinable public static var name: String { "BITOP" }
 
     public var operation: Operation
     public var destkey: ValkeyKey
@@ -405,6 +413,8 @@ public struct BITPOS: ValkeyCommand {
     }
     public typealias Response = Int
 
+    @inlinable public static var name: String { "BITPOS" }
+
     public var key: ValkeyKey
     public var bit: Int
     public var range: Range?
@@ -429,6 +439,8 @@ public struct BITPOS: ValkeyCommand {
 public struct GETBIT: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "GETBIT" }
+
     public var key: ValkeyKey
     public var offset: Int
 
@@ -450,6 +462,8 @@ public struct GETBIT: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct SETBIT: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "SETBIT" }
 
     public var key: ValkeyKey
     public var offset: Int

--- a/Sources/Valkey/Commands/ClusterCommands.swift
+++ b/Sources/Valkey/Commands/ClusterCommands.swift
@@ -28,6 +28,8 @@ public enum CLUSTER {
     /// Assigns new hash slots to a node.
     @_documentation(visibility: internal)
     public struct ADDSLOTS: ValkeyCommand {
+        @inlinable public static var name: String { "CLUSTER ADDSLOTS" }
+
         public var slots: [Int]
 
         @inlinable public init(slots: [Int]) {
@@ -62,6 +64,8 @@ public enum CLUSTER {
                 endSlot.encode(into: &commandEncoder)
             }
         }
+        @inlinable public static var name: String { "CLUSTER ADDSLOTSRANGE" }
+
         public var ranges: [Range]
 
         @inlinable public init(ranges: [Range]) {
@@ -78,6 +82,8 @@ public enum CLUSTER {
     public struct BUMPEPOCH: ValkeyCommand {
         public typealias Response = ByteBuffer
 
+        @inlinable public static var name: String { "CLUSTER BUMPEPOCH" }
+
         @inlinable public init() {
         }
 
@@ -90,6 +96,8 @@ public enum CLUSTER {
     @_documentation(visibility: internal)
     public struct COUNTFAILUREREPORTS<NodeId: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = Int
+
+        @inlinable public static var name: String { "CLUSTER COUNT-FAILURE-REPORTS" }
 
         public var nodeId: NodeId
 
@@ -107,6 +115,8 @@ public enum CLUSTER {
     public struct COUNTKEYSINSLOT: ValkeyCommand {
         public typealias Response = Int
 
+        @inlinable public static var name: String { "CLUSTER COUNTKEYSINSLOT" }
+
         public var slot: Int
 
         @inlinable public init(slot: Int) {
@@ -121,6 +131,8 @@ public enum CLUSTER {
     /// Sets hash slots as unbound for a node.
     @_documentation(visibility: internal)
     public struct DELSLOTS: ValkeyCommand {
+        @inlinable public static var name: String { "CLUSTER DELSLOTS" }
+
         public var slots: [Int]
 
         @inlinable public init(slots: [Int]) {
@@ -155,6 +167,8 @@ public enum CLUSTER {
                 endSlot.encode(into: &commandEncoder)
             }
         }
+        @inlinable public static var name: String { "CLUSTER DELSLOTSRANGE" }
+
         public var ranges: [Range]
 
         @inlinable public init(ranges: [Range]) {
@@ -184,6 +198,8 @@ public enum CLUSTER {
                 }
             }
         }
+        @inlinable public static var name: String { "CLUSTER FAILOVER" }
+
         public var options: Options?
 
         @inlinable public init(options: Options? = nil) {
@@ -198,6 +214,8 @@ public enum CLUSTER {
     /// Deletes all slots information from a node.
     @_documentation(visibility: internal)
     public struct FLUSHSLOTS: ValkeyCommand {
+        @inlinable public static var name: String { "CLUSTER FLUSHSLOTS" }
+
         @inlinable public init() {
         }
 
@@ -209,6 +227,8 @@ public enum CLUSTER {
     /// Removes a node from the nodes table.
     @_documentation(visibility: internal)
     public struct FORGET<NodeId: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "CLUSTER FORGET" }
+
         public var nodeId: NodeId
 
         @inlinable public init(nodeId: NodeId) {
@@ -224,6 +244,8 @@ public enum CLUSTER {
     @_documentation(visibility: internal)
     public struct GETKEYSINSLOT: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "CLUSTER GETKEYSINSLOT" }
 
         public var slot: Int
         public var count: Int
@@ -243,6 +265,8 @@ public enum CLUSTER {
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "CLUSTER HELP" }
+
         @inlinable public init() {
         }
 
@@ -256,6 +280,8 @@ public enum CLUSTER {
     public struct INFO: ValkeyCommand {
         public typealias Response = ByteBuffer
 
+        @inlinable public static var name: String { "CLUSTER INFO" }
+
         @inlinable public init() {
         }
 
@@ -268,6 +294,8 @@ public enum CLUSTER {
     @_documentation(visibility: internal)
     public struct KEYSLOT<Key: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = Int
+
+        @inlinable public static var name: String { "CLUSTER KEYSLOT" }
 
         public var key: Key
 
@@ -285,6 +313,8 @@ public enum CLUSTER {
     public struct LINKS: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "CLUSTER LINKS" }
+
         @inlinable public init() {
         }
 
@@ -296,6 +326,8 @@ public enum CLUSTER {
     /// Forces a node to handshake with another node.
     @_documentation(visibility: internal)
     public struct MEET<Ip: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "CLUSTER MEET" }
+
         public var ip: Ip
         public var port: Int
         public var clusterBusPort: Int?
@@ -316,6 +348,8 @@ public enum CLUSTER {
     public struct MYID: ValkeyCommand {
         public typealias Response = ByteBuffer
 
+        @inlinable public static var name: String { "CLUSTER MYID" }
+
         @inlinable public init() {
         }
 
@@ -328,6 +362,8 @@ public enum CLUSTER {
     @_documentation(visibility: internal)
     public struct MYSHARDID: ValkeyCommand {
         public typealias Response = ByteBuffer
+
+        @inlinable public static var name: String { "CLUSTER MYSHARDID" }
 
         @inlinable public init() {
         }
@@ -342,6 +378,8 @@ public enum CLUSTER {
     public struct NODES: ValkeyCommand {
         public typealias Response = ByteBuffer
 
+        @inlinable public static var name: String { "CLUSTER NODES" }
+
         @inlinable public init() {
         }
 
@@ -354,6 +392,8 @@ public enum CLUSTER {
     @_documentation(visibility: internal)
     public struct REPLICAS<NodeId: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "CLUSTER REPLICAS" }
 
         public var nodeId: NodeId
 
@@ -369,6 +409,8 @@ public enum CLUSTER {
     /// Configure a node as replica of a primary node.
     @_documentation(visibility: internal)
     public struct REPLICATE<NodeId: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "CLUSTER REPLICATE" }
+
         public var nodeId: NodeId
 
         @inlinable public init(nodeId: NodeId) {
@@ -398,6 +440,8 @@ public enum CLUSTER {
                 }
             }
         }
+        @inlinable public static var name: String { "CLUSTER RESET" }
+
         public var resetType: ResetType?
 
         @inlinable public init(resetType: ResetType? = nil) {
@@ -412,6 +456,8 @@ public enum CLUSTER {
     /// Forces a node to save the cluster configuration to disk.
     @_documentation(visibility: internal)
     public struct SAVECONFIG: ValkeyCommand {
+        @inlinable public static var name: String { "CLUSTER SAVECONFIG" }
+
         @inlinable public init() {
         }
 
@@ -423,6 +469,8 @@ public enum CLUSTER {
     /// Sets the configuration epoch for a new node.
     @_documentation(visibility: internal)
     public struct SETCONFIGEPOCH: ValkeyCommand {
+        @inlinable public static var name: String { "CLUSTER SET-CONFIG-EPOCH" }
+
         public var configEpoch: Int
 
         @inlinable public init(configEpoch: Int) {
@@ -463,6 +511,8 @@ public enum CLUSTER {
                 }
             }
         }
+        @inlinable public static var name: String { "CLUSTER SETSLOT" }
+
         public var slot: Int
         public var subcommand: Subcommand
         public var timeout: Int?
@@ -481,6 +531,8 @@ public enum CLUSTER {
     /// Returns the mapping of cluster slots to shards.
     @_documentation(visibility: internal)
     public struct SHARDS: ValkeyCommand {
+        @inlinable public static var name: String { "CLUSTER SHARDS" }
+
         @inlinable public init() {
         }
 
@@ -493,6 +545,8 @@ public enum CLUSTER {
     @_documentation(visibility: internal)
     public struct SLAVES<NodeId: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "CLUSTER SLAVES" }
 
         public var nodeId: NodeId
 
@@ -588,6 +642,8 @@ public enum CLUSTER {
         }
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "CLUSTER SLOT-STATS" }
+
         public var filter: Filter
 
         @inlinable public init(filter: Filter) {
@@ -604,6 +660,8 @@ public enum CLUSTER {
     public struct SLOTS: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "CLUSTER SLOTS" }
+
         @inlinable public init() {
         }
 
@@ -617,6 +675,8 @@ public enum CLUSTER {
 /// Signals that a cluster client is following an -ASK redirect.
 @_documentation(visibility: internal)
 public struct ASKING: ValkeyCommand {
+    @inlinable public static var name: String { "ASKING" }
+
     @inlinable public init() {
     }
 
@@ -628,6 +688,8 @@ public struct ASKING: ValkeyCommand {
 /// Enables read-only queries for a connection to a Valkey replica node.
 @_documentation(visibility: internal)
 public struct READONLY: ValkeyCommand {
+    @inlinable public static var name: String { "READONLY" }
+
     @inlinable public init() {
     }
 
@@ -639,6 +701,8 @@ public struct READONLY: ValkeyCommand {
 /// Enables read-write queries for a connection to a Valkey replica node.
 @_documentation(visibility: internal)
 public struct READWRITE: ValkeyCommand {
+    @inlinable public static var name: String { "READWRITE" }
+
     @inlinable public init() {
     }
 

--- a/Sources/Valkey/Commands/ConnectionCommands.swift
+++ b/Sources/Valkey/Commands/ConnectionCommands.swift
@@ -41,6 +41,8 @@ extension CLIENT {
                 }
             }
         }
+        @inlinable public static var name: String { "CLIENT CACHING" }
+
         public var mode: Mode
 
         @inlinable public init(mode: Mode) {
@@ -55,6 +57,8 @@ extension CLIENT {
     /// A client claims its capability.
     @_documentation(visibility: internal)
     public struct CAPA<Capability: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "CLIENT CAPA" }
+
         public var capabilities: [Capability]
 
         @inlinable public init(capabilities: [Capability]) {
@@ -71,6 +75,8 @@ extension CLIENT {
     public struct GETNAME: ValkeyCommand {
         public typealias Response = ByteBuffer?
 
+        @inlinable public static var name: String { "CLIENT GETNAME" }
+
         @inlinable public init() {
         }
 
@@ -83,6 +89,8 @@ extension CLIENT {
     @_documentation(visibility: internal)
     public struct GETREDIR: ValkeyCommand {
         public typealias Response = Int
+
+        @inlinable public static var name: String { "CLIENT GETREDIR" }
 
         @inlinable public init() {
         }
@@ -97,6 +105,8 @@ extension CLIENT {
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "CLIENT HELP" }
+
         @inlinable public init() {
         }
 
@@ -109,6 +119,8 @@ extension CLIENT {
     @_documentation(visibility: internal)
     public struct ID: ValkeyCommand {
         public typealias Response = Int
+
+        @inlinable public static var name: String { "CLIENT ID" }
 
         @inlinable public init() {
         }
@@ -136,6 +148,8 @@ extension CLIENT {
                 }
             }
         }
+        @inlinable public static var name: String { "CLIENT IMPORT-SOURCE" }
+
         public var enabled: Enabled
 
         @inlinable public init(enabled: Enabled) {
@@ -151,6 +165,8 @@ extension CLIENT {
     @_documentation(visibility: internal)
     public struct INFO: ValkeyCommand {
         public typealias Response = ByteBuffer
+
+        @inlinable public static var name: String { "CLIENT INFO" }
 
         @inlinable public init() {
         }
@@ -258,6 +274,8 @@ extension CLIENT {
         }
         public typealias Response = Int?
 
+        @inlinable public static var name: String { "CLIENT KILL" }
+
         public var filter: Filter
 
         @inlinable public init(filter: Filter) {
@@ -307,6 +325,8 @@ extension CLIENT {
             }
         }
         public typealias Response = ByteBuffer
+
+        @inlinable public static var name: String { "CLIENT LIST" }
 
         public var clientType: ClientType?
         public var clientIds: [Int]
@@ -367,6 +387,8 @@ extension CLIENT {
                 }
             }
         }
+        @inlinable public static var name: String { "CLIENT NO-EVICT" }
+
         public var enabled: Enabled
 
         @inlinable public init(enabled: Enabled) {
@@ -396,6 +418,8 @@ extension CLIENT {
                 }
             }
         }
+        @inlinable public static var name: String { "CLIENT NO-TOUCH" }
+
         public var enabled: Enabled
 
         @inlinable public init(enabled: Enabled) {
@@ -425,6 +449,8 @@ extension CLIENT {
                 }
             }
         }
+        @inlinable public static var name: String { "CLIENT PAUSE" }
+
         public var timeout: Int
         public var mode: Mode?
 
@@ -458,6 +484,8 @@ extension CLIENT {
                 }
             }
         }
+        @inlinable public static var name: String { "CLIENT REPLY" }
+
         public var action: Action
 
         @inlinable public init(action: Action) {
@@ -492,6 +520,8 @@ extension CLIENT {
                 }
             }
         }
+        @inlinable public static var name: String { "CLIENT SETINFO" }
+
         public var attr: Attr
 
         @inlinable public init(attr: Attr) {
@@ -506,6 +536,8 @@ extension CLIENT {
     /// Sets the connection name.
     @_documentation(visibility: internal)
     public struct SETNAME<ConnectionName: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "CLIENT SETNAME" }
+
         public var connectionName: ConnectionName
 
         @inlinable public init(connectionName: ConnectionName) {
@@ -535,6 +567,8 @@ extension CLIENT {
                 }
             }
         }
+        @inlinable public static var name: String { "CLIENT TRACKING" }
+
         public var status: Status
         public var clientId: Int?
         public var prefixes: [String]
@@ -581,6 +615,8 @@ extension CLIENT {
     public struct TRACKINGINFO: ValkeyCommand {
         public typealias Response = RESPToken.Map
 
+        @inlinable public static var name: String { "CLIENT TRACKINGINFO" }
+
         @inlinable public init() {
         }
 
@@ -609,6 +645,8 @@ extension CLIENT {
         }
         public typealias Response = Int
 
+        @inlinable public static var name: String { "CLIENT UNBLOCK" }
+
         public var clientId: Int
         public var unblockType: UnblockType?
 
@@ -625,6 +663,8 @@ extension CLIENT {
     /// Resumes processing commands from paused clients.
     @_documentation(visibility: internal)
     public struct UNPAUSE: ValkeyCommand {
+        @inlinable public static var name: String { "CLIENT UNPAUSE" }
+
         @inlinable public init() {
         }
 
@@ -638,6 +678,8 @@ extension CLIENT {
 /// Authenticates the connection.
 @_documentation(visibility: internal)
 public struct AUTH<Password: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "AUTH" }
+
     public var username: String?
     public var password: Password
 
@@ -654,6 +696,8 @@ public struct AUTH<Password: RESPStringRenderable>: ValkeyCommand {
 /// A container for client connection commands.
 @_documentation(visibility: internal)
 public struct CLIENT: ValkeyCommand {
+    @inlinable public static var name: String { "CLIENT" }
+
     @inlinable public init() {
     }
 
@@ -666,6 +710,8 @@ public struct CLIENT: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct ECHO<Message: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = ByteBuffer
+
+    @inlinable public static var name: String { "ECHO" }
 
     public var message: Message
 
@@ -726,6 +772,8 @@ public struct HELLO: ValkeyCommand {
     }
     public typealias Response = RESPToken.Map
 
+    @inlinable public static var name: String { "HELLO" }
+
     public var arguments: Arguments?
 
     @inlinable public init(arguments: Arguments? = nil) {
@@ -740,6 +788,8 @@ public struct HELLO: ValkeyCommand {
 /// Returns the server's liveliness response.
 @_documentation(visibility: internal)
 public struct PING: ValkeyCommand {
+    @inlinable public static var name: String { "PING" }
+
     public var message: String?
 
     @inlinable public init(message: String? = nil) {
@@ -754,6 +804,8 @@ public struct PING: ValkeyCommand {
 /// Closes the connection.
 @_documentation(visibility: internal)
 public struct QUIT: ValkeyCommand {
+    @inlinable public static var name: String { "QUIT" }
+
     @inlinable public init() {
     }
 
@@ -767,6 +819,8 @@ public struct QUIT: ValkeyCommand {
 public struct RESET: ValkeyCommand {
     public typealias Response = String
 
+    @inlinable public static var name: String { "RESET" }
+
     @inlinable public init() {
     }
 
@@ -778,6 +832,8 @@ public struct RESET: ValkeyCommand {
 /// Changes the selected database.
 @_documentation(visibility: internal)
 public struct SELECT: ValkeyCommand {
+    @inlinable public static var name: String { "SELECT" }
+
     public var index: Int
 
     @inlinable public init(index: Int) {

--- a/Sources/Valkey/Commands/GenericCommands.swift
+++ b/Sources/Valkey/Commands/GenericCommands.swift
@@ -30,6 +30,8 @@ public enum OBJECT {
     public struct ENCODING: ValkeyCommand {
         public typealias Response = ByteBuffer?
 
+        @inlinable public static var name: String { "OBJECT ENCODING" }
+
         public var key: ValkeyKey
 
         @inlinable public init(_ key: ValkeyKey) {
@@ -49,6 +51,8 @@ public enum OBJECT {
     @_documentation(visibility: internal)
     public struct FREQ: ValkeyCommand {
         public typealias Response = Int
+
+        @inlinable public static var name: String { "OBJECT FREQ" }
 
         public var key: ValkeyKey
 
@@ -70,6 +74,8 @@ public enum OBJECT {
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "OBJECT HELP" }
+
         @inlinable public init() {
         }
 
@@ -82,6 +88,8 @@ public enum OBJECT {
     @_documentation(visibility: internal)
     public struct IDLETIME: ValkeyCommand {
         public typealias Response = Int
+
+        @inlinable public static var name: String { "OBJECT IDLETIME" }
 
         public var key: ValkeyKey
 
@@ -102,6 +110,8 @@ public enum OBJECT {
     @_documentation(visibility: internal)
     public struct REFCOUNT: ValkeyCommand {
         public typealias Response = Int
+
+        @inlinable public static var name: String { "OBJECT REFCOUNT" }
 
         public var key: ValkeyKey
 
@@ -124,6 +134,8 @@ public enum OBJECT {
 @_documentation(visibility: internal)
 public struct COPY: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "COPY" }
 
     public var source: ValkeyKey
     public var destination: ValkeyKey
@@ -149,6 +161,8 @@ public struct COPY: ValkeyCommand {
 public struct DEL: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "DEL" }
+
     public var keys: [ValkeyKey]
 
     @inlinable public init(keys: [ValkeyKey]) {
@@ -166,6 +180,8 @@ public struct DEL: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct DUMP: ValkeyCommand {
     public typealias Response = ByteBuffer?
+
+    @inlinable public static var name: String { "DUMP" }
 
     public var key: ValkeyKey
 
@@ -186,6 +202,8 @@ public struct DUMP: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct EXISTS: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "EXISTS" }
 
     public var keys: [ValkeyKey]
 
@@ -225,6 +243,8 @@ public struct EXPIRE: ValkeyCommand {
         }
     }
     public typealias Response = Int
+
+    @inlinable public static var name: String { "EXPIRE" }
 
     public var key: ValkeyKey
     public var seconds: Int
@@ -267,6 +287,8 @@ public struct EXPIREAT: ValkeyCommand {
     }
     public typealias Response = Int
 
+    @inlinable public static var name: String { "EXPIREAT" }
+
     public var key: ValkeyKey
     public var unixTimeSeconds: Date
     public var condition: Condition?
@@ -289,6 +311,8 @@ public struct EXPIREAT: ValkeyCommand {
 public struct EXPIRETIME: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "EXPIRETIME" }
+
     public var key: ValkeyKey
 
     @inlinable public init(_ key: ValkeyKey) {
@@ -308,6 +332,8 @@ public struct EXPIRETIME: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct KEYS: ValkeyCommand {
     public typealias Response = RESPToken.Array
+
+    @inlinable public static var name: String { "KEYS" }
 
     public var pattern: String
 
@@ -387,6 +413,8 @@ public struct MIGRATE<Host: RESPStringRenderable>: ValkeyCommand {
     }
     public typealias Response = String?
 
+    @inlinable public static var name: String { "MIGRATE" }
+
     public var host: Host
     public var port: Int
     public var keySelector: KeySelector
@@ -442,6 +470,8 @@ public struct MIGRATE<Host: RESPStringRenderable>: ValkeyCommand {
 public struct MOVE: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "MOVE" }
+
     public var key: ValkeyKey
     public var db: Int
 
@@ -461,6 +491,8 @@ public struct MOVE: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct PERSIST: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "PERSIST" }
 
     public var key: ValkeyKey
 
@@ -498,6 +530,8 @@ public struct PEXPIRE: ValkeyCommand {
         }
     }
     public typealias Response = Int
+
+    @inlinable public static var name: String { "PEXPIRE" }
 
     public var key: ValkeyKey
     public var milliseconds: Int
@@ -540,6 +574,8 @@ public struct PEXPIREAT: ValkeyCommand {
     }
     public typealias Response = Int
 
+    @inlinable public static var name: String { "PEXPIREAT" }
+
     public var key: ValkeyKey
     public var unixTimeMilliseconds: Date
     public var condition: Condition?
@@ -562,6 +598,8 @@ public struct PEXPIREAT: ValkeyCommand {
 public struct PEXPIRETIME: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "PEXPIRETIME" }
+
     public var key: ValkeyKey
 
     @inlinable public init(_ key: ValkeyKey) {
@@ -581,6 +619,8 @@ public struct PEXPIRETIME: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct PTTL: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "PTTL" }
 
     public var key: ValkeyKey
 
@@ -602,6 +642,8 @@ public struct PTTL: ValkeyCommand {
 public struct RANDOMKEY: ValkeyCommand {
     public typealias Response = ByteBuffer?
 
+    @inlinable public static var name: String { "RANDOMKEY" }
+
     @inlinable public init() {
     }
 
@@ -615,6 +657,8 @@ public struct RANDOMKEY: ValkeyCommand {
 /// Renames a key and overwrites the destination.
 @_documentation(visibility: internal)
 public struct RENAME: ValkeyCommand {
+    @inlinable public static var name: String { "RENAME" }
+
     public var key: ValkeyKey
     public var newkey: ValkeyKey
 
@@ -635,6 +679,8 @@ public struct RENAME: ValkeyCommand {
 public struct RENAMENX: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "RENAMENX" }
+
     public var key: ValkeyKey
     public var newkey: ValkeyKey
 
@@ -653,6 +699,8 @@ public struct RENAMENX: ValkeyCommand {
 /// Creates a key from the serialized representation of a value.
 @_documentation(visibility: internal)
 public struct RESTORE<SerializedValue: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "RESTORE" }
+
     public var key: ValkeyKey
     public var ttl: Int
     public var serializedValue: SerializedValue
@@ -699,6 +747,8 @@ public struct RESTORE<SerializedValue: RESPStringRenderable>: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct SCAN: ValkeyCommand {
     public typealias Response = RESPToken.Array
+
+    @inlinable public static var name: String { "SCAN" }
 
     public var cursor: Int
     public var pattern: String?
@@ -757,6 +807,8 @@ public struct SORT: ValkeyCommand {
             }
         }
     }
+    @inlinable public static var name: String { "SORT" }
+
     public var key: ValkeyKey
     public var byPattern: String?
     public var limit: Limit?
@@ -839,6 +891,8 @@ public struct SORTRO: ValkeyCommand {
     }
     public typealias Response = RESPToken.Array
 
+    @inlinable public static var name: String { "SORT_RO" }
+
     public var key: ValkeyKey
     public var byPattern: String?
     public var limit: Limit?
@@ -884,6 +938,8 @@ public struct SORTRO: ValkeyCommand {
 public struct TOUCH: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "TOUCH" }
+
     public var keys: [ValkeyKey]
 
     @inlinable public init(keys: [ValkeyKey]) {
@@ -903,6 +959,8 @@ public struct TOUCH: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct TTL: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "TTL" }
 
     public var key: ValkeyKey
 
@@ -924,6 +982,8 @@ public struct TTL: ValkeyCommand {
 public struct TYPE: ValkeyCommand {
     public typealias Response = ByteBuffer?
 
+    @inlinable public static var name: String { "TYPE" }
+
     public var key: ValkeyKey
 
     @inlinable public init(_ key: ValkeyKey) {
@@ -944,6 +1004,8 @@ public struct TYPE: ValkeyCommand {
 public struct UNLINK: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "UNLINK" }
+
     public var keys: [ValkeyKey]
 
     @inlinable public init(keys: [ValkeyKey]) {
@@ -961,6 +1023,8 @@ public struct UNLINK: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct WAIT: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "WAIT" }
 
     public var numreplicas: Int
     public var timeout: Int
@@ -981,6 +1045,8 @@ public struct WAIT: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct WAITAOF: ValkeyCommand {
     public typealias Response = RESPToken.Array
+
+    @inlinable public static var name: String { "WAITAOF" }
 
     public var numlocal: Int
     public var numreplicas: Int

--- a/Sources/Valkey/Commands/GeoCommands.swift
+++ b/Sources/Valkey/Commands/GeoCommands.swift
@@ -65,6 +65,8 @@ public struct GEOADD<Member: RESPStringRenderable>: ValkeyCommand {
     }
     public typealias Response = Int
 
+    @inlinable public static var name: String { "GEOADD" }
+
     public var key: ValkeyKey
     public var condition: Condition?
     public var change: Bool
@@ -106,6 +108,8 @@ public struct GEODIST<Member1: RESPStringRenderable, Member2: RESPStringRenderab
             }
         }
     }
+    @inlinable public static var name: String { "GEODIST" }
+
     public var key: ValkeyKey
     public var member1: Member1
     public var member2: Member2
@@ -132,6 +136,8 @@ public struct GEODIST<Member1: RESPStringRenderable, Member2: RESPStringRenderab
 public struct GEOHASH: ValkeyCommand {
     public typealias Response = RESPToken.Array
 
+    @inlinable public static var name: String { "GEOHASH" }
+
     public var key: ValkeyKey
     public var members: [String]
 
@@ -152,6 +158,8 @@ public struct GEOHASH: ValkeyCommand {
 /// Returns the longitude and latitude of members from a geospatial index.
 @_documentation(visibility: internal)
 public struct GEOPOS: ValkeyCommand {
+    @inlinable public static var name: String { "GEOPOS" }
+
     public var key: ValkeyKey
     public var members: [String]
 
@@ -246,6 +254,8 @@ public struct GEORADIUS: ValkeyCommand {
             }
         }
     }
+    @inlinable public static var name: String { "GEORADIUS" }
+
     public var key: ValkeyKey
     public var longitude: Double
     public var latitude: Double
@@ -381,6 +391,8 @@ public struct GEORADIUSBYMEMBER<Member: RESPStringRenderable>: ValkeyCommand {
             }
         }
     }
+    @inlinable public static var name: String { "GEORADIUSBYMEMBER" }
+
     public var key: ValkeyKey
     public var member: Member
     public var radius: Double
@@ -494,6 +506,8 @@ public struct GEORADIUSBYMEMBERRO<Member: RESPStringRenderable>: ValkeyCommand {
     }
     public typealias Response = RESPToken.Array
 
+    @inlinable public static var name: String { "GEORADIUSBYMEMBER_RO" }
+
     public var key: ValkeyKey
     public var member: Member
     public var radius: Double
@@ -604,6 +618,8 @@ public struct GEORADIUSRO: ValkeyCommand {
         }
     }
     public typealias Response = RESPToken.Array
+
+    @inlinable public static var name: String { "GEORADIUS_RO" }
 
     public var key: ValkeyKey
     public var longitude: Double
@@ -840,6 +856,8 @@ public struct GEOSEARCH: ValkeyCommand {
             RESPPureToken("ANY", any).encode(into: &commandEncoder)
         }
     }
+    @inlinable public static var name: String { "GEOSEARCH" }
+
     public var key: ValkeyKey
     public var from: From
     public var by: By
@@ -1068,6 +1086,8 @@ public struct GEOSEARCHSTORE: ValkeyCommand {
         }
     }
     public typealias Response = Int
+
+    @inlinable public static var name: String { "GEOSEARCHSTORE" }
 
     public var destination: ValkeyKey
     public var source: ValkeyKey

--- a/Sources/Valkey/Commands/HashCommands.swift
+++ b/Sources/Valkey/Commands/HashCommands.swift
@@ -27,6 +27,8 @@ import Foundation
 public struct HDEL<Field: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "HDEL" }
+
     public var key: ValkeyKey
     public var fields: [Field]
 
@@ -46,6 +48,8 @@ public struct HDEL<Field: RESPStringRenderable>: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct HEXISTS<Field: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "HEXISTS" }
 
     public var key: ValkeyKey
     public var field: Field
@@ -69,6 +73,8 @@ public struct HEXISTS<Field: RESPStringRenderable>: ValkeyCommand {
 public struct HGET<Field: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = ByteBuffer?
 
+    @inlinable public static var name: String { "HGET" }
+
     public var key: ValkeyKey
     public var field: Field
 
@@ -91,6 +97,8 @@ public struct HGET<Field: RESPStringRenderable>: ValkeyCommand {
 public struct HGETALL: ValkeyCommand {
     public typealias Response = RESPToken.Map
 
+    @inlinable public static var name: String { "HGETALL" }
+
     public var key: ValkeyKey
 
     @inlinable public init(_ key: ValkeyKey) {
@@ -110,6 +118,8 @@ public struct HGETALL: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct HINCRBY<Field: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "HINCRBY" }
 
     public var key: ValkeyKey
     public var field: Field
@@ -133,6 +143,8 @@ public struct HINCRBY<Field: RESPStringRenderable>: ValkeyCommand {
 public struct HINCRBYFLOAT<Field: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = ByteBuffer
 
+    @inlinable public static var name: String { "HINCRBYFLOAT" }
+
     public var key: ValkeyKey
     public var field: Field
     public var increment: Double
@@ -155,6 +167,8 @@ public struct HINCRBYFLOAT<Field: RESPStringRenderable>: ValkeyCommand {
 public struct HKEYS: ValkeyCommand {
     public typealias Response = RESPToken.Array
 
+    @inlinable public static var name: String { "HKEYS" }
+
     public var key: ValkeyKey
 
     @inlinable public init(_ key: ValkeyKey) {
@@ -175,6 +189,8 @@ public struct HKEYS: ValkeyCommand {
 public struct HLEN: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "HLEN" }
+
     public var key: ValkeyKey
 
     @inlinable public init(_ key: ValkeyKey) {
@@ -194,6 +210,8 @@ public struct HLEN: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct HMGET<Field: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = RESPToken.Array
+
+    @inlinable public static var name: String { "HMGET" }
 
     public var key: ValkeyKey
     public var fields: [Field]
@@ -235,6 +253,8 @@ public struct HMSET<Field: RESPStringRenderable, Value: RESPStringRenderable>: V
             RESPBulkString(value).encode(into: &commandEncoder)
         }
     }
+    @inlinable public static var name: String { "HMSET" }
+
     public var key: ValkeyKey
     public var data: [Data]
 
@@ -275,6 +295,8 @@ public struct HRANDFIELD: ValkeyCommand {
     }
     public typealias Response = RESPToken?
 
+    @inlinable public static var name: String { "HRANDFIELD" }
+
     public var key: ValkeyKey
     public var options: Options?
 
@@ -296,6 +318,8 @@ public struct HRANDFIELD: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct HSCAN: ValkeyCommand {
     public typealias Response = RESPToken.Array
+
+    @inlinable public static var name: String { "HSCAN" }
 
     public var key: ValkeyKey
     public var cursor: Int
@@ -352,6 +376,8 @@ public struct HSET<Field: RESPStringRenderable, Value: RESPStringRenderable>: Va
     }
     public typealias Response = Int
 
+    @inlinable public static var name: String { "HSET" }
+
     public var key: ValkeyKey
     public var data: [Data]
 
@@ -371,6 +397,8 @@ public struct HSET<Field: RESPStringRenderable, Value: RESPStringRenderable>: Va
 @_documentation(visibility: internal)
 public struct HSETNX<Field: RESPStringRenderable, Value: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "HSETNX" }
 
     public var key: ValkeyKey
     public var field: Field
@@ -394,6 +422,8 @@ public struct HSETNX<Field: RESPStringRenderable, Value: RESPStringRenderable>: 
 public struct HSTRLEN<Field: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "HSTRLEN" }
+
     public var key: ValkeyKey
     public var field: Field
 
@@ -415,6 +445,8 @@ public struct HSTRLEN<Field: RESPStringRenderable>: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct HVALS: ValkeyCommand {
     public typealias Response = RESPToken.Array
+
+    @inlinable public static var name: String { "HVALS" }
 
     public var key: ValkeyKey
 

--- a/Sources/Valkey/Commands/HyperloglogCommands.swift
+++ b/Sources/Valkey/Commands/HyperloglogCommands.swift
@@ -27,6 +27,8 @@ import Foundation
 public struct PFADD: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "PFADD" }
+
     public var key: ValkeyKey
     public var elements: [String]
 
@@ -47,6 +49,8 @@ public struct PFADD: ValkeyCommand {
 public struct PFCOUNT: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "PFCOUNT" }
+
     public var keys: [ValkeyKey]
 
     @inlinable public init(keys: [ValkeyKey]) {
@@ -65,6 +69,8 @@ public struct PFCOUNT: ValkeyCommand {
 /// Merges one or more HyperLogLog values into a single key.
 @_documentation(visibility: internal)
 public struct PFMERGE: ValkeyCommand {
+    @inlinable public static var name: String { "PFMERGE" }
+
     public var destkey: ValkeyKey
     public var sourcekeys: [ValkeyKey]
 

--- a/Sources/Valkey/Commands/ListCommands.swift
+++ b/Sources/Valkey/Commands/ListCommands.swift
@@ -57,6 +57,8 @@ public struct BLMOVE: ValkeyCommand {
     }
     public typealias Response = ByteBuffer?
 
+    @inlinable public static var name: String { "BLMOVE" }
+
     public var source: ValkeyKey
     public var destination: ValkeyKey
     public var wherefrom: Wherefrom
@@ -100,6 +102,8 @@ public struct BLMPOP: ValkeyCommand {
     }
     public typealias Response = RESPToken.Array?
 
+    @inlinable public static var name: String { "BLMPOP" }
+
     public var timeout: Double
     public var keys: [ValkeyKey]
     public var `where`: Where
@@ -126,6 +130,8 @@ public struct BLMPOP: ValkeyCommand {
 public struct BLPOP: ValkeyCommand {
     public typealias Response = RESPToken.Array?
 
+    @inlinable public static var name: String { "BLPOP" }
+
     public var keys: [ValkeyKey]
     public var timeout: Double
 
@@ -148,6 +154,8 @@ public struct BLPOP: ValkeyCommand {
 public struct BRPOP: ValkeyCommand {
     public typealias Response = RESPToken.Array?
 
+    @inlinable public static var name: String { "BRPOP" }
+
     public var keys: [ValkeyKey]
     public var timeout: Double
 
@@ -169,6 +177,8 @@ public struct BRPOP: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct BRPOPLPUSH: ValkeyCommand {
     public typealias Response = ByteBuffer?
+
+    @inlinable public static var name: String { "BRPOPLPUSH" }
 
     public var source: ValkeyKey
     public var destination: ValkeyKey
@@ -193,6 +203,8 @@ public struct BRPOPLPUSH: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct LINDEX: ValkeyCommand {
     public typealias Response = ByteBuffer?
+
+    @inlinable public static var name: String { "LINDEX" }
 
     public var key: ValkeyKey
     public var index: Int
@@ -231,6 +243,8 @@ public struct LINSERT<Pivot: RESPStringRenderable, Element: RESPStringRenderable
     }
     public typealias Response = Int
 
+    @inlinable public static var name: String { "LINSERT" }
+
     public var key: ValkeyKey
     public var `where`: Where
     public var pivot: Pivot
@@ -254,6 +268,8 @@ public struct LINSERT<Pivot: RESPStringRenderable, Element: RESPStringRenderable
 @_documentation(visibility: internal)
 public struct LLEN: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "LLEN" }
 
     public var key: ValkeyKey
 
@@ -305,6 +321,8 @@ public struct LMOVE: ValkeyCommand {
     }
     public typealias Response = ByteBuffer
 
+    @inlinable public static var name: String { "LMOVE" }
+
     public var source: ValkeyKey
     public var destination: ValkeyKey
     public var wherefrom: Wherefrom
@@ -342,6 +360,8 @@ public struct LMPOP: ValkeyCommand {
             }
         }
     }
+    @inlinable public static var name: String { "LMPOP" }
+
     public var keys: [ValkeyKey]
     public var `where`: Where
     public var count: Int?
@@ -364,6 +384,8 @@ public struct LMPOP: ValkeyCommand {
 public struct LPOP: ValkeyCommand {
     public typealias Response = RESPToken?
 
+    @inlinable public static var name: String { "LPOP" }
+
     public var key: ValkeyKey
     public var count: Int?
 
@@ -383,6 +405,8 @@ public struct LPOP: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct LPOS<Element: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = [Int]?
+
+    @inlinable public static var name: String { "LPOS" }
 
     public var key: ValkeyKey
     public var element: Element
@@ -419,6 +443,8 @@ public struct LPOS<Element: RESPStringRenderable>: ValkeyCommand {
 public struct LPUSH<Element: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "LPUSH" }
+
     public var key: ValkeyKey
     public var elements: [Element]
 
@@ -439,6 +465,8 @@ public struct LPUSH<Element: RESPStringRenderable>: ValkeyCommand {
 public struct LPUSHX<Element: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "LPUSHX" }
+
     public var key: ValkeyKey
     public var elements: [Element]
 
@@ -458,6 +486,8 @@ public struct LPUSHX<Element: RESPStringRenderable>: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct LRANGE: ValkeyCommand {
     public typealias Response = RESPToken.Array
+
+    @inlinable public static var name: String { "LRANGE" }
 
     public var key: ValkeyKey
     public var start: Int
@@ -483,6 +513,8 @@ public struct LRANGE: ValkeyCommand {
 public struct LREM<Element: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "LREM" }
+
     public var key: ValkeyKey
     public var count: Int
     public var element: Element
@@ -503,6 +535,8 @@ public struct LREM<Element: RESPStringRenderable>: ValkeyCommand {
 /// Sets the value of an element in a list by its index.
 @_documentation(visibility: internal)
 public struct LSET<Element: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "LSET" }
+
     public var key: ValkeyKey
     public var index: Int
     public var element: Element
@@ -523,6 +557,8 @@ public struct LSET<Element: RESPStringRenderable>: ValkeyCommand {
 /// Removes elements from both ends a list. Deletes the list if all elements were trimmed.
 @_documentation(visibility: internal)
 public struct LTRIM: ValkeyCommand {
+    @inlinable public static var name: String { "LTRIM" }
+
     public var key: ValkeyKey
     public var start: Int
     public var stop: Int
@@ -545,6 +581,8 @@ public struct LTRIM: ValkeyCommand {
 public struct RPOP: ValkeyCommand {
     public typealias Response = RESPToken?
 
+    @inlinable public static var name: String { "RPOP" }
+
     public var key: ValkeyKey
     public var count: Int?
 
@@ -564,6 +602,8 @@ public struct RPOP: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct RPOPLPUSH: ValkeyCommand {
     public typealias Response = ByteBuffer?
+
+    @inlinable public static var name: String { "RPOPLPUSH" }
 
     public var source: ValkeyKey
     public var destination: ValkeyKey
@@ -585,6 +625,8 @@ public struct RPOPLPUSH: ValkeyCommand {
 public struct RPUSH<Element: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "RPUSH" }
+
     public var key: ValkeyKey
     public var elements: [Element]
 
@@ -604,6 +646,8 @@ public struct RPUSH<Element: RESPStringRenderable>: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct RPUSHX<Element: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "RPUSHX" }
 
     public var key: ValkeyKey
     public var elements: [Element]

--- a/Sources/Valkey/Commands/PubsubCommands.swift
+++ b/Sources/Valkey/Commands/PubsubCommands.swift
@@ -30,6 +30,8 @@ public enum PUBSUB {
     public struct CHANNELS: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "PUBSUB CHANNELS" }
+
         public var pattern: String?
 
         @inlinable public init(pattern: String? = nil) {
@@ -46,6 +48,8 @@ public enum PUBSUB {
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "PUBSUB HELP" }
+
         @inlinable public init() {
         }
 
@@ -59,6 +63,8 @@ public enum PUBSUB {
     public struct NUMPAT: ValkeyCommand {
         public typealias Response = Int
 
+        @inlinable public static var name: String { "PUBSUB NUMPAT" }
+
         @inlinable public init() {
         }
 
@@ -71,6 +77,8 @@ public enum PUBSUB {
     @_documentation(visibility: internal)
     public struct NUMSUB: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "PUBSUB NUMSUB" }
 
         public var channels: [String]
 
@@ -88,6 +96,8 @@ public enum PUBSUB {
     public struct SHARDCHANNELS: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "PUBSUB SHARDCHANNELS" }
+
         public var pattern: String?
 
         @inlinable public init(pattern: String? = nil) {
@@ -103,6 +113,8 @@ public enum PUBSUB {
     @_documentation(visibility: internal)
     public struct SHARDNUMSUB: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "PUBSUB SHARDNUMSUB" }
 
         public var shardchannels: [String]
 
@@ -120,6 +132,8 @@ public enum PUBSUB {
 /// Listens for messages published to channels that match one or more patterns.
 @_documentation(visibility: internal)
 public struct PSUBSCRIBE: ValkeyCommand {
+    @inlinable public static var name: String { "PSUBSCRIBE" }
+
     public var patterns: [String]
 
     @inlinable public init(patterns: [String]) {
@@ -135,6 +149,8 @@ public struct PSUBSCRIBE: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct PUBLISH<Channel: RESPStringRenderable, Message: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "PUBLISH" }
 
     public var channel: Channel
     public var message: Message
@@ -152,6 +168,8 @@ public struct PUBLISH<Channel: RESPStringRenderable, Message: RESPStringRenderab
 /// Stops listening to messages published to channels that match one or more patterns.
 @_documentation(visibility: internal)
 public struct PUNSUBSCRIBE: ValkeyCommand {
+    @inlinable public static var name: String { "PUNSUBSCRIBE" }
+
     public var patterns: [String]
 
     @inlinable public init(patterns: [String] = []) {
@@ -167,6 +185,8 @@ public struct PUNSUBSCRIBE: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct SPUBLISH<Shardchannel: RESPStringRenderable, Message: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "SPUBLISH" }
 
     public var shardchannel: Shardchannel
     public var message: Message
@@ -184,6 +204,8 @@ public struct SPUBLISH<Shardchannel: RESPStringRenderable, Message: RESPStringRe
 /// Listens for messages published to shard channels.
 @_documentation(visibility: internal)
 public struct SSUBSCRIBE<Shardchannel: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "SSUBSCRIBE" }
+
     public var shardchannels: [Shardchannel]
 
     @inlinable public init(shardchannels: [Shardchannel]) {
@@ -198,6 +220,8 @@ public struct SSUBSCRIBE<Shardchannel: RESPStringRenderable>: ValkeyCommand {
 /// Listens for messages published to channels.
 @_documentation(visibility: internal)
 public struct SUBSCRIBE<Channel: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "SUBSCRIBE" }
+
     public var channels: [Channel]
 
     @inlinable public init(channels: [Channel]) {
@@ -212,6 +236,8 @@ public struct SUBSCRIBE<Channel: RESPStringRenderable>: ValkeyCommand {
 /// Stops listening to messages posted to shard channels.
 @_documentation(visibility: internal)
 public struct SUNSUBSCRIBE: ValkeyCommand {
+    @inlinable public static var name: String { "SUNSUBSCRIBE" }
+
     public var shardchannels: [String]
 
     @inlinable public init(shardchannels: [String] = []) {
@@ -226,6 +252,8 @@ public struct SUNSUBSCRIBE: ValkeyCommand {
 /// Stops listening to messages posted to channels.
 @_documentation(visibility: internal)
 public struct UNSUBSCRIBE: ValkeyCommand {
+    @inlinable public static var name: String { "UNSUBSCRIBE" }
+
     public var channels: [String]
 
     @inlinable public init(channels: [String] = []) {

--- a/Sources/Valkey/Commands/ScriptingCommands.swift
+++ b/Sources/Valkey/Commands/ScriptingCommands.swift
@@ -28,6 +28,8 @@ public enum FUNCTION {
     /// Deletes a library and its functions.
     @_documentation(visibility: internal)
     public struct DELETE<LibraryName: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "FUNCTION DELETE" }
+
         public var libraryName: LibraryName
 
         @inlinable public init(libraryName: LibraryName) {
@@ -43,6 +45,8 @@ public enum FUNCTION {
     @_documentation(visibility: internal)
     public struct DUMP: ValkeyCommand {
         public typealias Response = ByteBuffer
+
+        @inlinable public static var name: String { "FUNCTION DUMP" }
 
         @inlinable public init() {
         }
@@ -70,6 +74,8 @@ public enum FUNCTION {
                 }
             }
         }
+        @inlinable public static var name: String { "FUNCTION FLUSH" }
+
         public var flushType: FlushType?
 
         @inlinable public init(flushType: FlushType? = nil) {
@@ -86,6 +92,8 @@ public enum FUNCTION {
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "FUNCTION HELP" }
+
         @inlinable public init() {
         }
 
@@ -97,6 +105,8 @@ public enum FUNCTION {
     /// Terminates a function during execution.
     @_documentation(visibility: internal)
     public struct KILL: ValkeyCommand {
+        @inlinable public static var name: String { "FUNCTION KILL" }
+
         @inlinable public init() {
         }
 
@@ -109,6 +119,8 @@ public enum FUNCTION {
     @_documentation(visibility: internal)
     public struct LIST: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "FUNCTION LIST" }
 
         public var libraryNamePattern: String?
         public var withcode: Bool
@@ -127,6 +139,8 @@ public enum FUNCTION {
     @_documentation(visibility: internal)
     public struct LOAD<FunctionCode: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = ByteBuffer
+
+        @inlinable public static var name: String { "FUNCTION LOAD" }
 
         public var replace: Bool
         public var functionCode: FunctionCode
@@ -161,6 +175,8 @@ public enum FUNCTION {
                 }
             }
         }
+        @inlinable public static var name: String { "FUNCTION RESTORE" }
+
         public var serializedValue: SerializedValue
         public var policy: Policy?
 
@@ -178,6 +194,8 @@ public enum FUNCTION {
     @_documentation(visibility: internal)
     public struct STATS: ValkeyCommand {
         public typealias Response = RESPToken.Map
+
+        @inlinable public static var name: String { "FUNCTION STATS" }
 
         @inlinable public init() {
         }
@@ -212,6 +230,8 @@ public enum SCRIPT {
                 }
             }
         }
+        @inlinable public static var name: String { "SCRIPT DEBUG" }
+
         public var mode: Mode
 
         @inlinable public init(mode: Mode) {
@@ -227,6 +247,8 @@ public enum SCRIPT {
     @_documentation(visibility: internal)
     public struct EXISTS<Sha1: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "SCRIPT EXISTS" }
 
         public var sha1s: [Sha1]
 
@@ -257,6 +279,8 @@ public enum SCRIPT {
                 }
             }
         }
+        @inlinable public static var name: String { "SCRIPT FLUSH" }
+
         public var flushType: FlushType?
 
         @inlinable public init(flushType: FlushType? = nil) {
@@ -273,6 +297,8 @@ public enum SCRIPT {
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "SCRIPT HELP" }
+
         @inlinable public init() {
         }
 
@@ -284,6 +310,8 @@ public enum SCRIPT {
     /// Terminates a server-side Lua script during execution.
     @_documentation(visibility: internal)
     public struct KILL: ValkeyCommand {
+        @inlinable public static var name: String { "SCRIPT KILL" }
+
         @inlinable public init() {
         }
 
@@ -296,6 +324,8 @@ public enum SCRIPT {
     @_documentation(visibility: internal)
     public struct LOAD<Script: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = ByteBuffer
+
+        @inlinable public static var name: String { "SCRIPT LOAD" }
 
         public var script: Script
 
@@ -313,6 +343,8 @@ public enum SCRIPT {
     public struct SHOW<Sha1: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = ByteBuffer
 
+        @inlinable public static var name: String { "SCRIPT SHOW" }
+
         public var sha1: Sha1
 
         @inlinable public init(sha1: Sha1) {
@@ -329,6 +361,8 @@ public enum SCRIPT {
 /// Executes a server-side Lua script.
 @_documentation(visibility: internal)
 public struct EVAL<Script: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "EVAL" }
+
     public var script: Script
     public var keys: [ValkeyKey]
     public var args: [String]
@@ -349,6 +383,8 @@ public struct EVAL<Script: RESPStringRenderable>: ValkeyCommand {
 /// Executes a server-side Lua script by SHA1 digest.
 @_documentation(visibility: internal)
 public struct EVALSHA<Sha1: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "EVALSHA" }
+
     public var sha1: Sha1
     public var keys: [ValkeyKey]
     public var args: [String]
@@ -369,6 +405,8 @@ public struct EVALSHA<Sha1: RESPStringRenderable>: ValkeyCommand {
 /// Executes a read-only server-side Lua script by SHA1 digest.
 @_documentation(visibility: internal)
 public struct EVALSHARO<Sha1: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "EVALSHA_RO" }
+
     public var sha1: Sha1
     public var keys: [ValkeyKey]
     public var args: [String]
@@ -391,6 +429,8 @@ public struct EVALSHARO<Sha1: RESPStringRenderable>: ValkeyCommand {
 /// Executes a read-only server-side Lua script.
 @_documentation(visibility: internal)
 public struct EVALRO<Script: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "EVAL_RO" }
+
     public var script: Script
     public var keys: [ValkeyKey]
     public var args: [String]
@@ -413,6 +453,8 @@ public struct EVALRO<Script: RESPStringRenderable>: ValkeyCommand {
 /// Invokes a function.
 @_documentation(visibility: internal)
 public struct FCALL<Function: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "FCALL" }
+
     public var function: Function
     public var keys: [ValkeyKey]
     public var args: [String]
@@ -433,6 +475,8 @@ public struct FCALL<Function: RESPStringRenderable>: ValkeyCommand {
 /// Invokes a read-only function.
 @_documentation(visibility: internal)
 public struct FCALLRO<Function: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "FCALL_RO" }
+
     public var function: Function
     public var keys: [ValkeyKey]
     public var args: [String]

--- a/Sources/Valkey/Commands/SentinelCommands.swift
+++ b/Sources/Valkey/Commands/SentinelCommands.swift
@@ -30,6 +30,8 @@ public enum SENTINEL {
     public struct CKQUORUM<PrimaryName: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = ByteBuffer
 
+        @inlinable public static var name: String { "SENTINEL CKQUORUM" }
+
         public var primaryName: PrimaryName
 
         @inlinable public init(primaryName: PrimaryName) {
@@ -86,6 +88,8 @@ public enum SENTINEL {
         }
         public typealias Response = RESPToken.Map?
 
+        @inlinable public static var name: String { "SENTINEL CONFIG" }
+
         public var action: Action
 
         @inlinable public init(action: Action) {
@@ -122,6 +126,8 @@ public enum SENTINEL {
         }
         public typealias Response = RESPToken.Map?
 
+        @inlinable public static var name: String { "SENTINEL DEBUG" }
+
         public var data: [Data]
 
         @inlinable public init(data: [Data] = []) {
@@ -136,6 +142,8 @@ public enum SENTINEL {
     /// Forces a Sentinel failover.
     @_documentation(visibility: internal)
     public struct FAILOVER<PrimaryName: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "SENTINEL FAILOVER" }
+
         public var primaryName: PrimaryName
 
         @inlinable public init(primaryName: PrimaryName) {
@@ -150,6 +158,8 @@ public enum SENTINEL {
     /// Rewrites the Sentinel configuration file.
     @_documentation(visibility: internal)
     public struct FLUSHCONFIG: ValkeyCommand {
+        @inlinable public static var name: String { "SENTINEL FLUSHCONFIG" }
+
         @inlinable public init() {
         }
 
@@ -162,6 +172,8 @@ public enum SENTINEL {
     @_documentation(visibility: internal)
     public struct GETMASTERADDRBYNAME<PrimaryName: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "SENTINEL GET-MASTER-ADDR-BY-NAME" }
 
         public var primaryName: PrimaryName
 
@@ -179,6 +191,8 @@ public enum SENTINEL {
     public struct GETPRIMARYADDRBYNAME<PrimaryName: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "SENTINEL GET-PRIMARY-ADDR-BY-NAME" }
+
         public var primaryName: PrimaryName
 
         @inlinable public init(primaryName: PrimaryName) {
@@ -195,6 +209,8 @@ public enum SENTINEL {
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "SENTINEL HELP" }
+
         @inlinable public init() {
         }
 
@@ -207,6 +223,8 @@ public enum SENTINEL {
     @_documentation(visibility: internal)
     public struct INFOCACHE<Nodename: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "SENTINEL INFO-CACHE" }
 
         public var nodenames: [Nodename]
 
@@ -223,6 +241,8 @@ public enum SENTINEL {
     @_documentation(visibility: internal)
     public struct ISMASTERDOWNBYADDR<Ip: RESPStringRenderable, Runid: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "SENTINEL IS-MASTER-DOWN-BY-ADDR" }
 
         public var ip: Ip
         public var port: Int
@@ -246,6 +266,8 @@ public enum SENTINEL {
     public struct ISPRIMARYDOWNBYADDR<Ip: RESPStringRenderable, Runid: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "SENTINEL IS-PRIMARY-DOWN-BY-ADDR" }
+
         public var ip: Ip
         public var port: Int
         public var currentEpoch: Int
@@ -268,6 +290,8 @@ public enum SENTINEL {
     public struct MASTER<PrimaryName: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Map
 
+        @inlinable public static var name: String { "SENTINEL MASTER" }
+
         public var primaryName: PrimaryName
 
         @inlinable public init(primaryName: PrimaryName) {
@@ -284,6 +308,8 @@ public enum SENTINEL {
     public struct MASTERS: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "SENTINEL MASTERS" }
+
         @inlinable public init() {
         }
 
@@ -295,6 +321,8 @@ public enum SENTINEL {
     /// Starts monitoring.
     @_documentation(visibility: internal)
     public struct MONITOR<Name: RESPStringRenderable, Ip: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "SENTINEL MONITOR" }
+
         public var name: Name
         public var ip: Ip
         public var port: Int
@@ -317,6 +345,8 @@ public enum SENTINEL {
     public struct MYID: ValkeyCommand {
         public typealias Response = ByteBuffer
 
+        @inlinable public static var name: String { "SENTINEL MYID" }
+
         @inlinable public init() {
         }
 
@@ -329,6 +359,8 @@ public enum SENTINEL {
     @_documentation(visibility: internal)
     public struct PENDINGSCRIPTS: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "SENTINEL PENDING-SCRIPTS" }
 
         @inlinable public init() {
         }
@@ -343,6 +375,8 @@ public enum SENTINEL {
     public struct PRIMARIES: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "SENTINEL PRIMARIES" }
+
         @inlinable public init() {
         }
 
@@ -355,6 +389,8 @@ public enum SENTINEL {
     @_documentation(visibility: internal)
     public struct PRIMARY<PrimaryName: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Map
+
+        @inlinable public static var name: String { "SENTINEL PRIMARY" }
 
         public var primaryName: PrimaryName
 
@@ -370,6 +406,8 @@ public enum SENTINEL {
     /// Stops monitoring.
     @_documentation(visibility: internal)
     public struct REMOVE<PrimaryName: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "SENTINEL REMOVE" }
+
         public var primaryName: PrimaryName
 
         @inlinable public init(primaryName: PrimaryName) {
@@ -385,6 +423,8 @@ public enum SENTINEL {
     @_documentation(visibility: internal)
     public struct REPLICAS<PrimaryName: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "SENTINEL REPLICAS" }
 
         public var primaryName: PrimaryName
 
@@ -402,6 +442,8 @@ public enum SENTINEL {
     public struct RESET: ValkeyCommand {
         public typealias Response = Int
 
+        @inlinable public static var name: String { "SENTINEL RESET" }
+
         public var pattern: String
 
         @inlinable public init(pattern: String) {
@@ -417,6 +459,8 @@ public enum SENTINEL {
     @_documentation(visibility: internal)
     public struct SENTINELS<PrimaryName: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "SENTINEL SENTINELS" }
 
         public var primaryName: PrimaryName
 
@@ -452,6 +496,8 @@ public enum SENTINEL {
                 RESPBulkString(value).encode(into: &commandEncoder)
             }
         }
+        @inlinable public static var name: String { "SENTINEL SET" }
+
         public var primaryName: PrimaryName
         public var data: [Data]
 
@@ -487,6 +533,8 @@ public enum SENTINEL {
         }
         public typealias Response = RESPToken.Array?
 
+        @inlinable public static var name: String { "SENTINEL SIMULATE-FAILURE" }
+
         public var modes: [Mode]
 
         @inlinable public init(modes: [Mode] = []) {
@@ -502,6 +550,8 @@ public enum SENTINEL {
     @_documentation(visibility: internal)
     public struct SLAVES<PrimaryName: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "SENTINEL SLAVES" }
 
         public var primaryName: PrimaryName
 

--- a/Sources/Valkey/Commands/ServerCommands.swift
+++ b/Sources/Valkey/Commands/ServerCommands.swift
@@ -30,6 +30,8 @@ public enum ACL {
     public struct CAT: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "ACL CAT" }
+
         public var category: String?
 
         @inlinable public init(category: String? = nil) {
@@ -46,6 +48,8 @@ public enum ACL {
     public struct DELUSER<Username: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = Int
 
+        @inlinable public static var name: String { "ACL DELUSER" }
+
         public var usernames: [Username]
 
         @inlinable public init(usernames: [Username]) {
@@ -61,6 +65,8 @@ public enum ACL {
     @_documentation(visibility: internal)
     public struct DRYRUN<Username: RESPStringRenderable, Command: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = ByteBuffer?
+
+        @inlinable public static var name: String { "ACL DRYRUN" }
 
         public var username: Username
         public var command: Command
@@ -82,6 +88,8 @@ public enum ACL {
     public struct GENPASS: ValkeyCommand {
         public typealias Response = ByteBuffer
 
+        @inlinable public static var name: String { "ACL GENPASS" }
+
         public var bits: Int?
 
         @inlinable public init(bits: Int? = nil) {
@@ -97,6 +105,8 @@ public enum ACL {
     @_documentation(visibility: internal)
     public struct GETUSER<Username: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Map?
+
+        @inlinable public static var name: String { "ACL GETUSER" }
 
         public var username: Username
 
@@ -114,6 +124,8 @@ public enum ACL {
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "ACL HELP" }
+
         @inlinable public init() {
         }
 
@@ -127,6 +139,8 @@ public enum ACL {
     public struct LIST: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "ACL LIST" }
+
         @inlinable public init() {
         }
 
@@ -138,6 +152,8 @@ public enum ACL {
     /// Reloads the rules from the configured ACL file.
     @_documentation(visibility: internal)
     public struct LOAD: ValkeyCommand {
+        @inlinable public static var name: String { "ACL LOAD" }
+
         @inlinable public init() {
         }
 
@@ -171,6 +187,8 @@ public enum ACL {
         }
         public typealias Response = RESPToken.Array?
 
+        @inlinable public static var name: String { "ACL LOG" }
+
         public var operation: Operation?
 
         @inlinable public init(operation: Operation? = nil) {
@@ -185,6 +203,8 @@ public enum ACL {
     /// Saves the effective ACL rules in the configured ACL file.
     @_documentation(visibility: internal)
     public struct SAVE: ValkeyCommand {
+        @inlinable public static var name: String { "ACL SAVE" }
+
         @inlinable public init() {
         }
 
@@ -196,6 +216,8 @@ public enum ACL {
     /// Creates and modifies an ACL user and its rules.
     @_documentation(visibility: internal)
     public struct SETUSER<Username: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "ACL SETUSER" }
+
         public var username: Username
         public var rules: [String]
 
@@ -214,6 +236,8 @@ public enum ACL {
     public struct USERS: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "ACL USERS" }
+
         @inlinable public init() {
         }
 
@@ -226,6 +250,8 @@ public enum ACL {
     @_documentation(visibility: internal)
     public struct WHOAMI: ValkeyCommand {
         public typealias Response = ByteBuffer
+
+        @inlinable public static var name: String { "ACL WHOAMI" }
 
         @inlinable public init() {
         }
@@ -243,6 +269,8 @@ extension COMMAND {
     public struct COUNT: ValkeyCommand {
         public typealias Response = Int
 
+        @inlinable public static var name: String { "COMMAND COUNT" }
+
         @inlinable public init() {
         }
 
@@ -255,6 +283,8 @@ extension COMMAND {
     @_documentation(visibility: internal)
     public struct DOCS: ValkeyCommand {
         public typealias Response = RESPToken.Map
+
+        @inlinable public static var name: String { "COMMAND DOCS" }
 
         public var commandNames: [String]
 
@@ -271,6 +301,8 @@ extension COMMAND {
     @_documentation(visibility: internal)
     public struct GETKEYS<Command: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "COMMAND GETKEYS" }
 
         public var command: Command
         public var args: [String]
@@ -290,6 +322,8 @@ extension COMMAND {
     public struct GETKEYSANDFLAGS<Command: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "COMMAND GETKEYSANDFLAGS" }
+
         public var command: Command
         public var args: [String]
 
@@ -308,6 +342,8 @@ extension COMMAND {
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "COMMAND HELP" }
+
         @inlinable public init() {
         }
 
@@ -320,6 +356,8 @@ extension COMMAND {
     @_documentation(visibility: internal)
     public struct INFO: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "COMMAND INFO" }
 
         public var commandNames: [String]
 
@@ -359,6 +397,8 @@ extension COMMAND {
             }
         }
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "COMMAND LIST" }
 
         public var filterby: Filterby?
 
@@ -404,6 +444,8 @@ public enum COMMANDLOG {
         }
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "COMMANDLOG GET" }
+
         public var count: Int
         public var type: _Type
 
@@ -421,6 +463,8 @@ public enum COMMANDLOG {
     @_documentation(visibility: internal)
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "COMMANDLOG HELP" }
 
         @inlinable public init() {
         }
@@ -457,6 +501,8 @@ public enum COMMANDLOG {
             }
         }
         public typealias Response = Int
+
+        @inlinable public static var name: String { "COMMANDLOG LEN" }
 
         public var type: _Type
 
@@ -495,6 +541,8 @@ public enum COMMANDLOG {
                 }
             }
         }
+        @inlinable public static var name: String { "COMMANDLOG RESET" }
+
         public var type: _Type
 
         @inlinable public init(type: _Type) {
@@ -516,6 +564,8 @@ public enum CONFIG {
     public struct GET<Parameter: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Map
 
+        @inlinable public static var name: String { "CONFIG GET" }
+
         public var parameters: [Parameter]
 
         @inlinable public init(parameters: [Parameter]) {
@@ -532,6 +582,8 @@ public enum CONFIG {
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "CONFIG HELP" }
+
         @inlinable public init() {
         }
 
@@ -543,6 +595,8 @@ public enum CONFIG {
     /// Resets the server's statistics.
     @_documentation(visibility: internal)
     public struct RESETSTAT: ValkeyCommand {
+        @inlinable public static var name: String { "CONFIG RESETSTAT" }
+
         @inlinable public init() {
         }
 
@@ -554,6 +608,8 @@ public enum CONFIG {
     /// Persists the effective configuration to file.
     @_documentation(visibility: internal)
     public struct REWRITE: ValkeyCommand {
+        @inlinable public static var name: String { "CONFIG REWRITE" }
+
         @inlinable public init() {
         }
 
@@ -585,6 +641,8 @@ public enum CONFIG {
                 RESPBulkString(value).encode(into: &commandEncoder)
             }
         }
+        @inlinable public static var name: String { "CONFIG SET" }
+
         public var data: [Data]
 
         @inlinable public init(data: [Data]) {
@@ -606,6 +664,8 @@ public enum LATENCY {
     public struct DOCTOR: ValkeyCommand {
         public typealias Response = ByteBuffer
 
+        @inlinable public static var name: String { "LATENCY DOCTOR" }
+
         @inlinable public init() {
         }
 
@@ -618,6 +678,8 @@ public enum LATENCY {
     @_documentation(visibility: internal)
     public struct GRAPH<Event: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = ByteBuffer
+
+        @inlinable public static var name: String { "LATENCY GRAPH" }
 
         public var event: Event
 
@@ -635,6 +697,8 @@ public enum LATENCY {
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "LATENCY HELP" }
+
         @inlinable public init() {
         }
 
@@ -647,6 +711,8 @@ public enum LATENCY {
     @_documentation(visibility: internal)
     public struct HISTOGRAM: ValkeyCommand {
         public typealias Response = RESPToken.Map
+
+        @inlinable public static var name: String { "LATENCY HISTOGRAM" }
 
         public var commands: [String]
 
@@ -664,6 +730,8 @@ public enum LATENCY {
     public struct HISTORY<Event: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "LATENCY HISTORY" }
+
         public var event: Event
 
         @inlinable public init(event: Event) {
@@ -680,6 +748,8 @@ public enum LATENCY {
     public struct LATEST: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "LATENCY LATEST" }
+
         @inlinable public init() {
         }
 
@@ -692,6 +762,8 @@ public enum LATENCY {
     @_documentation(visibility: internal)
     public struct RESET: ValkeyCommand {
         public typealias Response = Int
+
+        @inlinable public static var name: String { "LATENCY RESET" }
 
         public var events: [String]
 
@@ -714,6 +786,8 @@ public enum MEMORY {
     public struct DOCTOR: ValkeyCommand {
         public typealias Response = ByteBuffer
 
+        @inlinable public static var name: String { "MEMORY DOCTOR" }
+
         @inlinable public init() {
         }
 
@@ -726,6 +800,8 @@ public enum MEMORY {
     @_documentation(visibility: internal)
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "MEMORY HELP" }
 
         @inlinable public init() {
         }
@@ -740,6 +816,8 @@ public enum MEMORY {
     public struct MALLOCSTATS: ValkeyCommand {
         public typealias Response = ByteBuffer
 
+        @inlinable public static var name: String { "MEMORY MALLOC-STATS" }
+
         @inlinable public init() {
         }
 
@@ -751,6 +829,8 @@ public enum MEMORY {
     /// Asks the allocator to release memory.
     @_documentation(visibility: internal)
     public struct PURGE: ValkeyCommand {
+        @inlinable public static var name: String { "MEMORY PURGE" }
+
         @inlinable public init() {
         }
 
@@ -764,6 +844,8 @@ public enum MEMORY {
     public struct STATS: ValkeyCommand {
         public typealias Response = RESPToken.Map
 
+        @inlinable public static var name: String { "MEMORY STATS" }
+
         @inlinable public init() {
         }
 
@@ -776,6 +858,8 @@ public enum MEMORY {
     @_documentation(visibility: internal)
     public struct USAGE: ValkeyCommand {
         public typealias Response = Int?
+
+        @inlinable public static var name: String { "MEMORY USAGE" }
 
         public var key: ValkeyKey
         public var count: Int?
@@ -804,6 +888,8 @@ public enum MODULE {
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "MODULE HELP" }
+
         @inlinable public init() {
         }
 
@@ -817,6 +903,8 @@ public enum MODULE {
     public struct LIST: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "MODULE LIST" }
+
         @inlinable public init() {
         }
 
@@ -828,6 +916,8 @@ public enum MODULE {
     /// Loads a module.
     @_documentation(visibility: internal)
     public struct LOAD<Path: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "MODULE LOAD" }
+
         public var path: Path
         public var args: [String]
 
@@ -864,6 +954,8 @@ public enum MODULE {
                 value.encode(into: &commandEncoder)
             }
         }
+        @inlinable public static var name: String { "MODULE LOADEX" }
+
         public var path: Path
         public var configs: [Configs]
         public var args: [String]
@@ -882,6 +974,8 @@ public enum MODULE {
     /// Unloads a module.
     @_documentation(visibility: internal)
     public struct UNLOAD<Name: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "MODULE UNLOAD" }
+
         public var name: Name
 
         @inlinable public init(name: Name) {
@@ -903,6 +997,8 @@ public enum SLOWLOG {
     public struct GET: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "SLOWLOG GET" }
+
         public var count: Int?
 
         @inlinable public init(count: Int? = nil) {
@@ -919,6 +1015,8 @@ public enum SLOWLOG {
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "SLOWLOG HELP" }
+
         @inlinable public init() {
         }
 
@@ -932,6 +1030,8 @@ public enum SLOWLOG {
     public struct LEN: ValkeyCommand {
         public typealias Response = Int
 
+        @inlinable public static var name: String { "SLOWLOG LEN" }
+
         @inlinable public init() {
         }
 
@@ -943,6 +1043,8 @@ public enum SLOWLOG {
     /// Clears all entries from the slow log.
     @_documentation(visibility: internal)
     public struct RESET: ValkeyCommand {
+        @inlinable public static var name: String { "SLOWLOG RESET" }
+
         @inlinable public init() {
         }
 
@@ -957,6 +1059,8 @@ public enum SLOWLOG {
 @_documentation(visibility: internal)
 public struct BGREWRITEAOF: ValkeyCommand {
     public typealias Response = ByteBuffer
+
+    @inlinable public static var name: String { "BGREWRITEAOF" }
 
     @inlinable public init() {
     }
@@ -986,6 +1090,8 @@ public struct BGSAVE: ValkeyCommand {
     }
     public typealias Response = String
 
+    @inlinable public static var name: String { "BGSAVE" }
+
     public var operation: Operation?
 
     @inlinable public init(operation: Operation? = nil) {
@@ -1000,6 +1106,8 @@ public struct BGSAVE: ValkeyCommand {
 /// Returns detailed information about all commands.
 @_documentation(visibility: internal)
 public struct COMMAND: ValkeyCommand {
+    @inlinable public static var name: String { "COMMAND" }
+
     @inlinable public init() {
     }
 
@@ -1012,6 +1120,8 @@ public struct COMMAND: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct DBSIZE: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "DBSIZE" }
 
     @inlinable public init() {
     }
@@ -1049,6 +1159,8 @@ public struct FAILOVER: ValkeyCommand {
             RESPPureToken("FORCE", force).encode(into: &commandEncoder)
         }
     }
+    @inlinable public static var name: String { "FAILOVER" }
+
     public var target: Target?
     public var abort: Bool
     public var milliseconds: Int?
@@ -1082,6 +1194,8 @@ public struct FLUSHALL: ValkeyCommand {
             }
         }
     }
+    @inlinable public static var name: String { "FLUSHALL" }
+
     public var flushType: FlushType?
 
     @inlinable public init(flushType: FlushType? = nil) {
@@ -1111,6 +1225,8 @@ public struct FLUSHDB: ValkeyCommand {
             }
         }
     }
+    @inlinable public static var name: String { "FLUSHDB" }
+
     public var flushType: FlushType?
 
     @inlinable public init(flushType: FlushType? = nil) {
@@ -1126,6 +1242,8 @@ public struct FLUSHDB: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct INFO: ValkeyCommand {
     public typealias Response = ByteBuffer
+
+    @inlinable public static var name: String { "INFO" }
 
     public var sections: [String]
 
@@ -1143,6 +1261,8 @@ public struct INFO: ValkeyCommand {
 public struct LASTSAVE: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "LASTSAVE" }
+
     @inlinable public init() {
     }
 
@@ -1155,6 +1275,8 @@ public struct LASTSAVE: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct LOLWUT: ValkeyCommand {
     public typealias Response = ByteBuffer
+
+    @inlinable public static var name: String { "LOLWUT" }
 
     public var version: Int?
 
@@ -1172,6 +1294,8 @@ public struct LOLWUT: ValkeyCommand {
 /// Listens for all requests received by the server in real-time.
 @_documentation(visibility: internal)
 public struct MONITOR: ValkeyCommand {
+    @inlinable public static var name: String { "MONITOR" }
+
     @inlinable public init() {
     }
 
@@ -1183,6 +1307,8 @@ public struct MONITOR: ValkeyCommand {
 /// An internal command used in replication.
 @_documentation(visibility: internal)
 public struct PSYNC<Replicationid: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "PSYNC" }
+
     public var replicationid: Replicationid
     public var offset: Int
 
@@ -1257,6 +1383,8 @@ public struct REPLICAOF: ValkeyCommand {
     }
     public typealias Response = ByteBuffer
 
+    @inlinable public static var name: String { "REPLICAOF" }
+
     public var args: Args
 
     @inlinable public init(args: Args) {
@@ -1271,6 +1399,8 @@ public struct REPLICAOF: ValkeyCommand {
 /// Returns the replication role.
 @_documentation(visibility: internal)
 public struct ROLE: ValkeyCommand {
+    @inlinable public static var name: String { "ROLE" }
+
     @inlinable public init() {
     }
 
@@ -1282,6 +1412,8 @@ public struct ROLE: ValkeyCommand {
 /// Synchronously saves the database(s) to disk.
 @_documentation(visibility: internal)
 public struct SAVE: ValkeyCommand {
+    @inlinable public static var name: String { "SAVE" }
+
     @inlinable public init() {
     }
 
@@ -1351,6 +1483,8 @@ public struct SHUTDOWN: ValkeyCommand {
             }
         }
     }
+    @inlinable public static var name: String { "SHUTDOWN" }
+
     public var abortSelector: AbortSelector?
 
     @inlinable public init(abortSelector: AbortSelector? = nil) {
@@ -1423,6 +1557,8 @@ public struct SLAVEOF: ValkeyCommand {
     }
     public typealias Response = ByteBuffer
 
+    @inlinable public static var name: String { "SLAVEOF" }
+
     public var args: Args
 
     @inlinable public init(args: Args) {
@@ -1437,6 +1573,8 @@ public struct SLAVEOF: ValkeyCommand {
 /// Swaps two databases.
 @_documentation(visibility: internal)
 public struct SWAPDB: ValkeyCommand {
+    @inlinable public static var name: String { "SWAPDB" }
+
     public var index1: Int
     public var index2: Int
 
@@ -1453,6 +1591,8 @@ public struct SWAPDB: ValkeyCommand {
 /// An internal command used in replication.
 @_documentation(visibility: internal)
 public struct SYNC: ValkeyCommand {
+    @inlinable public static var name: String { "SYNC" }
+
     @inlinable public init() {
     }
 
@@ -1465,6 +1605,8 @@ public struct SYNC: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct TIME: ValkeyCommand {
     public typealias Response = RESPToken.Array
+
+    @inlinable public static var name: String { "TIME" }
 
     @inlinable public init() {
     }

--- a/Sources/Valkey/Commands/SetCommands.swift
+++ b/Sources/Valkey/Commands/SetCommands.swift
@@ -27,6 +27,8 @@ import Foundation
 public struct SADD<Member: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "SADD" }
+
     public var key: ValkeyKey
     public var members: [Member]
 
@@ -46,6 +48,8 @@ public struct SADD<Member: RESPStringRenderable>: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct SCARD: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "SCARD" }
 
     public var key: ValkeyKey
 
@@ -67,6 +71,8 @@ public struct SCARD: ValkeyCommand {
 public struct SDIFF: ValkeyCommand {
     public typealias Response = RESPToken.Array
 
+    @inlinable public static var name: String { "SDIFF" }
+
     public var keys: [ValkeyKey]
 
     @inlinable public init(keys: [ValkeyKey]) {
@@ -86,6 +92,8 @@ public struct SDIFF: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct SDIFFSTORE: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "SDIFFSTORE" }
 
     public var destination: ValkeyKey
     public var keys: [ValkeyKey]
@@ -107,6 +115,8 @@ public struct SDIFFSTORE: ValkeyCommand {
 public struct SINTER: ValkeyCommand {
     public typealias Response = RESPToken.Array
 
+    @inlinable public static var name: String { "SINTER" }
+
     public var keys: [ValkeyKey]
 
     @inlinable public init(keys: [ValkeyKey]) {
@@ -126,6 +136,8 @@ public struct SINTER: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct SINTERCARD: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "SINTERCARD" }
 
     public var keys: [ValkeyKey]
     public var limit: Int?
@@ -149,6 +161,8 @@ public struct SINTERCARD: ValkeyCommand {
 public struct SINTERSTORE: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "SINTERSTORE" }
+
     public var destination: ValkeyKey
     public var keys: [ValkeyKey]
 
@@ -168,6 +182,8 @@ public struct SINTERSTORE: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct SISMEMBER<Member: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "SISMEMBER" }
 
     public var key: ValkeyKey
     public var member: Member
@@ -191,6 +207,8 @@ public struct SISMEMBER<Member: RESPStringRenderable>: ValkeyCommand {
 public struct SMEMBERS: ValkeyCommand {
     public typealias Response = RESPToken.Array
 
+    @inlinable public static var name: String { "SMEMBERS" }
+
     public var key: ValkeyKey
 
     @inlinable public init(_ key: ValkeyKey) {
@@ -210,6 +228,8 @@ public struct SMEMBERS: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct SMISMEMBER<Member: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = RESPToken.Array
+
+    @inlinable public static var name: String { "SMISMEMBER" }
 
     public var key: ValkeyKey
     public var members: [Member]
@@ -233,6 +253,8 @@ public struct SMISMEMBER<Member: RESPStringRenderable>: ValkeyCommand {
 public struct SMOVE<Member: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "SMOVE" }
+
     public var source: ValkeyKey
     public var destination: ValkeyKey
     public var member: Member
@@ -253,6 +275,8 @@ public struct SMOVE<Member: RESPStringRenderable>: ValkeyCommand {
 /// Returns one or more random members from a set after removing them. Deletes the set if the last member was popped.
 @_documentation(visibility: internal)
 public struct SPOP: ValkeyCommand {
+    @inlinable public static var name: String { "SPOP" }
+
     public var key: ValkeyKey
     public var count: Int?
 
@@ -272,6 +296,8 @@ public struct SPOP: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct SRANDMEMBER: ValkeyCommand {
     public typealias Response = RESPToken?
+
+    @inlinable public static var name: String { "SRANDMEMBER" }
 
     public var key: ValkeyKey
     public var count: Int?
@@ -295,6 +321,8 @@ public struct SRANDMEMBER: ValkeyCommand {
 public struct SREM<Member: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "SREM" }
+
     public var key: ValkeyKey
     public var members: [Member]
 
@@ -313,6 +341,8 @@ public struct SREM<Member: RESPStringRenderable>: ValkeyCommand {
 /// Iterates over members of a set.
 @_documentation(visibility: internal)
 public struct SSCAN: ValkeyCommand {
+    @inlinable public static var name: String { "SSCAN" }
+
     public var key: ValkeyKey
     public var cursor: Int
     public var pattern: String?
@@ -339,6 +369,8 @@ public struct SSCAN: ValkeyCommand {
 public struct SUNION: ValkeyCommand {
     public typealias Response = RESPToken.Array
 
+    @inlinable public static var name: String { "SUNION" }
+
     public var keys: [ValkeyKey]
 
     @inlinable public init(keys: [ValkeyKey]) {
@@ -358,6 +390,8 @@ public struct SUNION: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct SUNIONSTORE: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "SUNIONSTORE" }
 
     public var destination: ValkeyKey
     public var keys: [ValkeyKey]

--- a/Sources/Valkey/Commands/SortedSetCommands.swift
+++ b/Sources/Valkey/Commands/SortedSetCommands.swift
@@ -40,6 +40,8 @@ public struct BZMPOP: ValkeyCommand {
             }
         }
     }
+    @inlinable public static var name: String { "BZMPOP" }
+
     public var timeout: Double
     public var keys: [ValkeyKey]
     public var `where`: Where
@@ -64,6 +66,8 @@ public struct BZMPOP: ValkeyCommand {
 /// Removes and returns the member with the highest score from one or more sorted sets. Blocks until a member available otherwise.  Deletes the sorted set if the last element was popped.
 @_documentation(visibility: internal)
 public struct BZPOPMAX: ValkeyCommand {
+    @inlinable public static var name: String { "BZPOPMAX" }
+
     public var keys: [ValkeyKey]
     public var timeout: Double
 
@@ -84,6 +88,8 @@ public struct BZPOPMAX: ValkeyCommand {
 /// Removes and returns the member with the lowest score from one or more sorted sets. Blocks until a member is available otherwise. Deletes the sorted set if the last element was popped.
 @_documentation(visibility: internal)
 public struct BZPOPMIN: ValkeyCommand {
+    @inlinable public static var name: String { "BZPOPMIN" }
+
     public var keys: [ValkeyKey]
     public var timeout: Double
 
@@ -156,6 +162,8 @@ public struct ZADD<Member: RESPStringRenderable>: ValkeyCommand {
     }
     public typealias Response = RESPToken?
 
+    @inlinable public static var name: String { "ZADD" }
+
     public var key: ValkeyKey
     public var condition: Condition?
     public var comparison: Comparison?
@@ -191,6 +199,8 @@ public struct ZADD<Member: RESPStringRenderable>: ValkeyCommand {
 public struct ZCARD: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "ZCARD" }
+
     public var key: ValkeyKey
 
     @inlinable public init(_ key: ValkeyKey) {
@@ -210,6 +220,8 @@ public struct ZCARD: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct ZCOUNT: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "ZCOUNT" }
 
     public var key: ValkeyKey
     public var min: Double
@@ -235,6 +247,8 @@ public struct ZCOUNT: ValkeyCommand {
 public struct ZDIFF: ValkeyCommand {
     public typealias Response = RESPToken.Array
 
+    @inlinable public static var name: String { "ZDIFF" }
+
     public var keys: [ValkeyKey]
     public var withscores: Bool
 
@@ -257,6 +271,8 @@ public struct ZDIFF: ValkeyCommand {
 public struct ZDIFFSTORE: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "ZDIFFSTORE" }
+
     public var destination: ValkeyKey
     public var keys: [ValkeyKey]
 
@@ -276,6 +292,8 @@ public struct ZDIFFSTORE: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct ZINCRBY<Member: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Double
+
+    @inlinable public static var name: String { "ZINCRBY" }
 
     public var key: ValkeyKey
     public var increment: Int
@@ -316,6 +334,8 @@ public struct ZINTER: ValkeyCommand {
     }
     public typealias Response = RESPToken.Array
 
+    @inlinable public static var name: String { "ZINTER" }
+
     public var keys: [ValkeyKey]
     public var weights: [Int]
     public var aggregate: Aggregate?
@@ -347,6 +367,8 @@ public struct ZINTER: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct ZINTERCARD: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "ZINTERCARD" }
 
     public var keys: [ValkeyKey]
     public var limit: Int?
@@ -387,6 +409,8 @@ public struct ZINTERSTORE: ValkeyCommand {
     }
     public typealias Response = Int
 
+    @inlinable public static var name: String { "ZINTERSTORE" }
+
     public var destination: ValkeyKey
     public var keys: [ValkeyKey]
     public var weights: [Int]
@@ -416,6 +440,8 @@ public struct ZINTERSTORE: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct ZLEXCOUNT<Min: RESPStringRenderable, Max: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "ZLEXCOUNT" }
 
     public var key: ValkeyKey
     public var min: Min
@@ -454,6 +480,8 @@ public struct ZMPOP: ValkeyCommand {
             }
         }
     }
+    @inlinable public static var name: String { "ZMPOP" }
+
     public var keys: [ValkeyKey]
     public var `where`: Where
     public var count: Int?
@@ -476,6 +504,8 @@ public struct ZMPOP: ValkeyCommand {
 public struct ZMSCORE<Member: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = RESPToken.Array
 
+    @inlinable public static var name: String { "ZMSCORE" }
+
     public var key: ValkeyKey
     public var members: [Member]
 
@@ -496,6 +526,8 @@ public struct ZMSCORE<Member: RESPStringRenderable>: ValkeyCommand {
 /// Returns the highest-scoring members from a sorted set after removing them. Deletes the sorted set if the last member was popped.
 @_documentation(visibility: internal)
 public struct ZPOPMAX: ValkeyCommand {
+    @inlinable public static var name: String { "ZPOPMAX" }
+
     public var key: ValkeyKey
     public var count: Int?
 
@@ -514,6 +546,8 @@ public struct ZPOPMAX: ValkeyCommand {
 /// Returns the lowest-scoring members from a sorted set after removing them. Deletes the sorted set if the last member was popped.
 @_documentation(visibility: internal)
 public struct ZPOPMIN: ValkeyCommand {
+    @inlinable public static var name: String { "ZPOPMIN" }
+
     public var key: ValkeyKey
     public var count: Int?
 
@@ -553,6 +587,8 @@ public struct ZRANDMEMBER: ValkeyCommand {
         }
     }
     public typealias Response = RESPToken?
+
+    @inlinable public static var name: String { "ZRANDMEMBER" }
 
     public var key: ValkeyKey
     public var options: Options?
@@ -610,6 +646,8 @@ public struct ZRANGE<Start: RESPStringRenderable, Stop: RESPStringRenderable>: V
         }
     }
     public typealias Response = RESPToken.Array
+
+    @inlinable public static var name: String { "ZRANGE" }
 
     public var key: ValkeyKey
     public var start: Start
@@ -680,6 +718,8 @@ public struct ZRANGEBYLEX<Min: RESPStringRenderable, Max: RESPStringRenderable>:
     }
     public typealias Response = RESPToken.Array
 
+    @inlinable public static var name: String { "ZRANGEBYLEX" }
+
     public var key: ValkeyKey
     public var min: Min
     public var max: Max
@@ -725,6 +765,8 @@ public struct ZRANGEBYSCORE: ValkeyCommand {
         }
     }
     public typealias Response = RESPToken.Array
+
+    @inlinable public static var name: String { "ZRANGEBYSCORE" }
 
     public var key: ValkeyKey
     public var min: Double
@@ -789,6 +831,8 @@ public struct ZRANGESTORE<Min: RESPStringRenderable, Max: RESPStringRenderable>:
     }
     public typealias Response = Int
 
+    @inlinable public static var name: String { "ZRANGESTORE" }
+
     public var dst: ValkeyKey
     public var src: ValkeyKey
     public var min: Min
@@ -828,6 +872,8 @@ public struct ZRANGESTORE<Min: RESPStringRenderable, Max: RESPStringRenderable>:
 public struct ZRANK<Member: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = RESPToken?
 
+    @inlinable public static var name: String { "ZRANK" }
+
     public var key: ValkeyKey
     public var member: Member
     public var withscore: Bool
@@ -852,6 +898,8 @@ public struct ZRANK<Member: RESPStringRenderable>: ValkeyCommand {
 public struct ZREM<Member: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "ZREM" }
+
     public var key: ValkeyKey
     public var members: [Member]
 
@@ -871,6 +919,8 @@ public struct ZREM<Member: RESPStringRenderable>: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct ZREMRANGEBYLEX<Min: RESPStringRenderable, Max: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "ZREMRANGEBYLEX" }
 
     public var key: ValkeyKey
     public var min: Min
@@ -894,6 +944,8 @@ public struct ZREMRANGEBYLEX<Min: RESPStringRenderable, Max: RESPStringRenderabl
 public struct ZREMRANGEBYRANK: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "ZREMRANGEBYRANK" }
+
     public var key: ValkeyKey
     public var start: Int
     public var stop: Int
@@ -916,6 +968,8 @@ public struct ZREMRANGEBYRANK: ValkeyCommand {
 public struct ZREMRANGEBYSCORE: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "ZREMRANGEBYSCORE" }
+
     public var key: ValkeyKey
     public var min: Double
     public var max: Double
@@ -937,6 +991,8 @@ public struct ZREMRANGEBYSCORE: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct ZREVRANGE: ValkeyCommand {
     public typealias Response = RESPToken.Array
+
+    @inlinable public static var name: String { "ZREVRANGE" }
 
     public var key: ValkeyKey
     public var start: Int
@@ -984,6 +1040,8 @@ public struct ZREVRANGEBYLEX<Max: RESPStringRenderable, Min: RESPStringRenderabl
     }
     public typealias Response = RESPToken.Array
 
+    @inlinable public static var name: String { "ZREVRANGEBYLEX" }
+
     public var key: ValkeyKey
     public var max: Max
     public var min: Min
@@ -1030,6 +1088,8 @@ public struct ZREVRANGEBYSCORE: ValkeyCommand {
     }
     public typealias Response = RESPToken.Array
 
+    @inlinable public static var name: String { "ZREVRANGEBYSCORE" }
+
     public var key: ValkeyKey
     public var max: Double
     public var min: Double
@@ -1058,6 +1118,8 @@ public struct ZREVRANGEBYSCORE: ValkeyCommand {
 public struct ZREVRANK<Member: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = RESPToken?
 
+    @inlinable public static var name: String { "ZREVRANK" }
+
     public var key: ValkeyKey
     public var member: Member
     public var withscore: Bool
@@ -1081,6 +1143,8 @@ public struct ZREVRANK<Member: RESPStringRenderable>: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct ZSCAN: ValkeyCommand {
     public typealias Response = RESPToken.Array
+
+    @inlinable public static var name: String { "ZSCAN" }
 
     public var key: ValkeyKey
     public var cursor: Int
@@ -1116,6 +1180,8 @@ public struct ZSCAN: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct ZSCORE<Member: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Double?
+
+    @inlinable public static var name: String { "ZSCORE" }
 
     public var key: ValkeyKey
     public var member: Member
@@ -1155,6 +1221,8 @@ public struct ZUNION: ValkeyCommand {
         }
     }
     public typealias Response = RESPToken.Array
+
+    @inlinable public static var name: String { "ZUNION" }
 
     public var keys: [ValkeyKey]
     public var weights: [Int]
@@ -1204,6 +1272,8 @@ public struct ZUNIONSTORE: ValkeyCommand {
         }
     }
     public typealias Response = Int
+
+    @inlinable public static var name: String { "ZUNIONSTORE" }
 
     public var destination: ValkeyKey
     public var keys: [ValkeyKey]

--- a/Sources/Valkey/Commands/StreamCommands.swift
+++ b/Sources/Valkey/Commands/StreamCommands.swift
@@ -48,6 +48,8 @@ public enum XGROUP {
                 }
             }
         }
+        @inlinable public static var name: String { "XGROUP CREATE" }
+
         public var key: ValkeyKey
         public var group: Group
         public var idSelector: IdSelector
@@ -82,6 +84,8 @@ public enum XGROUP {
     public struct CREATECONSUMER<Group: RESPStringRenderable, Consumer: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = Int
 
+        @inlinable public static var name: String { "XGROUP CREATECONSUMER" }
+
         public var key: ValkeyKey
         public var group: Group
         public var consumer: Consumer
@@ -103,6 +107,8 @@ public enum XGROUP {
     @_documentation(visibility: internal)
     public struct DELCONSUMER<Group: RESPStringRenderable, Consumer: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = Int
+
+        @inlinable public static var name: String { "XGROUP DELCONSUMER" }
 
         public var key: ValkeyKey
         public var group: Group
@@ -126,6 +132,8 @@ public enum XGROUP {
     public struct DESTROY<Group: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = Int
 
+        @inlinable public static var name: String { "XGROUP DESTROY" }
+
         public var key: ValkeyKey
         public var group: Group
 
@@ -145,6 +153,8 @@ public enum XGROUP {
     @_documentation(visibility: internal)
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "XGROUP HELP" }
 
         @inlinable public init() {
         }
@@ -177,6 +187,8 @@ public enum XGROUP {
                 }
             }
         }
+        @inlinable public static var name: String { "XGROUP SETID" }
+
         public var key: ValkeyKey
         public var group: Group
         public var idSelector: IdSelector
@@ -206,6 +218,8 @@ public enum XINFO {
     public struct CONSUMERS<Group: RESPStringRenderable>: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "XINFO CONSUMERS" }
+
         public var key: ValkeyKey
         public var group: Group
 
@@ -228,6 +242,8 @@ public enum XINFO {
     public struct GROUPS: ValkeyCommand {
         public typealias Response = RESPToken.Array
 
+        @inlinable public static var name: String { "XINFO GROUPS" }
+
         public var key: ValkeyKey
 
         @inlinable public init(_ key: ValkeyKey) {
@@ -247,6 +263,8 @@ public enum XINFO {
     @_documentation(visibility: internal)
     public struct HELP: ValkeyCommand {
         public typealias Response = RESPToken.Array
+
+        @inlinable public static var name: String { "XINFO HELP" }
 
         @inlinable public init() {
         }
@@ -279,6 +297,8 @@ public enum XINFO {
         }
         public typealias Response = RESPToken.Map
 
+        @inlinable public static var name: String { "XINFO STREAM" }
+
         public var key: ValkeyKey
         public var fullBlock: FullBlock?
 
@@ -302,6 +322,8 @@ public enum XINFO {
 @_documentation(visibility: internal)
 public struct XACK<Group: RESPStringRenderable, Id: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "XACK" }
 
     public var key: ValkeyKey
     public var group: Group
@@ -421,6 +443,8 @@ public struct XADD<Field: RESPStringRenderable, Value: RESPStringRenderable>: Va
     }
     public typealias Response = ByteBuffer?
 
+    @inlinable public static var name: String { "XADD" }
+
     public var key: ValkeyKey
     public var nomkstream: Bool
     public var trim: Trim?
@@ -447,6 +471,8 @@ public struct XADD<Field: RESPStringRenderable, Value: RESPStringRenderable>: Va
 public struct XAUTOCLAIM<Group: RESPStringRenderable, Consumer: RESPStringRenderable, MinIdleTime: RESPStringRenderable, Start: RESPStringRenderable>:
     ValkeyCommand
 {
+    @inlinable public static var name: String { "XAUTOCLAIM" }
+
     public var key: ValkeyKey
     public var group: Group
     public var consumer: Consumer
@@ -494,6 +520,8 @@ public struct XAUTOCLAIM<Group: RESPStringRenderable, Consumer: RESPStringRender
 public struct XCLAIM<Group: RESPStringRenderable, Consumer: RESPStringRenderable, MinIdleTime: RESPStringRenderable, Id: RESPStringRenderable>:
     ValkeyCommand
 {
+    @inlinable public static var name: String { "XCLAIM" }
+
     public var key: ValkeyKey
     public var group: Group
     public var consumer: Consumer
@@ -557,6 +585,8 @@ public struct XCLAIM<Group: RESPStringRenderable, Consumer: RESPStringRenderable
 public struct XDEL<Id: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "XDEL" }
+
     public var key: ValkeyKey
     public var ids: [Id]
 
@@ -576,6 +606,8 @@ public struct XDEL<Id: RESPStringRenderable>: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct XLEN: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "XLEN" }
 
     public var key: ValkeyKey
 
@@ -624,6 +656,8 @@ public struct XPENDING<Group: RESPStringRenderable>: ValkeyCommand {
             consumer.encode(into: &commandEncoder)
         }
     }
+    @inlinable public static var name: String { "XPENDING" }
+
     public var key: ValkeyKey
     public var group: Group
     public var filters: Filters?
@@ -646,6 +680,8 @@ public struct XPENDING<Group: RESPStringRenderable>: ValkeyCommand {
 /// Returns the messages from a stream within a range of IDs.
 @_documentation(visibility: internal)
 public struct XRANGE<Start: RESPStringRenderable, End: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "XRANGE" }
+
     public var key: ValkeyKey
     public var start: Start
     public var end: End
@@ -690,6 +726,8 @@ public struct XREAD<Id: RESPStringRenderable>: ValkeyCommand {
             ids.map { RESPBulkString($0) }.encode(into: &commandEncoder)
         }
     }
+    @inlinable public static var name: String { "XREAD" }
+
     public var count: Int?
     public var milliseconds: Int?
     public var streams: Streams
@@ -754,6 +792,8 @@ public struct XREADGROUP<Group: RESPStringRenderable, Consumer: RESPStringRender
             ids.map { RESPBulkString($0) }.encode(into: &commandEncoder)
         }
     }
+    @inlinable public static var name: String { "XREADGROUP" }
+
     public var groupBlock: GroupBlock
     public var count: Int?
     public var milliseconds: Int?
@@ -787,6 +827,8 @@ public struct XREADGROUP<Group: RESPStringRenderable, Consumer: RESPStringRender
 /// Returns the messages from a stream within a range of IDs in reverse order.
 @_documentation(visibility: internal)
 public struct XREVRANGE<End: RESPStringRenderable, Start: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "XREVRANGE" }
+
     public var key: ValkeyKey
     public var end: End
     public var start: Start
@@ -811,6 +853,8 @@ public struct XREVRANGE<End: RESPStringRenderable, Start: RESPStringRenderable>:
 /// An internal command for replicating stream values.
 @_documentation(visibility: internal)
 public struct XSETID<LastId: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "XSETID" }
+
     public var key: ValkeyKey
     public var lastId: LastId
     public var entriesAdded: Int?
@@ -896,6 +940,8 @@ public struct XTRIM<Threshold: RESPStringRenderable>: ValkeyCommand {
         }
     }
     public typealias Response = Int
+
+    @inlinable public static var name: String { "XTRIM" }
 
     public var key: ValkeyKey
     public var trim: Trim

--- a/Sources/Valkey/Commands/StringCommands.swift
+++ b/Sources/Valkey/Commands/StringCommands.swift
@@ -27,6 +27,8 @@ import Foundation
 public struct APPEND<Value: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "APPEND" }
+
     public var key: ValkeyKey
     public var value: Value
 
@@ -47,6 +49,8 @@ public struct APPEND<Value: RESPStringRenderable>: ValkeyCommand {
 public struct DECR: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "DECR" }
+
     public var key: ValkeyKey
 
     @inlinable public init(_ key: ValkeyKey) {
@@ -64,6 +68,8 @@ public struct DECR: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct DECRBY: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "DECRBY" }
 
     public var key: ValkeyKey
     public var decrement: Int
@@ -85,6 +91,8 @@ public struct DECRBY: ValkeyCommand {
 public struct GET: ValkeyCommand {
     public typealias Response = ByteBuffer?
 
+    @inlinable public static var name: String { "GET" }
+
     public var key: ValkeyKey
 
     @inlinable public init(_ key: ValkeyKey) {
@@ -104,6 +112,8 @@ public struct GET: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct GETDEL: ValkeyCommand {
     public typealias Response = ByteBuffer?
+
+    @inlinable public static var name: String { "GETDEL" }
 
     public var key: ValkeyKey
 
@@ -155,6 +165,8 @@ public struct GETEX: ValkeyCommand {
     }
     public typealias Response = ByteBuffer?
 
+    @inlinable public static var name: String { "GETEX" }
+
     public var key: ValkeyKey
     public var expiration: Expiration?
 
@@ -174,6 +186,8 @@ public struct GETEX: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct GETRANGE: ValkeyCommand {
     public typealias Response = ByteBuffer
+
+    @inlinable public static var name: String { "GETRANGE" }
 
     public var key: ValkeyKey
     public var start: Int
@@ -199,6 +213,8 @@ public struct GETRANGE: ValkeyCommand {
 public struct GETSET<Value: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = ByteBuffer?
 
+    @inlinable public static var name: String { "GETSET" }
+
     public var key: ValkeyKey
     public var value: Value
 
@@ -219,6 +235,8 @@ public struct GETSET<Value: RESPStringRenderable>: ValkeyCommand {
 public struct INCR: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "INCR" }
+
     public var key: ValkeyKey
 
     @inlinable public init(_ key: ValkeyKey) {
@@ -236,6 +254,8 @@ public struct INCR: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct INCRBY: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "INCRBY" }
 
     public var key: ValkeyKey
     public var increment: Int
@@ -257,6 +277,8 @@ public struct INCRBY: ValkeyCommand {
 public struct INCRBYFLOAT: ValkeyCommand {
     public typealias Response = ByteBuffer
 
+    @inlinable public static var name: String { "INCRBYFLOAT" }
+
     public var key: ValkeyKey
     public var increment: Double
 
@@ -275,6 +297,8 @@ public struct INCRBYFLOAT: ValkeyCommand {
 /// Finds the longest common substring.
 @_documentation(visibility: internal)
 public struct LCS: ValkeyCommand {
+    @inlinable public static var name: String { "LCS" }
+
     public var key1: ValkeyKey
     public var key2: ValkeyKey
     public var len: Bool
@@ -320,6 +344,8 @@ public struct LCS: ValkeyCommand {
 public struct MGET: ValkeyCommand {
     public typealias Response = RESPToken.Array
 
+    @inlinable public static var name: String { "MGET" }
+
     public var keys: [ValkeyKey]
 
     @inlinable public init(keys: [ValkeyKey]) {
@@ -358,6 +384,8 @@ public struct MSET<Value: RESPStringRenderable>: ValkeyCommand {
             RESPBulkString(value).encode(into: &commandEncoder)
         }
     }
+    @inlinable public static var name: String { "MSET" }
+
     public var data: [Data]
 
     @inlinable public init(data: [Data]) {
@@ -396,6 +424,8 @@ public struct MSETNX<Value: RESPStringRenderable>: ValkeyCommand {
     }
     public typealias Response = Int
 
+    @inlinable public static var name: String { "MSETNX" }
+
     public var data: [Data]
 
     @inlinable public init(data: [Data]) {
@@ -412,6 +442,8 @@ public struct MSETNX<Value: RESPStringRenderable>: ValkeyCommand {
 /// Sets both string value and expiration time in milliseconds of a key. The key is created if it doesn't exist.
 @_documentation(visibility: internal)
 public struct PSETEX<Value: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "PSETEX" }
+
     public var key: ValkeyKey
     public var milliseconds: Int
     public var value: Value
@@ -489,6 +521,8 @@ public struct SET<Value: RESPStringRenderable>: ValkeyCommand {
     }
     public typealias Response = ByteBuffer?
 
+    @inlinable public static var name: String { "SET" }
+
     public var key: ValkeyKey
     public var value: Value
     public var condition: Condition?
@@ -513,6 +547,8 @@ public struct SET<Value: RESPStringRenderable>: ValkeyCommand {
 /// Sets the string value and expiration time of a key. Creates the key if it doesn't exist.
 @_documentation(visibility: internal)
 public struct SETEX<Value: RESPStringRenderable>: ValkeyCommand {
+    @inlinable public static var name: String { "SETEX" }
+
     public var key: ValkeyKey
     public var seconds: Int
     public var value: Value
@@ -535,6 +571,8 @@ public struct SETEX<Value: RESPStringRenderable>: ValkeyCommand {
 public struct SETNX<Value: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "SETNX" }
+
     public var key: ValkeyKey
     public var value: Value
 
@@ -554,6 +592,8 @@ public struct SETNX<Value: RESPStringRenderable>: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct SETRANGE<Value: RESPStringRenderable>: ValkeyCommand {
     public typealias Response = Int
+
+    @inlinable public static var name: String { "SETRANGE" }
 
     public var key: ValkeyKey
     public var offset: Int
@@ -577,6 +617,8 @@ public struct SETRANGE<Value: RESPStringRenderable>: ValkeyCommand {
 public struct STRLEN: ValkeyCommand {
     public typealias Response = Int
 
+    @inlinable public static var name: String { "STRLEN" }
+
     public var key: ValkeyKey
 
     @inlinable public init(_ key: ValkeyKey) {
@@ -596,6 +638,8 @@ public struct STRLEN: ValkeyCommand {
 @_documentation(visibility: internal)
 public struct SUBSTR: ValkeyCommand {
     public typealias Response = ByteBuffer
+
+    @inlinable public static var name: String { "SUBSTR" }
 
     public var key: ValkeyKey
     public var start: Int

--- a/Sources/Valkey/Commands/TransactionsCommands.swift
+++ b/Sources/Valkey/Commands/TransactionsCommands.swift
@@ -25,6 +25,8 @@ import Foundation
 /// Discards a transaction.
 @_documentation(visibility: internal)
 public struct DISCARD: ValkeyCommand {
+    @inlinable public static var name: String { "DISCARD" }
+
     @inlinable public init() {
     }
 
@@ -38,6 +40,8 @@ public struct DISCARD: ValkeyCommand {
 public struct EXEC: ValkeyCommand {
     public typealias Response = RESPToken.Array?
 
+    @inlinable public static var name: String { "EXEC" }
+
     @inlinable public init() {
     }
 
@@ -49,6 +53,8 @@ public struct EXEC: ValkeyCommand {
 /// Starts a transaction.
 @_documentation(visibility: internal)
 public struct MULTI: ValkeyCommand {
+    @inlinable public static var name: String { "MULTI" }
+
     @inlinable public init() {
     }
 
@@ -60,6 +66,8 @@ public struct MULTI: ValkeyCommand {
 /// Forgets about watched keys of a transaction.
 @_documentation(visibility: internal)
 public struct UNWATCH: ValkeyCommand {
+    @inlinable public static var name: String { "UNWATCH" }
+
     @inlinable public init() {
     }
 
@@ -71,6 +79,8 @@ public struct UNWATCH: ValkeyCommand {
 /// Monitors changes to keys to determine the execution of a transaction.
 @_documentation(visibility: internal)
 public struct WATCH: ValkeyCommand {
+    @inlinable public static var name: String { "WATCH" }
+
     public var keys: [ValkeyKey]
 
     @inlinable public init(keys: [ValkeyKey]) {

--- a/Sources/Valkey/ValkeyCommand.swift
+++ b/Sources/Valkey/ValkeyCommand.swift
@@ -19,6 +19,9 @@ public protocol ValkeyCommand: Sendable, Hashable {
     associatedtype Response: RESPTokenDecodable & Sendable = RESPToken
     associatedtype Keys: Collection<ValkeyKey>
 
+    /// The name of this command.
+    static var name: String { get }
+
     /// Keys affected by command. This is used in cluster mode to determine which
     /// shard to connect to.
     var keysAffected: Keys { get }
@@ -46,6 +49,9 @@ extension ValkeyCommand {
 /// Wrapper for Valkey command that returns the response as a `RESPToken`
 @usableFromInline
 struct ValkeyRawResponseCommand<Command: ValkeyCommand>: ValkeyCommand {
+    @inlinable
+    static var name: String { Command.name }
+
     @usableFromInline
     let command: Command
 

--- a/Sources/ValkeyBloom/BloomCommands.swift
+++ b/Sources/ValkeyBloom/BloomCommands.swift
@@ -28,6 +28,8 @@ public enum BF {
     /// Add a single item to a bloom filter. The bloom filter is created if it doesn't exist
     @_documentation(visibility: internal)
     public struct ADD<Value: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "BF.ADD" }
+
         public var key: ValkeyKey
         public var value: Value
 
@@ -46,6 +48,8 @@ public enum BF {
     /// Returns the cardinality of a bloom filter
     @_documentation(visibility: internal)
     public struct CARD: ValkeyCommand {
+        @inlinable public static var name: String { "BF.CARD" }
+
         public var key: ValkeyKey
 
         @inlinable public init(_ key: ValkeyKey) {
@@ -62,6 +66,8 @@ public enum BF {
     /// Determines if the bloom filter contains the specified item
     @_documentation(visibility: internal)
     public struct EXISTS<Value: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "BF.EXISTS" }
+
         public var key: ValkeyKey
         public var value: Value
 
@@ -105,6 +111,8 @@ public enum BF {
                 }
             }
         }
+        @inlinable public static var name: String { "BF.INFO" }
+
         public var key: ValkeyKey
         public var sortby: Sortby?
 
@@ -123,6 +131,8 @@ public enum BF {
     /// Creates a bloom filter with 0 or more items or adds items to an existing bloom filter
     @_documentation(visibility: internal)
     public struct INSERT: ValkeyCommand {
+        @inlinable public static var name: String { "BF.INSERT" }
+
         public var key: ValkeyKey
         public var capacity: Int?
         public var error: Double?
@@ -180,6 +190,8 @@ public enum BF {
     /// Restores a bloom filter in a single operation. The command is only generated during AOF Rewrite of bloom filters
     @_documentation(visibility: internal)
     public struct LOAD<Dump: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "BF.LOAD" }
+
         public var key: ValkeyKey
         public var dump: Dump
 
@@ -198,6 +210,8 @@ public enum BF {
     /// Adds one or more items to a bloom filter. The bloom filter is created if it doesn't exist
     @_documentation(visibility: internal)
     public struct MADD<Value: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "BF.MADD" }
+
         public var key: ValkeyKey
         public var values: [Value]
 
@@ -216,6 +230,8 @@ public enum BF {
     /// Determines if the bloom filter contains one or more items
     @_documentation(visibility: internal)
     public struct MEXISTS<Value: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "BF.MEXISTS" }
+
         public var key: ValkeyKey
         public var values: [Value]
 
@@ -234,6 +250,8 @@ public enum BF {
     /// Creates an empty bloom filter with the specified properties
     @_documentation(visibility: internal)
     public struct RESERVE: ValkeyCommand {
+        @inlinable public static var name: String { "BF.RESERVE" }
+
         public var key: ValkeyKey
         public var errorRate: Double
         public var capacity: Int

--- a/Sources/ValkeyJSON/JsonCommands.swift
+++ b/Sources/ValkeyJSON/JsonCommands.swift
@@ -28,6 +28,8 @@ public enum JSON {
     /// Append one or more values to the array values at the path.
     @_documentation(visibility: internal)
     public struct ARRAPPEND<Path: RESPStringRenderable, Json: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.ARRAPPEND" }
+
         public var key: ValkeyKey
         public var path: Path
         public var jsons: [Json]
@@ -48,6 +50,8 @@ public enum JSON {
     /// Search for the first occurrence of a scalar JSON value in arrays located at the specified path. Indices out of range are adjusted.
     @_documentation(visibility: internal)
     public struct ARRINDEX<Path: RESPStringRenderable, JsonScalar: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.ARRINDEX" }
+
         public var key: ValkeyKey
         public var path: Path
         public var jsonScalar: JsonScalar
@@ -72,6 +76,8 @@ public enum JSON {
     /// Insert one or more values into an array at the given path before the specified index.
     @_documentation(visibility: internal)
     public struct ARRINSERT<Path: RESPStringRenderable, Json: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.ARRINSERT" }
+
         public var key: ValkeyKey
         public var path: Path
         public var index: Int
@@ -94,6 +100,8 @@ public enum JSON {
     /// Get length of the array at the path.
     @_documentation(visibility: internal)
     public struct ARRLEN: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.ARRLEN" }
+
         public var key: ValkeyKey
         public var path: String?
 
@@ -112,6 +120,8 @@ public enum JSON {
     /// Remove and returns the element at the given index. Popping an empty array returns null.
     @_documentation(visibility: internal)
     public struct ARRPOP: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.ARRPOP" }
+
         public var key: ValkeyKey
         public var path: String?
         public var index: Int?
@@ -132,6 +142,8 @@ public enum JSON {
     /// Trim the array at the path so that it becomes subarray [start, end], both inclusive.
     @_documentation(visibility: internal)
     public struct ARRTRIM<Path: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.ARRTRIM" }
+
         public var key: ValkeyKey
         public var path: Path
         public var start: Int
@@ -154,6 +166,8 @@ public enum JSON {
     /// Clear the arrays or an object at the specified path.
     @_documentation(visibility: internal)
     public struct CLEAR: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.CLEAR" }
+
         public var key: ValkeyKey
         public var path: String?
 
@@ -172,6 +186,8 @@ public enum JSON {
     /// Reports information. Supported subcommands are: MEMORY, DEPTH, FIELDS, HELP
     @_documentation(visibility: internal)
     public struct DEBUG<SubcommandArguments: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.DEBUG" }
+
         public var subcommandArguments: SubcommandArguments
 
         @inlinable public init(subcommandArguments: SubcommandArguments) {
@@ -186,6 +202,8 @@ public enum JSON {
     /// Delete the JSON values at the specified path in a document key.
     @_documentation(visibility: internal)
     public struct DEL: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.DEL" }
+
         public var key: ValkeyKey
         public var path: String?
 
@@ -204,6 +222,8 @@ public enum JSON {
     /// An alias of JSON.DEL.
     @_documentation(visibility: internal)
     public struct FORGET: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.FORGET" }
+
         @inlinable public init() {
         }
 
@@ -215,6 +235,8 @@ public enum JSON {
     /// Get the serialized JSON at one or multiple paths.
     @_documentation(visibility: internal)
     public struct GET: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.GET" }
+
         public var key: ValkeyKey
         public var indentNewlineSpace: String?
         public var noescape: String?
@@ -237,6 +259,8 @@ public enum JSON {
     /// Get serialized JSONs at the path from multiple document keys. Return null for non-existent key or JSON path.
     @_documentation(visibility: internal)
     public struct MGET<Path: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.MGET" }
+
         public var keys: [ValkeyKey]
         public var path: Path
 
@@ -278,6 +302,8 @@ public enum JSON {
                 RESPBulkString(json).encode(into: &commandEncoder)
             }
         }
+        @inlinable public static var name: String { "JSON.MSET" }
+
         public var data: [Data]
 
         @inlinable public init(data: [Data]) {
@@ -294,6 +320,8 @@ public enum JSON {
     /// Increment the number values at the path by a given number.
     @_documentation(visibility: internal)
     public struct NUMINCRBY<Path: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.NUMINCRBY" }
+
         public var key: ValkeyKey
         public var path: Path
         public var number: Int
@@ -314,6 +342,8 @@ public enum JSON {
     /// Multiply the numeric values at the path by a given number.
     @_documentation(visibility: internal)
     public struct NUMMULTBY<Path: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.NUMMULTBY" }
+
         public var key: ValkeyKey
         public var path: Path
         public var number: Int
@@ -334,6 +364,8 @@ public enum JSON {
     /// Retrieve the key names from the objects at the specified path.
     @_documentation(visibility: internal)
     public struct OBJKEYS: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.OBJKEYS" }
+
         public var key: ValkeyKey
         public var path: String?
 
@@ -352,6 +384,8 @@ public enum JSON {
     /// Get the number of keys in the object at the specified path.
     @_documentation(visibility: internal)
     public struct OBJLEN: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.OBJLEN" }
+
         public var key: ValkeyKey
         public var path: String?
 
@@ -370,6 +404,8 @@ public enum JSON {
     /// Return the JSON value at the given path in Redis Serialization Protocol (RESP).
     @_documentation(visibility: internal)
     public struct RESP: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.RESP" }
+
         public var key: ValkeyKey
         public var path: String?
 
@@ -388,6 +424,8 @@ public enum JSON {
     /// Set JSON values at the specified path.
     @_documentation(visibility: internal)
     public struct SET<Path: RESPStringRenderable, Json: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.SET" }
+
         public var key: ValkeyKey
         public var path: Path
         public var json: Json
@@ -410,6 +448,8 @@ public enum JSON {
     /// Append a string to the JSON strings at the specified path.
     @_documentation(visibility: internal)
     public struct STRAPPEND<JsonString: RESPStringRenderable>: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.STRAPPEND" }
+
         public var key: ValkeyKey
         public var path: String?
         public var jsonString: JsonString
@@ -430,6 +470,8 @@ public enum JSON {
     /// Get the length of the JSON string values at the specified path.
     @_documentation(visibility: internal)
     public struct STRLEN: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.STRLEN" }
+
         public var key: ValkeyKey
         public var path: String?
 
@@ -448,6 +490,8 @@ public enum JSON {
     /// Toggle boolean values between true and false at the specified path.
     @_documentation(visibility: internal)
     public struct TOGGLE: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.TOGGLE" }
+
         public var key: ValkeyKey
         public var path: String?
 
@@ -466,6 +510,8 @@ public enum JSON {
     /// Report the type of the values at the given path.
     @_documentation(visibility: internal)
     public struct TYPE: ValkeyCommand {
+        @inlinable public static var name: String { "JSON.TYPE" }
+
         public var key: ValkeyKey
         public var path: String?
 

--- a/Sources/_ValkeyCommandsBuilder/ValkeyCommandsRender.swift
+++ b/Sources/_ValkeyCommandsBuilder/ValkeyCommandsRender.swift
@@ -429,6 +429,8 @@ extension String {
         if returnType != "RESPToken" {
             self.append("\(tab)    public typealias Response = \(returnType)\n\n")
         }
+        let name = subCommand.map { "\(commandName) \($0)" } ?? commandName
+        self.append("\(tab)    @inlinable public static var name: String { \"\(name)\" }\n\n")
         if arguments.count > 0 {
             for arg in arguments {
                 self.append(

--- a/Tests/IntegrationTests/ValkeyTests.swift
+++ b/Tests/IntegrationTests/ValkeyTests.swift
@@ -75,6 +75,8 @@ struct GeneratedCommands {
         struct GET: ValkeyCommand {
             typealias Response = String?
 
+            static let name = "GET"
+
             var key: ValkeyKey
 
             init(key: ValkeyKey) {


### PR DESCRIPTION
## Motivation

Most `ValkeyCommand` types in valley-swift exactly match their underlying Valkey command name. However, for some commands like nested ones the Swift type name differs from the underlying command. This means there's no simple way of accessing the underlying command's name such as using `"\(type(of: Self.self))"`, which is required for Distributed Tracing support to derive proper span operation names based on the command being executed. See Also: https://github.com/valkey-io/valkey-swift/pull/177
When running codegen for these commands we _do_ have access to the underlying command names, so we could add them as properties to the generated Swift types.

> [!Note]
> This PR is split off from #177 to decrease that PR's diff and keep it focused on just adding Distributed Tracing support.

## Modifications

- Updated the command builder to generate a command name property, to be used in Distributed Tracing spans
- Re-run command builder to generate command name properties

## Result

All `ValkeyCommand` conforming types now have a static `name` property exposing the underlying Valkey command name. This will enable proper Distributed Tracing span operation names.