### PR TITLE
Cluster pipeline

### DIFF
--- a/Sources/Valkey/Cluster/ValkeyClusterClient.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClient.swift
@@ -272,7 +272,7 @@ public final class ValkeyClusterClient: Sendable {
             for node in nodes {
                 let indices = node.commandIndices
                 group.addTask {
-                    let results = try await self.execute(node: node.node, commands: SparseCollection(commands, indices: indices))
+                    let results = try await self.execute(node: node.node, commands: IndexedSubCollection(commands, indices: indices))
                     return .init(indices: indices, results: results)
                 }
             }

--- a/Sources/Valkey/Cluster/ValkeyClusterClient.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClient.swift
@@ -224,7 +224,7 @@ public final class ValkeyClusterClient: Sendable {
 
     /// Results from pipeline and index for each result
     @usableFromInline
-    struct NodeResult: Sendable {
+    struct NodePipelineResult: Sendable {
         @usableFromInline
         let indices: [[any ValkeyCommand].Index]
         @usableFromInline
@@ -267,7 +267,7 @@ public final class ValkeyClusterClient: Sendable {
         if nodes.count == 1 {
             return try await self.execute(node: nodes[nodes.startIndex].node, commands: commands)
         }
-        return try await withThrowingTaskGroup(of: NodeResult.self) { group in
+        return try await withThrowingTaskGroup(of: NodePipelineResult.self) { group in
             // run generated pipelines concurrently
             for node in nodes {
                 let indices = node.commandIndices

--- a/Sources/Valkey/Cluster/ValkeyClusterClient.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClient.swift
@@ -200,6 +200,25 @@ public final class ValkeyClusterClient: Sendable {
         }
     }
 
+    /// Pipeline a series of commands to nodes in the Valkey cluster
+    ///
+    /// This function splits up the array of commands into smaller arrays containing
+    /// the commands that should be run on each node in the cluster. It then runs a
+    /// pipelined execute using these smaller arrays on each node concurrently.
+    ///
+    /// Once all the responses for the commands have been received the function returns
+    /// an array of RESPToken Results, one for each command.
+    ///
+    /// Because the commands are split across nodes it is not possible to guarantee
+    /// the order that commands will run in. The only way to guarantee the order is to
+    /// only pipeline commands that use keys from the same HashSlot. If a key has a
+    /// substring between brackets `{}` then that substring is used to calculate the
+    /// HashSlot. That substring is called the hash tag. Using this you can ensure two
+    /// keys are in the same hash slot, by giving them the same hash tag eg `user:{123}`
+    /// and `profile:{123}`.
+    ///
+    /// - Parameter commands: Parameter pack of ValkeyCommands
+    /// - Returns: Array holding the RESPToken responses of all the commands
     @inlinable
     public func execute(
         _ commands: [any ValkeyCommand]

--- a/Sources/Valkey/Cluster/ValkeyClusterClient.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClient.swift
@@ -200,14 +200,10 @@ public final class ValkeyClusterClient: Sendable {
     /// - Parameter commands: Parameter pack of ValkeyCommands
     /// - Returns: Array holding the RESPToken responses of all the commands
     @usableFromInline
-    func execute(
+    func execute<Commands: Collection & Sendable>(
         node: ValkeyNodeClient,
-        commands: [any ValkeyCommand]
-    ) async throws -> sending [Result<RESPToken, Error>] {
-        struct Redirection {
-            let node: ValkeyNodeClient
-            let ask: Bool
-        }
+        commands: Commands
+    ) async throws -> sending [Result<RESPToken, Error>] where Commands.Element == any ValkeyCommand, Commands.Index == Int {
         // execute pipeline
         var results = await node.execute(commands)
         var retryCommands: [(any ValkeyCommand, Int)] = []

--- a/Sources/Valkey/Cluster/ValkeyClusterClient.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClient.swift
@@ -200,10 +200,14 @@ public final class ValkeyClusterClient: Sendable {
     /// - Parameter commands: Parameter pack of ValkeyCommands
     /// - Returns: Array holding the RESPToken responses of all the commands
     @usableFromInline
-    func execute<Commands: Collection & Sendable>(
+    func execute(
         node: ValkeyNodeClient,
-        commands: Commands
-    ) async throws -> sending [Result<RESPToken, Error>] where Commands.Element == any ValkeyCommand, Commands.Index == Int {
+        commands: [any ValkeyCommand]
+    ) async throws -> sending [Result<RESPToken, Error>] {
+        struct Redirection {
+            let node: ValkeyNodeClient
+            let ask: Bool
+        }
         // execute pipeline
         var results = await node.execute(commands)
         var retryCommands: [(any ValkeyCommand, Int)] = []

--- a/Sources/Valkey/Cluster/ValkeyClusterError.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterError.swift
@@ -23,6 +23,7 @@ public struct ValkeyClusterError: Error, Equatable {
         case clusterClientIsShutDown
         case clientRequestCancelled
         case waitedForDiscoveryAfterMovedErrorThreeTimes
+        case pipelinedResultNotReturned
     }
     private let value: Internal
     private init(_ value: Internal) {
@@ -57,5 +58,7 @@ public struct ValkeyClusterError: Error, Equatable {
     static public var clientRequestCancelled: Self { .init(.clientRequestCancelled) }
     /// Wait for discovery failed three times after receiving a MOVED error
     static public var waitedForDiscoveryAfterMovedErrorThreeTimes: Self { .init(.waitedForDiscoveryAfterMovedErrorThreeTimes) }
+    /// Pipelined result not returned. If you receive this, it is an internal error and should be reported as a bug
+    static public var pipelinedResultNotReturned: Self { .init(.waitedForDiscoveryAfterMovedErrorThreeTimes) }
 
 }

--- a/Sources/Valkey/Connection/ValkeyConnection.swift
+++ b/Sources/Valkey/Connection/ValkeyConnection.swift
@@ -225,16 +225,25 @@ public final actor ValkeyConnection: ValkeyClientProtocol, Sendable {
     public func execute<each Command: ValkeyCommand>(
         _ commands: repeat each Command
     ) async -> sending (repeat Result<(each Command).Response, Error>) {
-        func convert<Response: RESPTokenDecodable>(_ result: Result<RESPToken, Error>, to: Response.Type) -> Result<Response, Error> {
-            result.flatMap {
-                do {
-                    return try .success(Response(fromRESP: $0))
-                } catch {
-                    return .failure(error)
-                }
-            }
-        }
         let requestID = Self.requestIDGenerator.next()
+        return await withTaskCancellationHandler {
+            let commandPromises = self._execute(requestID: requestID, commands: repeat each commands)
+            var index = AutoIncrementingInteger()
+            return await (repeat commandPromises[index.next()].futureResult._result().convertRESP(to: (each Command).Response.self))
+        } onCancel: {
+            self.cancel(requestID: requestID)
+        }
+    }
+
+    /// Pipeline a series of commands to Valkey connection
+    ///
+    /// - Parameter commands: Parameter pack of ValkeyCommands
+    /// - Returns: Array of promises (one for each command)
+    @inlinable
+    func _execute<each Command: ValkeyCommand>(
+        requestID: Int,
+        commands: repeat each Command
+    ) -> [EventLoopPromise<RESPToken>] {
         // this currently allocates a promise for every command. We could collapse this down to one promise
         var mpromises: [EventLoopPromise<RESPToken>] = []
         var encoder = ValkeyCommandEncoder()
@@ -244,21 +253,15 @@ public final actor ValkeyConnection: ValkeyClientProtocol, Sendable {
         }
         let outBuffer = encoder.buffer
         let promises = mpromises
-        return await withTaskCancellationHandler {
-            if Task.isCancelled {
-                for promise in mpromises {
-                    promise.fail(ValkeyClientError(.cancelled))
-                }
-            } else {
-                // write directly to channel handler
-                self.channelHandler.write(request: ValkeyRequest.multiple(buffer: outBuffer, promises: promises.map { .nio($0) }, id: requestID))
+        if Task.isCancelled {
+            for promise in mpromises {
+                promise.fail(ValkeyClientError(.cancelled))
             }
-            // get response from channel handler
-            var index = AutoIncrementingInteger()
-            return await (repeat convert(promises[index.next()].futureResult._result(), to: (each Command).Response.self))
-        } onCancel: {
-            self.cancel(requestID: requestID)
+        } else {
+            // write directly to channel handler
+            self.channelHandler.write(request: ValkeyRequest.multiple(buffer: outBuffer, promises: promises.map { .nio($0) }, id: requestID))
         }
+        return promises
     }
 
     /// Pipeline a series of commands to Valkey connection
@@ -548,6 +551,11 @@ struct AutoIncrementingInteger {
         value += 1
         return value - 1
     }
+
+    @inlinable
+    mutating func reset() {
+        value = 0
+    }
 }
 
 #if DistributedTracingSupport
@@ -566,3 +574,19 @@ extension ValkeyClientError {
     }
 }
 #endif
+
+extension Result where Success == RESPToken {
+    @inlinable
+    func convertRESP<Response: RESPTokenDecodable>(to: Response.Type) -> Result<Response, Error> {
+        switch self {
+        case .success(let token):
+            do {
+                return try .success(Response(fromRESP: token))
+            } catch {
+                return .failure(error)
+            }
+        case .failure(let error):
+            return .failure(error)
+        }
+    }
+}

--- a/Sources/Valkey/Connection/ValkeyConnection.swift
+++ b/Sources/Valkey/Connection/ValkeyConnection.swift
@@ -225,25 +225,16 @@ public final actor ValkeyConnection: ValkeyClientProtocol, Sendable {
     public func execute<each Command: ValkeyCommand>(
         _ commands: repeat each Command
     ) async -> sending (repeat Result<(each Command).Response, Error>) {
-        let requestID = Self.requestIDGenerator.next()
-        return await withTaskCancellationHandler {
-            let commandPromises = self._execute(requestID: requestID, commands: repeat each commands)
-            var index = AutoIncrementingInteger()
-            return await (repeat commandPromises[index.next()].futureResult._result().convertRESP(to: (each Command).Response.self))
-        } onCancel: {
-            self.cancel(requestID: requestID)
+        func convert<Response: RESPTokenDecodable>(_ result: Result<RESPToken, Error>, to: Response.Type) -> Result<Response, Error> {
+            result.flatMap {
+                do {
+                    return try .success(Response(fromRESP: $0))
+                } catch {
+                    return .failure(error)
+                }
+            }
         }
-    }
-
-    /// Pipeline a series of commands to Valkey connection
-    ///
-    /// - Parameter commands: Parameter pack of ValkeyCommands
-    /// - Returns: Array of promises (one for each command)
-    @inlinable
-    func _execute<each Command: ValkeyCommand>(
-        requestID: Int,
-        commands: repeat each Command
-    ) -> [EventLoopPromise<RESPToken>] {
+        let requestID = Self.requestIDGenerator.next()
         // this currently allocates a promise for every command. We could collapse this down to one promise
         var mpromises: [EventLoopPromise<RESPToken>] = []
         var encoder = ValkeyCommandEncoder()
@@ -253,15 +244,21 @@ public final actor ValkeyConnection: ValkeyClientProtocol, Sendable {
         }
         let outBuffer = encoder.buffer
         let promises = mpromises
-        if Task.isCancelled {
-            for promise in mpromises {
-                promise.fail(ValkeyClientError(.cancelled))
+        return await withTaskCancellationHandler {
+            if Task.isCancelled {
+                for promise in mpromises {
+                    promise.fail(ValkeyClientError(.cancelled))
+                }
+            } else {
+                // write directly to channel handler
+                self.channelHandler.write(request: ValkeyRequest.multiple(buffer: outBuffer, promises: promises.map { .nio($0) }, id: requestID))
             }
-        } else {
-            // write directly to channel handler
-            self.channelHandler.write(request: ValkeyRequest.multiple(buffer: outBuffer, promises: promises.map { .nio($0) }, id: requestID))
+            // get response from channel handler
+            var index = AutoIncrementingInteger()
+            return await (repeat convert(promises[index.next()].futureResult._result(), to: (each Command).Response.self))
+        } onCancel: {
+            self.cancel(requestID: requestID)
         }
-        return promises
     }
 
     /// Pipeline a series of commands to Valkey connection
@@ -322,7 +319,7 @@ public final actor ValkeyConnection: ValkeyClientProtocol, Sendable {
     ///
     /// - Parameter commands: Collection of ValkeyCommands
     /// - Returns: Array holding the RESPToken responses of all the commands
-    @inlinable
+    @usableFromInline
     func executeWithAsk(
         _ commands: some Collection<any ValkeyCommand>
     ) async -> sending [Result<RESPToken, Error>] {
@@ -551,11 +548,6 @@ struct AutoIncrementingInteger {
         value += 1
         return value - 1
     }
-
-    @inlinable
-    mutating func reset() {
-        value = 0
-    }
 }
 
 #if DistributedTracingSupport
@@ -574,19 +566,3 @@ extension ValkeyClientError {
     }
 }
 #endif
-
-extension Result where Success == RESPToken {
-    @inlinable
-    func convertRESP<Response: RESPTokenDecodable>(to: Response.Type) -> Result<Response, Error> {
-        switch self {
-        case .success(let token):
-            do {
-                return try .success(Response(fromRESP: token))
-            } catch {
-                return .failure(error)
-            }
-        case .failure(let error):
-            return .failure(error)
-        }
-    }
-}

--- a/Sources/Valkey/Connection/ValkeyServerAddress.swift
+++ b/Sources/Valkey/Connection/ValkeyServerAddress.swift
@@ -8,8 +8,8 @@
 import NIOCore
 
 /// A Valkey server address to connect to.
-public struct ValkeyServerAddress: Sendable, Equatable, Hashable {
-    enum _Internal: Equatable, Hashable {
+public struct ValkeyServerAddress: Sendable, Equatable {
+    enum _Internal: Equatable {
         case hostname(_ host: String, port: Int)
         case unixDomainSocket(path: String)
     }

--- a/Sources/Valkey/Connection/ValkeyServerAddress.swift
+++ b/Sources/Valkey/Connection/ValkeyServerAddress.swift
@@ -8,8 +8,8 @@
 import NIOCore
 
 /// A Valkey server address to connect to.
-public struct ValkeyServerAddress: Sendable, Equatable {
-    enum _Internal: Equatable {
+public struct ValkeyServerAddress: Sendable, Equatable, Hashable {
+    enum _Internal: Equatable, Hashable {
         case hostname(_ host: String, port: Int)
         case unixDomainSocket(path: String)
     }

--- a/Sources/Valkey/Utils/SparseCollection.swift
+++ b/Sources/Valkey/Utils/SparseCollection.swift
@@ -1,0 +1,79 @@
+//
+// This source file is part of the valkey-swift project
+// Copyright (c) 2025 the valkey-swift project authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+@usableFromInline
+struct SparseCollection<Base: Collection>: Collection {
+    @usableFromInline
+    typealias Element = Base.Element
+    @usableFromInline
+    typealias Index = [Base.Index].Index
+
+    @usableFromInline
+    let base: Base
+    @usableFromInline
+    let baseIndices: [Base.Index]
+
+    @inlinable
+    var startIndex: Index { self.baseIndices.startIndex }
+    @inlinable
+    var endIndex: Index { self.baseIndices.endIndex }
+
+    @inlinable
+    init(_ base: Base, indices: [Base.Index]) {
+        self.base = base
+        self.baseIndices = indices
+    }
+
+    @inlinable
+    func index(after i: Array<Base.Index>.Index) -> Array<Base.Index>.Index {
+        self.baseIndices.index(after: i)
+    }
+
+    @inlinable
+    subscript(position: Index) -> Element {
+        get {
+            let index = self.baseIndices[position]
+            return self.base[index]
+        }
+    }
+
+    @inlinable
+    subscript(index: Index) -> Base.Index {
+        get {
+            self.baseIndices[index]
+        }
+    }
+
+    @usableFromInline
+    struct Iterator: IteratorProtocol {
+        @usableFromInline
+        let base: Base
+        @usableFromInline
+        var iterator: [Base.Index].Iterator
+
+        @inlinable
+        init(base: Base, iterator: [Base.Index].Iterator) {
+            self.base = base
+            self.iterator = iterator
+        }
+
+        @inlinable
+        mutating func next() -> Base.Element? {
+            if let index = self.iterator.next() {
+                return base[index]
+            }
+            return nil
+        }
+    }
+
+    @inlinable
+    func makeIterator() -> Iterator {
+        .init(base: self.base, iterator: self.baseIndices.makeIterator())
+    }
+}
+
+extension SparseCollection: Sendable where Base: Sendable, Base.Index: Sendable {}

--- a/Sources/Valkey/Utils/SparseCollection.swift
+++ b/Sources/Valkey/Utils/SparseCollection.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 @usableFromInline
-struct SparseCollection<Base: Collection>: Collection {
+struct IndexedSubCollection<Base: Collection>: Collection {
     @usableFromInline
     typealias Element = Base.Element
     @usableFromInline
@@ -76,4 +76,4 @@ struct SparseCollection<Base: Collection>: Collection {
     }
 }
 
-extension SparseCollection: Sendable where Base: Sendable, Base.Index: Sendable {}
+extension IndexedSubCollection: Sendable where Base: Sendable, Base.Index: Sendable {}

--- a/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
+++ b/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
@@ -328,7 +328,7 @@ struct ClusterIntegrationTests {
                     commands.append(SET(key2, value: "cluster pipeline test"))
                     commands.append(GET(key2))
                     commands.append(DEL(keys: [key2]))
-                    let results = try await client.execute(node: node, commands: .init(commands.dropFirst()))
+                    let results = try await client.execute(node: node, commands: commands.dropFirst())
                     let response = try results[3].get().decode(as: String.self)
                     #expect(response == "cluster pipeline test")
                 }

--- a/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
+++ b/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
@@ -328,7 +328,7 @@ struct ClusterIntegrationTests {
                     commands.append(SET(key2, value: "cluster pipeline test"))
                     commands.append(GET(key2))
                     commands.append(DEL(keys: [key2]))
-                    let results = try await client.execute(node: node, commands: commands.dropFirst())
+                    let results = try await client.execute(node: node, commands: .init(commands.dropFirst()))
                     let response = try results[3].get().decode(as: String.self)
                     #expect(response == "cluster pipeline test")
                 }

--- a/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
+++ b/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
@@ -25,7 +25,7 @@ struct ClusterIntegrationTests {
         logger.logLevel = .trace
         let firstNodeHostname = clusterFirstNodeHostname!
         let firstNodePort = clusterFirstNodePort ?? 6379
-        try await Self.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort, tls: false)], logger: logger) { client in
+        try await Self.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) { client in
             try await Self.withKey(connection: client) { key in
                 try await client.set(key, value: "Hello")
 
@@ -42,7 +42,7 @@ struct ClusterIntegrationTests {
         logger.logLevel = .trace
         let firstNodeHostname = clusterFirstNodeHostname!
         let firstNodePort = clusterFirstNodePort ?? 6379
-        try await Self.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort, tls: false)], logger: logger) { client in
+        try await Self.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) { client in
             try await Self.withKey(connection: client) { key in
                 try await client.withConnection(forKeys: [key]) { connection in
                     _ = try await connection.set(key, value: "Hello")
@@ -60,7 +60,7 @@ struct ClusterIntegrationTests {
         logger.logLevel = .trace
         let firstNodeHostname = clusterFirstNodeHostname!
         let firstNodePort = clusterFirstNodePort ?? 6379
-        try await Self.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort, tls: false)], logger: logger) { clusterClient in
+        try await Self.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) { clusterClient in
             try await Self.withKey(connection: clusterClient) { key in
                 try await clusterClient.set(key, value: "bar")
                 let cluster = try await clusterClient.clusterShards()
@@ -91,7 +91,7 @@ struct ClusterIntegrationTests {
         logger.logLevel = .trace
         let firstNodeHostname = clusterFirstNodeHostname!
         let firstNodePort = clusterFirstNodePort ?? 6379
-        try await Self.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort, tls: false)], logger: logger) { client in
+        try await Self.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) { client in
             let keySuffix = "{\(UUID().uuidString)}"
             try await Self.withKey(connection: client, suffix: keySuffix) { key in
                 let hashSlot = HashSlot(key: key)
@@ -120,7 +120,7 @@ struct ClusterIntegrationTests {
         logger.logLevel = .trace
         let firstNodeHostname = clusterFirstNodeHostname!
         let firstNodePort = clusterFirstNodePort ?? 6379
-        try await Self.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort, tls: false)], logger: logger) { client in
+        try await Self.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) { client in
             let keySuffix = "{\(UUID().uuidString)}"
             try await Self.withKey(connection: client, suffix: keySuffix) { key in
                 try await Self.withKey(connection: client, suffix: keySuffix) { key2 in
@@ -213,7 +213,7 @@ struct ClusterIntegrationTests {
             logger.logLevel = .trace
             let firstNodeHostname = clusterFirstNodeHostname!
             let firstNodePort = clusterFirstNodePort ?? 6379
-            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort, tls: false)], logger: logger) {
+            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) {
                 client in
                 try await ClusterIntegrationTests.withKey(connection: client, suffix: "{foo}") { key in
                     let node = try await client.nodeClient(for: [HashSlot(key: key)])
@@ -234,7 +234,7 @@ struct ClusterIntegrationTests {
             logger.logLevel = .trace
             let firstNodeHostname = clusterFirstNodeHostname!
             let firstNodePort = clusterFirstNodePort ?? 6379
-            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort, tls: false)], logger: logger) {
+            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) {
                 client in
                 try await ClusterIntegrationTests.withKey(connection: client, suffix: "{foo}") { key in
                     let hashSlot = HashSlot(key: key)
@@ -271,7 +271,7 @@ struct ClusterIntegrationTests {
             logger.logLevel = .trace
             let firstNodeHostname = clusterFirstNodeHostname!
             let firstNodePort = clusterFirstNodePort ?? 6379
-            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort, tls: false)], logger: logger) {
+            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) {
                 client in
                 try await ClusterIntegrationTests.withKey(connection: client, suffix: "{foo}") { key in
                     let hashSlot = HashSlot(key: key)
@@ -306,7 +306,7 @@ struct ClusterIntegrationTests {
             logger.logLevel = .trace
             let firstNodeHostname = clusterFirstNodeHostname!
             let firstNodePort = clusterFirstNodePort ?? 6379
-            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort, tls: false)], logger: logger) {
+            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) {
                 client in
                 try await ClusterIntegrationTests.withKey(connection: client, suffix: "{foo}") { key in
                     let hashSlot = HashSlot(key: key)
@@ -342,7 +342,7 @@ struct ClusterIntegrationTests {
             logger.logLevel = .trace
             let firstNodeHostname = clusterFirstNodeHostname!
             let firstNodePort = clusterFirstNodePort ?? 6379
-            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort, tls: false)], logger: logger) {
+            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) {
                 clusterClient in
                 try await ClusterIntegrationTests.withKey(connection: clusterClient) { key in
                     let node = try await clusterClient.nodeClient(for: [HashSlot(key: key)])
@@ -382,7 +382,7 @@ struct ClusterIntegrationTests {
             logger.logLevel = .trace
             let firstNodeHostname = clusterFirstNodeHostname!
             let firstNodePort = clusterFirstNodePort ?? 6379
-            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort, tls: false)], logger: logger) {
+            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) {
                 client in
                 let keySuffix = "{\(UUID().uuidString)}"
                 try await ClusterIntegrationTests.withKey(connection: client, suffix: keySuffix) { key in
@@ -417,7 +417,7 @@ struct ClusterIntegrationTests {
             logger.logLevel = .trace
             let firstNodeHostname = clusterFirstNodeHostname!
             let firstNodePort = clusterFirstNodePort ?? 6379
-            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort, tls: false)], logger: logger) {
+            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) {
                 client in
                 let keySuffix = "{\(UUID().uuidString)}"
                 try await ClusterIntegrationTests.withKey(connection: client, suffix: keySuffix) { key in
@@ -443,6 +443,41 @@ struct ClusterIntegrationTests {
             }
         }
 
+        @Test(arguments: [
+            // verify an array of commands with no keys all go to the same node
+            (commands: [LOLWUT(), LOLWUT(), LOLWUT()], selection: [[0, 1, 2]]),
+            // verify an array of commands which starts with entries with no keys all go to the same node as the
+            // first that does affect a key
+            (commands: [any ValkeyCommand](commands: LOLWUT(), LOLWUT(), GET("foo")), selection: [[0, 1, 2]]),
+            // verify that commands that affect keys in different shards get broken up. This test makes the assumption that
+            // foo and baz are in different shards
+            (commands: [any ValkeyCommand](commands: LOLWUT(), GET("foo"), GET("baz")), selection: [[0, 1], [2]]),
+            // verify that a command has no key that follows a command that does goes to the same node
+            (commands: [any ValkeyCommand](commands: GET("foo"), LOLWUT(), GET("baz"), LOLWUT()), selection: [[0, 1], [2, 3]]),
+            // verify that commands that affect same node go to the same regardless of order
+            (commands: [any ValkeyCommand](commands: GET("foo"), GET("baz"), GET("foo")), selection: [[0, 2], [1]]),
+        ])
+        @available(valkeySwift 1.0, *)
+        func testNodeSelection(values: (commands: [any ValkeyCommand], selection: [[Int]])) async throws {
+            var logger = Logger(label: "ValkeyCluster")
+            logger.logLevel = .trace
+            let firstNodeHostname = clusterFirstNodeHostname!
+            let firstNodePort = clusterFirstNodePort ?? 6379
+            try await ClusterIntegrationTests.withValkeyCluster(
+                [(host: firstNodeHostname, port: firstNodePort)],
+                logger: logger
+            ) { client in
+                let nodesAndIndices = try await client.splitCommandsAcrossNodes(commands: values.commands)
+                #expect(nodesAndIndices.count == values.selection.count)
+                let sortedNodeAndIndics = nodesAndIndices.sorted { $0.commandIndices[0] < $1.commandIndices[0] }
+                var iterator = sortedNodeAndIndics.makeIterator()
+                var expectedIterator = values.selection.makeIterator()
+                while let result = iterator.next() {
+                    #expect(result.commandIndices == expectedIterator.next())
+                }
+            }
+        }
+
         @Test
         @available(valkeySwift 1.0, *)
         func testClientPipeline() async throws {
@@ -450,7 +485,7 @@ struct ClusterIntegrationTests {
             logger.logLevel = .trace
             let firstNodeHostname = clusterFirstNodeHostname!
             let firstNodePort = clusterFirstNodePort ?? 6379
-            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort, tls: false)], logger: logger) {
+            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) {
                 client in
                 try await ClusterIntegrationTests.withKey(connection: client, suffix: "{foo}") { key in
                     var commands: [any ValkeyCommand] = .init()
@@ -470,22 +505,47 @@ struct ClusterIntegrationTests {
             logger.logLevel = .trace
             let firstNodeHostname = clusterFirstNodeHostname!
             let firstNodePort = clusterFirstNodePort ?? 6379
-            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort, tls: false)], logger: logger) {
+            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) {
                 client in
-                try await ClusterIntegrationTests.withKey(connection: client, suffix: "{foo}") { key in
-                    var commands: [any ValkeyCommand] = .init()
-                    for i in 0..<100 {
-                        let key = ValkeyKey("Test\(i)")
-                        commands.append(SET(key, value: String(i)))
-                        commands.append(GET(.init("Test\(i)")))
-                        commands.append(DEL(keys: [key]))
-                    }
-                    let results = try await client.execute(commands)
-                    let response = try results[1].get().decode(as: String.self)
-                    #expect(response == "0")
-                    let response2 = try results[7].get().decode(as: String.self)
-                    #expect(response2 == "2")
+                var commands: [any ValkeyCommand] = .init()
+                for i in 0..<100 {
+                    let key = ValkeyKey("Test\(i)")
+                    commands.append(SET(key, value: String(i)))
+                    commands.append(GET(key))
+                    commands.append(DEL(keys: [key]))
                 }
+                let results = try await client.execute(commands)
+                let response = try results[1].get().decode(as: String.self)
+                #expect(response == "0")
+                let response2 = try results[7].get().decode(as: String.self)
+                #expect(response2 == "2")
+            }
+        }
+
+        @Test
+        @available(valkeySwift 1.0, *)
+        func testClientPipelineMultipleNodesParameterPack() async throws {
+            var logger = Logger(label: "ValkeyCluster")
+            logger.logLevel = .trace
+            let firstNodeHostname = clusterFirstNodeHostname!
+            let firstNodePort = clusterFirstNodePort ?? 6379
+            try await ClusterIntegrationTests.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) {
+                client in
+                let results = try await client.execute(
+                    SET("test1", value: "1"),
+                    GET("test1"),
+                    DEL(keys: ["test1"]),
+                    SET("test2", value: "2"),
+                    GET("test2"),
+                    DEL(keys: ["test2"]),
+                    SET("test3", value: "3"),
+                    GET("test3"),
+                    DEL(keys: ["test3"])
+                )
+                let response = try results.1.get().map { String(buffer: $0) }
+                #expect(response == "1")
+                let response2 = try results.7.get().map { String(buffer: $0) }
+                #expect(response2 == "3")
             }
         }
     }
@@ -509,7 +569,7 @@ struct ClusterIntegrationTests {
 
     @available(valkeySwift 1.0, *)
     static func withValkeyCluster<T>(
-        _ nodeAddresses: [(host: String, port: Int, tls: Bool)],
+        _ nodeAddresses: [(host: String, port: Int)],
         nodeClientConfiguration: ValkeyClientConfiguration = .init(),
         logger: Logger,
         _ body: (ValkeyClusterClient) async throws -> sending T


### PR DESCRIPTION
Add ValkeyClusterClient.execute for pipelined commands
- Adds version that takes array of `ValkeyCommands`. This is split up into smaller arrays, one for each node which has keys affected by the commands. This is done in function `splitCommandsAcrossNodes`. Then concurrently calls the execute command introduced in #218 for each node affected.
- Also added a version of execute that takes a parameter pack and returns the correct response types. This converts the parameter pack into an array so does have some additional cost
- Tests added include 
  - checking commands are being split up correctly across nodes
  - pipeline runs correctly when only one node is used
  - pipeline runs correctly when multiple nodes are used