### PR TITLE
Remove half closure from client connection

### DIFF
--- a/Sources/Valkey/Connection/ValkeyConnection.swift
+++ b/Sources/Valkey/Connection/ValkeyConnection.swift
@@ -361,15 +361,13 @@ public final actor ValkeyConnection: ValkeyClientProtocol, Sendable {
     /// create a BSD sockets based bootstrap
     private static func createSocketsBootstrap(eventLoopGroup: EventLoopGroup) -> ClientBootstrap {
         ClientBootstrap(group: eventLoopGroup)
-            .channelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
     }
 
     #if canImport(Network)
     /// create a NIOTransportServices bootstrap using Network.framework
     private static func createTSBootstrap(eventLoopGroup: EventLoopGroup, tlsOptions: NWProtocolTLS.Options?) -> NIOTSConnectionBootstrap? {
         guard
-            let bootstrap = NIOTSConnectionBootstrap(validatingGroup: eventLoopGroup)?
-                .channelOption(ChannelOptions.allowRemoteHalfClosure, value: true)
+            let bootstrap = NIOTSConnectionBootstrap(validatingGroup: eventLoopGroup)
         else {
             return nil
         }


### PR DESCRIPTION
The client shouldnt need half closure as the database closing the connection means the client connection should close as well. This was also leaving connections open.