### PR TITLE
Cluster command keys should all come from the same hash slot

### DIFF
--- a/Sources/Valkey/Cluster/ValkeyClusterError.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterError.swift
@@ -14,6 +14,7 @@ package enum ValkeyClusterError: Error {
     case noNodeToTalkTo
     case serverDiscoveryFailedNoKnownNode
     case keysInCommandRequireMultipleNodes
+    case keysInCommandRequireMultipleHashSlots
     case clusterIsUnavailable
     case noConsensusReachedCircuitBreakerOpen
     case clusterHasNoNodes

--- a/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
+++ b/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
@@ -66,7 +66,7 @@ struct ClusterIntegrationTests {
                 let shard = try #require(
                     cluster.shards.first { shard in
                         let hashSlot = HashSlot(key: key)
-                        return shard.slots[0].lowerBound <= hashSlot && shard.slots[0].upperBound >= hashSlot
+                        return shard.slots.reduce(into: false) { $0 = $0 || ($1.lowerBound <= hashSlot && $1.upperBound >= hashSlot) }
                     }
                 )
                 let replica = try #require(shard.nodes.first { $0.role == .replica })


### PR DESCRIPTION
This allows us to simplify a bunch of internal code as we only need to know the shard for a single hash key