### PR TITLE
Make ValkeyClusterError public and a struct

### DIFF
--- a/Sources/Valkey/Cluster/HashSlotShardMap.swift
+++ b/Sources/Valkey/Cluster/HashSlotShardMap.swift
@@ -101,7 +101,7 @@ package struct HashSlotShardMap: Sendable {
                 throw ValkeyClusterError.clusterIsMissingSlotAssignment
             }
             guard ogNodeID == nodeID else {
-                throw ValkeyClusterError.keysInCommandRequireMultipleNodes
+                throw ValkeyClusterError.keysRequireMultipleNodes
             }
         }
 

--- a/Sources/Valkey/Cluster/ValkeyClusterClient.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClient.swift
@@ -166,7 +166,7 @@ public final class ValkeyClusterClient: Sendable {
                 } else {
                     return try await client.execute(command)
                 }
-            } catch ValkeyClusterError.noNodeToTalkTo {
+            } catch let error as ValkeyClusterError where error == .noNodeToTalkTo {
                 // TODO: Rerun node discovery!
             } catch let error as ValkeyClientError where error.errorCode == .commandError {
                 guard let errorMessage = error.message else {
@@ -473,7 +473,7 @@ public final class ValkeyClusterClient: Sendable {
                 return try self.stateLock.withLock { state -> ValkeyNodeClient in
                     try state.poolFastPath(for: slots)
                 }
-            } catch ValkeyClusterError.clusterIsUnavailable {
+            } catch let error as ValkeyClusterError where error == .clusterIsUnavailable {
                 let waiterID = self.nextRequestID()
 
                 try await withTaskCancellationHandler {

--- a/Sources/Valkey/Cluster/ValkeyClusterError.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterError.swift
@@ -5,20 +5,57 @@
 // See LICENSE.txt for license information
 // SPDX-License-Identifier: Apache-2.0
 //
-@usableFromInline
-package enum ValkeyClusterError: Error {
-    case clusterIsMissingSlotAssignment
-    case clusterIsMissingMovedErrorNode
-    case shardIsMissingPrimaryNode
-    case shardHasMultiplePrimaryNodes
-    case noNodeToTalkTo
-    case serverDiscoveryFailedNoKnownNode
-    case keysInCommandRequireMultipleNodes
-    case keysInCommandRequireMultipleHashSlots
-    case clusterIsUnavailable
-    case noConsensusReachedCircuitBreakerOpen
-    case clusterHasNoNodes
-    case clusterClientIsShutDown
-    case clientRequestCancelled
-    case waitedForDiscoveryAfterMovedErrorThreeTimes
+
+/// Errors thrown from ValkeyClusterClient
+public struct ValkeyClusterError: Error, Equatable {
+    private enum Internal: Error, Equatable {
+        case clusterIsMissingSlotAssignment
+        case clusterIsMissingMovedErrorNode
+        case shardIsMissingPrimaryNode
+        case shardHasMultiplePrimaryNodes
+        case noNodeToTalkTo
+        case serverDiscoveryFailedNoKnownNode
+        case keysRequireMultipleNodes
+        case keysInCommandRequireMultipleHashSlots
+        case clusterIsUnavailable
+        case noConsensusReachedCircuitBreakerOpen
+        case clusterHasNoNodes
+        case clusterClientIsShutDown
+        case clientRequestCancelled
+        case waitedForDiscoveryAfterMovedErrorThreeTimes
+    }
+    private let value: Internal
+    private init(_ value: Internal) {
+        self.value = value
+    }
+
+    /// Slot is not assigned to any shard
+    static public var clusterIsMissingSlotAssignment: Self { .init(.clusterIsMissingSlotAssignment) }
+    /// We don't have a node for a shard associated with move error.
+    static public var clusterIsMissingMovedErrorNode: Self { .init(.clusterIsMissingMovedErrorNode) }
+    /// Shard in cluster description is missing a primary node
+    static public var shardIsMissingPrimaryNode: Self { .init(.shardIsMissingPrimaryNode) }
+    /// Shard in cluster description has multiple primary node
+    static public var shardHasMultiplePrimaryNodes: Self { .init(.shardHasMultiplePrimaryNodes) }
+    /// Not current used
+    static public var noNodeToTalkTo: Self { .init(.noNodeToTalkTo) }
+    /// Not current used
+    static public var serverDiscoveryFailedNoKnownNode: Self { .init(.serverDiscoveryFailedNoKnownNode) }
+    /// Keys require multiple nodes
+    static public var keysRequireMultipleNodes: Self { .init(.keysRequireMultipleNodes) }
+    /// Keys in command require multiple hash slots
+    static public var keysInCommandRequireMultipleHashSlots: Self { .init(.keysInCommandRequireMultipleHashSlots) }
+    /// Cluster is currently unavailable
+    static public var clusterIsUnavailable: Self { .init(.clusterIsUnavailable) }
+    /// No consensus about cluster state was reached in time
+    static public var noConsensusReachedCircuitBreakerOpen: Self { .init(.noConsensusReachedCircuitBreakerOpen) }
+    /// Cluster has no nodes
+    static public var clusterHasNoNodes: Self { .init(.clusterHasNoNodes) }
+    /// Cluster client is shutdown
+    static public var clusterClientIsShutDown: Self { .init(.clusterClientIsShutDown) }
+    /// Request was cancelled
+    static public var clientRequestCancelled: Self { .init(.clientRequestCancelled) }
+    /// Wait for discovery failed three times after receiving a MOVED error
+    static public var waitedForDiscoveryAfterMovedErrorThreeTimes: Self { .init(.waitedForDiscoveryAfterMovedErrorThreeTimes) }
+
 }

--- a/Tests/ValkeyTests/Cluster/HashSlotShardMapTests.swift
+++ b/Tests/ValkeyTests/Cluster/HashSlotShardMapTests.swift
@@ -192,7 +192,7 @@ struct HashSlotShardMapTests {
 
         // Test slots from different shards - should throw
         let differentShardSlots: [HashSlot] = [5, 150]  // 5 from shard1, 150 from shard2
-        #expect(throws: ValkeyClusterError.keysInCommandRequireMultipleNodes) {
+        #expect(throws: ValkeyClusterError.keysRequireMultipleNodes) {
             try map.nodeID(for: differentShardSlots)
         }
     }
@@ -449,7 +449,7 @@ struct HashSlotShardMapTests {
         #expect(shardNodes2.replicas.contains(expectedReplica2_2))
 
         // Verify that nodeID(for:) still throws when slots span multiple shards
-        #expect(throws: ValkeyClusterError.keysInCommandRequireMultipleNodes) {
+        #expect(throws: ValkeyClusterError.keysRequireMultipleNodes) {
             _ = try map.nodeID(for: [1000, 10000])
         }
     }


### PR DESCRIPTION
`ValkeyClusterError` is thrown outside of the cluster code. It is currently an internal enum so users can't make any use of the error. This PR makes it public and converts it to a struct so that it can be extending in the future without creating a major version breaking change.