### PR TITLE
ValkeyClusterClient client configuration defines whether TLS is required

### DIFF
--- a/Sources/Valkey/Cluster/ValkeyNodeDescription.swift
+++ b/Sources/Valkey/Cluster/ValkeyNodeDescription.swift
@@ -51,11 +51,6 @@ package struct ValkeyNodeDescription: Identifiable, Hashable, Sendable {
     /// This property is required and is used as part of the node's unique identifier.
     package var port: Int
 
-    /// Indicates whether TLS/SSL should be used when connecting to this node.
-    ///
-    /// When `true`, the connection will use secure transport with TLS.
-    package var useTLS: Bool
-
     /// Creates a node description from any type conforming to the `ValkeyNodeDescriptionProtocol`.
     ///
     /// This initializer allows for easy conversion from various node description types
@@ -68,7 +63,6 @@ package struct ValkeyNodeDescription: Identifiable, Hashable, Sendable {
         self.ip = description.ip
         self.endpoint = description.endpoint
         self.port = description.port
-        self.useTLS = description.useTLS
     }
 
     /// Creates a node description from a cluster node description.
@@ -84,7 +78,6 @@ package struct ValkeyNodeDescription: Identifiable, Hashable, Sendable {
         self.ip = description.ip
         self.endpoint = description.endpoint
         self.port = description.tlsPort ?? description.port ?? 6379
-        self.useTLS = description.tlsPort != nil
     }
 
     /// Determines whether this node description matches a given cluster node description.
@@ -97,6 +90,5 @@ package struct ValkeyNodeDescription: Identifiable, Hashable, Sendable {
     func matches(_ other: ValkeyClusterDescription.Node) -> Bool {
         self.endpoint == other.endpoint
             && self.port == other.tlsPort ?? other.port ?? 6379
-            && self.useTLS == (other.tlsPort != nil)
     }
 }

--- a/Sources/Valkey/Cluster/ValkeyNodeDescriptionProtocol.swift
+++ b/Sources/Valkey/Cluster/ValkeyNodeDescriptionProtocol.swift
@@ -40,10 +40,4 @@ public protocol ValkeyNodeDescriptionProtocol: Sendable, Equatable {
 
     /// The port number on which the Valkey service is listening.
     var port: Int { get }
-
-    /// Indicates whether TLS (Transport Layer Security) should be used when connecting to this node.
-    ///
-    /// - `true`: Use a secure TLS connection
-    /// - `false`: Use a plain TCP connection
-    var useTLS: Bool { get }
 }

--- a/Sources/Valkey/Cluster/ValkeyNodeDiscovery.swift
+++ b/Sources/Valkey/Cluster/ValkeyNodeDiscovery.swift
@@ -36,8 +36,8 @@ public protocol ValkeyNodeDiscovery: Sendable {
 /// ```swift
 /// // Using ExpressibleByArrayLiteral conformance for more concise initialization
 /// let discovery: ValkeyStaticNodeDiscovery = [
-///     .init(host: "replica1.valkey.io", port: 10600, useTLS: false),
-///     .init(ip: "192.168.12.1", port: 10600, useTLS: true)
+///     .init(host: "replica1.valkey.io", port: 10600),
+///     .init(ip: "192.168.12.1", port: 10600)
 /// ]
 /// ```
 public struct ValkeyStaticNodeDiscovery: ValkeyNodeDiscovery {
@@ -47,7 +47,6 @@ public struct ValkeyStaticNodeDiscovery: ValkeyNodeDiscovery {
         public var ip: String?
         public var endpoint: String
         public var port: Int
-        public var useTLS: Bool
 
         /// Initializes a `NodeDescription` with a host and optional IP.
         ///
@@ -55,13 +54,11 @@ public struct ValkeyStaticNodeDiscovery: ValkeyNodeDiscovery {
         ///   - host: The host name of the node.
         ///   - ip: The optional IP address of the node.
         ///   - port: The port number the node listens on (default is 6379).
-        ///   - useTLS: A boolean indicating whether TLS should be used (default is true).
-        public init(host: String, ip: String? = nil, port: Int = 6379, useTLS: Bool = true) {
+        public init(host: String, ip: String? = nil, port: Int = 6379) {
             self.host = host
             self.ip = ip
             self.endpoint = host
             self.port = port
-            self.useTLS = useTLS
         }
 
         /// Initializes a `NodeDescription` with an IP address.
@@ -69,13 +66,11 @@ public struct ValkeyStaticNodeDiscovery: ValkeyNodeDiscovery {
         /// - Parameters:
         ///   - ip: The IP address of the node.
         ///   - port: The port number the node listens on (default is 6379).
-        ///   - useTLS: A boolean indicating whether TLS should be used (default is false).
-        public init(ip: String, port: Int = 6379, useTLS: Bool = false) {
+        public init(ip: String, port: Int = 6379) {
             self.host = nil
             self.ip = ip
             self.endpoint = ip
             self.port = port
-            self.useTLS = useTLS
         }
     }
 

--- a/Sources/Valkey/Cluster/ValkeyTopologyCandidate.swift
+++ b/Sources/Valkey/Cluster/ValkeyTopologyCandidate.swift
@@ -37,16 +37,12 @@ package struct ValkeyTopologyCandidate: Hashable {
         /// The port to connect to (either standard port or TLS port).
         package var port: Int
 
-        /// Whether TLS should be used for connecting to this node.
-        package var useTLS: Bool
-
         /// Creates a simplified node representation from a `ValkeyClusterDescription.Node`.
         ///
         /// - Parameter node: The source node from a cluster description.
         package init(_ node: ValkeyClusterDescription.Node) {
             self.endpoint = node.endpoint
             self.port = node.tlsPort ?? node.port ?? 6379
-            self.useTLS = node.tlsPort != nil
         }
     }
 
@@ -86,9 +82,6 @@ package struct ValkeyTopologyCandidate: Hashable {
                 }
                 if lhs.port != rhs.port {
                     return lhs.port < rhs.port
-                }
-                if lhs.useTLS != rhs.useTLS {
-                    return !lhs.useTLS
                 }
                 return true
             })

--- a/Sources/Valkey/Node/ValkeyNodeClientFactory.swift
+++ b/Sources/Valkey/Node/ValkeyNodeClientFactory.swift
@@ -53,12 +53,6 @@ package struct ValkeyNodeClientFactory: ValkeyNodeConnectionPoolFactory {
             port: nodeDescription.port
         )
 
-        var clientConfiguration = self.configuration
-        if !nodeDescription.useTLS {
-            // TODO: Should this throw? What about the other way around?
-            clientConfiguration.tls = .disable
-        }
-
         return ValkeyNodeClient(
             serverAddress,
             connectionIDGenerator: self.connectionIDGenerator,

--- a/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
+++ b/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
@@ -107,7 +107,7 @@ struct ClusterIntegrationTests {
     ) async throws -> T {
         let client = ValkeyClusterClient(
             clientConfiguration: nodeClientConfiguration,
-            nodeDiscovery: ValkeyStaticNodeDiscovery(nodeAddresses.map { .init(host: $0.host, port: $0.port, useTLS: $0.tls) }),
+            nodeDiscovery: ValkeyStaticNodeDiscovery(nodeAddresses.map { .init(host: $0.host, port: $0.port) }),
             logger: logger
         )
 


### PR DESCRIPTION
It is assumed that the TLS requirement is consistent for all the cluster nodes. This means ValkeyNodeDescription does not need to include whether the node uses TLS. 

This is the same as valkey-glide. 