### PR TITLE
Add subscribe functions to ValkeyClientProtocol

### DIFF
--- a/Sources/Valkey/Commands/PubsubCommands.swift
+++ b/Sources/Valkey/Commands/PubsubCommands.swift
@@ -196,12 +196,12 @@ public struct SPUBLISH<Shardchannel: RESPStringRenderable, Message: RESPStringRe
 
 /// Listens for messages published to shard channels.
 @_documentation(visibility: internal)
-public struct SSUBSCRIBE<Shardchannel: RESPStringRenderable>: ValkeyCommand {
+public struct SSUBSCRIBE: ValkeyCommand {
     @inlinable public static var name: String { "SSUBSCRIBE" }
 
-    public var shardchannels: [Shardchannel]
+    public var shardchannels: [String]
 
-    @inlinable public init(shardchannels: [Shardchannel]) {
+    @inlinable public init(shardchannels: [String]) {
         self.shardchannels = shardchannels
     }
 
@@ -212,12 +212,12 @@ public struct SSUBSCRIBE<Shardchannel: RESPStringRenderable>: ValkeyCommand {
 
 /// Listens for messages published to channels.
 @_documentation(visibility: internal)
-public struct SUBSCRIBE<Channel: RESPStringRenderable>: ValkeyCommand {
+public struct SUBSCRIBE: ValkeyCommand {
     @inlinable public static var name: String { "SUBSCRIBE" }
 
-    public var channels: [Channel]
+    public var channels: [String]
 
-    @inlinable public init(channels: [Channel]) {
+    @inlinable public init(channels: [String]) {
         self.channels = channels
     }
 

--- a/Sources/Valkey/Subscriptions/ValkeyClient+subscribe.swift
+++ b/Sources/Valkey/Subscriptions/ValkeyClient+subscribe.swift
@@ -67,6 +67,12 @@ extension ValkeyClient {
         }
     }
 
+    /// Execute subscribe command and run closure using related ``ValkeySubscription``
+    /// AsyncSequence
+    ///
+    /// This should not be called directly, used the related commands
+    /// ``ValkeyClient/subscribe(to:isolation:process:)`` or
+    /// ``ValkeyClient/psubscribe(to:isolation:process:)``
     @inlinable
     public func _subscribe<Value>(
         command: some ValkeySubscribeCommand,

--- a/Sources/Valkey/Subscriptions/ValkeyClient+subscribe.swift
+++ b/Sources/Valkey/Subscriptions/ValkeyClient+subscribe.swift
@@ -69,13 +69,12 @@ extension ValkeyClient {
 
     @inlinable
     public func _subscribe<Value>(
-        command: some ValkeyCommand,
-        filters: [ValkeySubscriptionFilter],
+        command: some ValkeySubscribeCommand,
         isolation: isolated (any Actor)? = #isolation,
         process: (ValkeySubscription) async throws -> sending Value
     ) async throws -> sending Value {
         try await self.withSubscriptionConnection { connection in
-            try await connection._subscribe(command: command, filters: filters, isolation: isolation, process: process)
+            try await connection._subscribe(command: command, isolation: isolation, process: process)
         }
     }
 }

--- a/Sources/Valkey/Subscriptions/ValkeyClient+subscribe.swift
+++ b/Sources/Valkey/Subscriptions/ValkeyClient+subscribe.swift
@@ -37,98 +37,6 @@ extension ValkeyClient {
         return try await operation(connection)
     }
 
-    /// Subscribe to list of channels and run closure with subscription
-    ///
-    /// When the closure is exited the channels are automatically unsubscribed from.
-    ///
-    /// When running subscribe from `ValkeyClient` a single connection is used for
-    /// all subscriptions.
-    ///
-    /// - Parameters:
-    ///   - channels: list of channels to subscribe to
-    ///   - isolation: Actor isolation
-    ///   - process: Closure that is called with subscription async sequence
-    /// - Returns: Return value of closure
-    @inlinable
-    public func subscribe<Value>(
-        to channels: String...,
-        isolation: isolated (any Actor)? = #isolation,
-        process: (ValkeySubscription) async throws -> sending Value
-    ) async throws -> sending Value {
-        try await self.subscribe(to: channels, process: process)
-    }
-
-    @inlinable
-    /// Subscribe to list of channels and run closure with subscription
-    ///
-    /// When the closure is exited the channels are automatically unsubscribed from.
-    ///
-    /// When running subscribe from `ValkeyClient` a single connection is used for
-    /// all subscriptions.
-    ///
-    /// - Parameters:
-    ///   - channels: list of channels to subscribe to
-    ///   - isolation: Actor isolation
-    ///   - process: Closure that is called with subscription async sequence
-    /// - Returns: Return value of closure
-    public func subscribe<Value>(
-        to channels: [String],
-        isolation: isolated (any Actor)? = #isolation,
-        process: (ValkeySubscription) async throws -> sending Value
-    ) async throws -> sending Value {
-        try await self.subscribe(
-            command: SUBSCRIBE(channels: channels),
-            filters: channels.map { .channel($0) },
-            process: process
-        )
-    }
-
-    /// Subscribe to list of channel patterns and run closure with subscription
-    ///
-    /// When the closure is exited the patterns are automatically unsubscribed from.
-    ///
-    /// When running subscribe from `ValkeyClient` a single connection is used for
-    /// all subscriptions.
-    ///
-    /// - Parameters:
-    ///   - patterns: list of channel patterns to subscribe to
-    ///   - isolation: Actor isolation
-    ///   - process: Closure that is called with subscription async sequence
-    /// - Returns: Return value of closure
-    @inlinable
-    public func psubscribe<Value>(
-        to patterns: String...,
-        isolation: isolated (any Actor)? = #isolation,
-        process: (ValkeySubscription) async throws -> sending Value
-    ) async throws -> sending Value {
-        try await self.psubscribe(to: patterns, process: process)
-    }
-
-    /// Subscribe to list of pattern matching channels and run closure with subscription
-    ///
-    /// When the closure is exited the patterns are automatically unsubscribed from.
-    ///
-    /// When running subscribe from `ValkeyClient` a single connection is used for
-    /// all subscriptions.
-    ///
-    /// - Parameters:
-    ///   - patterns: list of channel patterns to subscribe to
-    ///   - isolation: Actor isolation
-    ///   - process: Closure that is called with subscription async sequence
-    /// - Returns: Return value of closure
-    @inlinable
-    public func psubscribe<Value>(
-        to patterns: [String],
-        isolation: isolated (any Actor)? = #isolation,
-        process: (ValkeySubscription) async throws -> sending Value
-    ) async throws -> sending Value {
-        try await self.subscribe(
-            command: PSUBSCRIBE(patterns: patterns),
-            filters: patterns.map { .pattern($0) },
-            process: process
-        )
-    }
-
     /// Subscribe to key invalidation channel required for client-side caching
     ///
     /// See https://valkey.io/topics/client-side-caching/ for more details. The `process`
@@ -160,14 +68,14 @@ extension ValkeyClient {
     }
 
     @inlinable
-    func subscribe<Value>(
+    public func _subscribe<Value>(
         command: some ValkeyCommand,
         filters: [ValkeySubscriptionFilter],
         isolation: isolated (any Actor)? = #isolation,
         process: (ValkeySubscription) async throws -> sending Value
     ) async throws -> sending Value {
         try await self.withSubscriptionConnection { connection in
-            try await connection.subscribe(command: command, filters: filters, process: process)
+            try await connection._subscribe(command: command, filters: filters, isolation: isolation, process: process)
         }
     }
 }

--- a/Sources/Valkey/Subscriptions/ValkeyClusterClient+subscribe.swift
+++ b/Sources/Valkey/Subscriptions/ValkeyClusterClient+subscribe.swift
@@ -67,6 +67,12 @@ extension ValkeyClusterClient {
         }
     }
 
+    /// Execute subscribe command and run closure using related ``ValkeySubscription``
+    /// AsyncSequence
+    ///
+    /// This should not be called directly, used the related commands
+    /// ``ValkeyClusterClient/subscribe(to:isolation:process:)`` or
+    /// ``ValkeyClusterClient/psubscribe(to:isolation:process:)``
     @inlinable
     public func _subscribe<Value>(
         command: some ValkeySubscribeCommand,

--- a/Sources/Valkey/Subscriptions/ValkeyClusterClient+subscribe.swift
+++ b/Sources/Valkey/Subscriptions/ValkeyClusterClient+subscribe.swift
@@ -37,98 +37,6 @@ extension ValkeyClusterClient {
         return try await operation(connection)
     }
 
-    /// Subscribe to list of channels and run closure with subscription
-    ///
-    /// When the closure is exited the channels are automatically unsubscribed from.
-    ///
-    /// When running subscribe from `ValkeyClient` a single connection is used for
-    /// all subscriptions.
-    ///
-    /// - Parameters:
-    ///   - channels: list of channels to subscribe to
-    ///   - isolation: Actor isolation
-    ///   - process: Closure that is called with subscription async sequence
-    /// - Returns: Return value of closure
-    @inlinable
-    public func subscribe<Value>(
-        to channels: String...,
-        isolation: isolated (any Actor)? = #isolation,
-        process: (ValkeySubscription) async throws -> sending Value
-    ) async throws -> sending Value {
-        try await self.subscribe(to: channels, process: process)
-    }
-
-    @inlinable
-    /// Subscribe to list of channels and run closure with subscription
-    ///
-    /// When the closure is exited the channels are automatically unsubscribed from.
-    ///
-    /// When running subscribe from `ValkeyClient` a single connection is used for
-    /// all subscriptions.
-    ///
-    /// - Parameters:
-    ///   - channels: list of channels to subscribe to
-    ///   - isolation: Actor isolation
-    ///   - process: Closure that is called with subscription async sequence
-    /// - Returns: Return value of closure
-    public func subscribe<Value>(
-        to channels: [String],
-        isolation: isolated (any Actor)? = #isolation,
-        process: (ValkeySubscription) async throws -> sending Value
-    ) async throws -> sending Value {
-        try await self.subscribe(
-            command: SUBSCRIBE(channels: channels),
-            filters: channels.map { .channel($0) },
-            process: process
-        )
-    }
-
-    /// Subscribe to list of channel patterns and run closure with subscription
-    ///
-    /// When the closure is exited the patterns are automatically unsubscribed from.
-    ///
-    /// When running subscribe from `ValkeyClient` a single connection is used for
-    /// all subscriptions.
-    ///
-    /// - Parameters:
-    ///   - patterns: list of channel patterns to subscribe to
-    ///   - isolation: Actor isolation
-    ///   - process: Closure that is called with subscription async sequence
-    /// - Returns: Return value of closure
-    @inlinable
-    public func psubscribe<Value>(
-        to patterns: String...,
-        isolation: isolated (any Actor)? = #isolation,
-        process: (ValkeySubscription) async throws -> sending Value
-    ) async throws -> sending Value {
-        try await self.psubscribe(to: patterns, process: process)
-    }
-
-    /// Subscribe to list of pattern matching channels and run closure with subscription
-    ///
-    /// When the closure is exited the patterns are automatically unsubscribed from.
-    ///
-    /// When running subscribe from `ValkeyClient` a single connection is used for
-    /// all subscriptions.
-    ///
-    /// - Parameters:
-    ///   - patterns: list of channel patterns to subscribe to
-    ///   - isolation: Actor isolation
-    ///   - process: Closure that is called with subscription async sequence
-    /// - Returns: Return value of closure
-    @inlinable
-    public func psubscribe<Value>(
-        to patterns: [String],
-        isolation: isolated (any Actor)? = #isolation,
-        process: (ValkeySubscription) async throws -> sending Value
-    ) async throws -> sending Value {
-        try await self.subscribe(
-            command: PSUBSCRIBE(patterns: patterns),
-            filters: patterns.map { .pattern($0) },
-            process: process
-        )
-    }
-
     /// Subscribe to key invalidation channel required for client-side caching
     ///
     /// See https://valkey.io/topics/client-side-caching/ for more details. The `process`
@@ -160,14 +68,14 @@ extension ValkeyClusterClient {
     }
 
     @inlinable
-    func subscribe<Value>(
+    public func _subscribe<Value>(
         command: some ValkeyCommand,
         filters: [ValkeySubscriptionFilter],
         isolation: isolated (any Actor)? = #isolation,
         process: (ValkeySubscription) async throws -> sending Value
     ) async throws -> sending Value {
         try await self.withSubscriptionConnection { connection in
-            try await connection.subscribe(command: command, filters: filters, process: process)
+            try await connection._subscribe(command: command, filters: filters, isolation: isolation, process: process)
         }
     }
 }

--- a/Sources/Valkey/Subscriptions/ValkeyClusterClient+subscribe.swift
+++ b/Sources/Valkey/Subscriptions/ValkeyClusterClient+subscribe.swift
@@ -69,13 +69,12 @@ extension ValkeyClusterClient {
 
     @inlinable
     public func _subscribe<Value>(
-        command: some ValkeyCommand,
-        filters: [ValkeySubscriptionFilter],
+        command: some ValkeySubscribeCommand,
         isolation: isolated (any Actor)? = #isolation,
         process: (ValkeySubscription) async throws -> sending Value
     ) async throws -> sending Value {
         try await self.withSubscriptionConnection { connection in
-            try await connection._subscribe(command: command, filters: filters, isolation: isolation, process: process)
+            try await connection._subscribe(command: command, isolation: isolation, process: process)
         }
     }
 }

--- a/Sources/Valkey/Subscriptions/ValkeyConnection+subscribe.swift
+++ b/Sources/Valkey/Subscriptions/ValkeyConnection+subscribe.swift
@@ -50,7 +50,6 @@ extension ValkeyConnection {
     ) async throws -> sending Value {
         try await self._subscribe(
             command: SSUBSCRIBE(shardchannels: shardchannels),
-            filters: shardchannels.map { .shardChannel($0) },
             isolation: isolation,
             process: process
         )
@@ -82,12 +81,11 @@ extension ValkeyConnection {
 
     @inlinable
     public func _subscribe<Value>(
-        command: some ValkeyCommand,
-        filters: [ValkeySubscriptionFilter],
+        command: some ValkeySubscribeCommand,
         isolation: isolated (any Actor)? = #isolation,
         process: (ValkeySubscription) async throws -> sending Value
     ) async throws -> sending Value {
-        let (id, stream) = try await subscribe(command: command, filters: filters)
+        let (id, stream) = try await subscribe(command: command, filters: command.filters)
         let value: Value
         do {
             value = try await process(stream)

--- a/Sources/Valkey/Subscriptions/ValkeyConnection+subscribe.swift
+++ b/Sources/Valkey/Subscriptions/ValkeyConnection+subscribe.swift
@@ -9,98 +9,6 @@ import NIOCore
 
 @available(valkeySwift 1.0, *)
 extension ValkeyConnection {
-    /// Subscribe to list of channels and run closure with subscription
-    ///
-    /// When the closure is exited the channels are automatically unsubscribed from. It is
-    /// possible to have multiple subscriptions running on the same connection and unsubscribe
-    /// commands will only be sent to Valkey when there are no subscriptions active for that
-    /// channel
-    ///
-    /// - Parameters:
-    ///   - channels: list of channels to subscribe to
-    ///   - isolation: Actor isolation
-    ///   - process: Closure that is called with subscription async sequence
-    /// - Returns: Return value of closure
-    @inlinable
-    public func subscribe<Value>(
-        to channels: String...,
-        isolation: isolated (any Actor)? = #isolation,
-        process: (ValkeySubscription) async throws -> sending Value
-    ) async throws -> sending Value {
-        try await self.subscribe(to: channels, process: process)
-    }
-
-    @inlinable
-    /// Subscribe to list of channels and run closure with subscription
-    ///
-    /// When the closure is exited the channels are automatically unsubscribed from. It is
-    /// possible to have multiple subscriptions running on the same connection and unsubscribe
-    /// commands will only be sent to Valkey when there are no subscriptions active for that
-    /// channel
-    ///
-    /// - Parameters:
-    ///   - channels: list of channels to subscribe to
-    ///   - isolation: Actor isolation
-    ///   - process: Closure that is called with subscription async sequence
-    /// - Returns: Return value of closure
-    public func subscribe<Value>(
-        to channels: [String],
-        isolation: isolated (any Actor)? = #isolation,
-        process: (ValkeySubscription) async throws -> sending Value
-    ) async throws -> sending Value {
-        try await self.subscribe(
-            command: SUBSCRIBE(channels: channels),
-            filters: channels.map { .channel($0) },
-            process: process
-        )
-    }
-
-    /// Subscribe to list of channel patterns and run closure with subscription
-    ///
-    /// When the closure is exited the patterns are automatically unsubscribed from. It is
-    /// possible to have multiple subscriptions running on the same connection and unsubscribe
-    /// commands will only be sent to Valkey when there are no subscriptions active for that
-    /// pattern
-    ///
-    /// - Parameters:
-    ///   - patterns: list of channel patterns to subscribe to
-    ///   - isolation: Actor isolation
-    ///   - process: Closure that is called with subscription async sequence
-    /// - Returns: Return value of closure
-    @inlinable
-    public func psubscribe<Value>(
-        to patterns: String...,
-        isolation: isolated (any Actor)? = #isolation,
-        process: (ValkeySubscription) async throws -> sending Value
-    ) async throws -> sending Value {
-        try await self.psubscribe(to: patterns, process: process)
-    }
-
-    /// Subscribe to list of pattern matching channels and run closure with subscription
-    ///
-    /// When the closure is exited the patterns are automatically unsubscribed from. It is
-    /// possible to have multiple subscriptions running on the same connection and unsubscribe
-    /// commands will only be sent to Valkey when there are no subscriptions active for that
-    /// pattern
-    ///
-    /// - Parameters:
-    ///   - patterns: list of channel patterns to subscribe to
-    ///   - isolation: Actor isolation
-    ///   - process: Closure that is called with subscription async sequence
-    /// - Returns: Return value of closure
-    @inlinable
-    public func psubscribe<Value>(
-        to patterns: [String],
-        isolation: isolated (any Actor)? = #isolation,
-        process: (ValkeySubscription) async throws -> sending Value
-    ) async throws -> sending Value {
-        try await self.subscribe(
-            command: PSUBSCRIBE(patterns: patterns),
-            filters: patterns.map { .pattern($0) },
-            process: process
-        )
-    }
-
     /// Subscribe to list of shard channels and run closure with subscription
     ///
     /// When the closure is exited the shard channels are automatically unsubscribed from. It is
@@ -140,9 +48,10 @@ extension ValkeyConnection {
         isolation: isolated (any Actor)? = #isolation,
         process: (ValkeySubscription) async throws -> sending Value
     ) async throws -> sending Value {
-        try await self.subscribe(
+        try await self._subscribe(
             command: SSUBSCRIBE(shardchannels: shardchannels),
             filters: shardchannels.map { .shardChannel($0) },
+            isolation: isolation,
             process: process
         )
     }
@@ -172,7 +81,7 @@ extension ValkeyConnection {
     }
 
     @inlinable
-    func subscribe<Value>(
+    public func _subscribe<Value>(
         command: some ValkeyCommand,
         filters: [ValkeySubscriptionFilter],
         isolation: isolated (any Actor)? = #isolation,

--- a/Sources/Valkey/Subscriptions/ValkeyConnection+subscribe.swift
+++ b/Sources/Valkey/Subscriptions/ValkeyConnection+subscribe.swift
@@ -79,6 +79,12 @@ extension ValkeyConnection {
         }
     }
 
+    /// Execute subscribe command and run closure using related ``ValkeySubscription``
+    /// AsyncSequence
+    ///
+    /// This should not be called directly, used the related commands
+    /// ``ValkeyConnection/subscribe(to:isolation:process:)`` or
+    /// ``ValkeyConnection/psubscribe(to:isolation:process:)``
     @inlinable
     public func _subscribe<Value>(
         command: some ValkeySubscribeCommand,

--- a/Sources/Valkey/Subscriptions/ValkeySubscribeCommand.swift
+++ b/Sources/Valkey/Subscriptions/ValkeySubscribeCommand.swift
@@ -1,0 +1,26 @@
+//
+// This source file is part of the valkey-swift project
+// Copyright (c) 2025 the valkey-swift project authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+public protocol ValkeySubscribeCommand: ValkeyCommand {
+    /// Array of subscription filters
+    var filters: [ValkeySubscriptionFilter] { get }
+}
+
+extension SUBSCRIBE: ValkeySubscribeCommand {
+    /// Channels as an array of subscription filters
+    public var filters: [ValkeySubscriptionFilter] { self.channels.map { .channel($0) } }
+}
+
+extension PSUBSCRIBE: ValkeySubscribeCommand {
+    /// Patterns as an array of subscription filters
+    public var filters: [ValkeySubscriptionFilter] { self.patterns.map { .pattern($0) } }
+}
+
+extension SSUBSCRIBE: ValkeySubscribeCommand {
+    /// Shard channels as an array of subscription filters
+    public var filters: [ValkeySubscriptionFilter] { self.shardchannels.map { .shardChannel($0) } }
+}

--- a/Sources/Valkey/Subscriptions/ValkeySubscribeCommand.swift
+++ b/Sources/Valkey/Subscriptions/ValkeySubscribeCommand.swift
@@ -5,6 +5,7 @@
 // See LICENSE.txt for license information
 // SPDX-License-Identifier: Apache-2.0
 //
+/// Protocol for command that initiates a subscription
 public protocol ValkeySubscribeCommand: ValkeyCommand {
     /// Array of subscription filters
     var filters: [ValkeySubscriptionFilter] { get }

--- a/Sources/Valkey/Subscriptions/ValkeySubscriptionFilter.swift
+++ b/Sources/Valkey/Subscriptions/ValkeySubscriptionFilter.swift
@@ -5,16 +5,14 @@
 // See LICENSE.txt for license information
 // SPDX-License-Identifier: Apache-2.0
 //
-@usableFromInline
-enum ValkeySubscriptionFilter: Equatable, Hashable, Sendable {
+public enum ValkeySubscriptionFilter: Equatable, Hashable, Sendable {
     case channel(String)
     case pattern(String)
     case shardChannel(String)
 }
 
 extension ValkeySubscriptionFilter: CustomStringConvertible {
-    @usableFromInline
-    var description: String {
+    public var description: String {
         switch self {
         case .channel(let string):
             "channel(\(string))"

--- a/Sources/Valkey/ValkeyClientProtocol.swift
+++ b/Sources/Valkey/ValkeyClientProtocol.swift
@@ -28,11 +28,12 @@ public protocol ValkeyClientProtocol: Sendable {
     /// - Returns: Array holding the RESPToken responses of all the commands
     func execute(_ commands: [any ValkeyCommand]) async -> sending [Result<RESPToken, Error>]
 
-    /// Execute subscribe command and run closure using related Subscription stream
+    /// Execute subscribe command and run closure using related ``ValkeySubscription``
+    /// AsyncSequence
     ///
     /// This should not be called directly, used the related commands
     /// ``ValkeyClientProtocol/subscribe(to:isolation:process:)`` or
-    /// ``ValkeyClientProtocol/psubscribe(to:isolation:process:)`
+    /// ``ValkeyClientProtocol/psubscribe(to:isolation:process:)``
     func _subscribe<Value>(
         command: some ValkeySubscribeCommand,
         isolation: isolated (any Actor)?,

--- a/Sources/Valkey/ValkeyClientProtocol.swift
+++ b/Sources/Valkey/ValkeyClientProtocol.swift
@@ -8,6 +8,7 @@
 /// A type that provides the ability to send a Valkey command and get a response.
 @available(valkeySwift 1.0, *)
 public protocol ValkeyClientProtocol: Sendable {
+    associatedtype Subscription: AsyncSequence<ValkeySubscriptionMessage, any Error>
     /// Send RESP command to Valkey connection
     /// - Parameter command: ValkeyCommand structure
     /// - Returns: The command response as defined in the ValkeyCommand
@@ -26,4 +27,109 @@ public protocol ValkeyClientProtocol: Sendable {
     /// - Parameter commands: Collection of ValkeyCommands
     /// - Returns: Array holding the RESPToken responses of all the commands
     func execute(_ commands: [any ValkeyCommand]) async -> sending [Result<RESPToken, Error>]
+
+    /// Execute subscribe command and run closure using related Subscription
+    func _subscribe<Value>(
+        command: some ValkeyCommand,
+        filters: [ValkeySubscriptionFilter],
+        isolation: isolated (any Actor)?,
+        process: (Subscription) async throws -> sending Value
+    ) async throws -> sending Value
+}
+
+@available(valkeySwift 1.0, *)
+extension ValkeyClientProtocol {
+    /// Subscribe to list of channels and run closure with subscription
+    ///
+    /// When the closure is exited the channels are automatically unsubscribed from. It is
+    /// possible to have multiple subscriptions running on the same connection and unsubscribe
+    /// commands will only be sent to Valkey when there are no subscriptions active for that
+    /// channel
+    ///
+    /// - Parameters:
+    ///   - channels: list of channels to subscribe to
+    ///   - isolation: Actor isolation
+    ///   - process: Closure that is called with subscription async sequence
+    /// - Returns: Return value of closure
+    @inlinable
+    public func subscribe<Value>(
+        to channels: String...,
+        isolation: isolated (any Actor)? = #isolation,
+        process: (Subscription) async throws -> sending Value
+    ) async throws -> sending Value {
+        try await self.subscribe(to: channels, isolation: isolation, process: process)
+    }
+
+    @inlinable
+    /// Subscribe to list of channels and run closure with subscription
+    ///
+    /// When the closure is exited the channels are automatically unsubscribed from. It is
+    /// possible to have multiple subscriptions running on the same connection and unsubscribe
+    /// commands will only be sent to Valkey when there are no subscriptions active for that
+    /// channel
+    ///
+    /// - Parameters:
+    ///   - channels: list of channels to subscribe to
+    ///   - isolation: Actor isolation
+    ///   - process: Closure that is called with subscription async sequence
+    /// - Returns: Return value of closure
+    public func subscribe<Value>(
+        to channels: [String],
+        isolation: isolated (any Actor)? = #isolation,
+        process: (Subscription) async throws -> sending Value
+    ) async throws -> sending Value {
+        try await self._subscribe(
+            command: SUBSCRIBE(channels: channels),
+            filters: channels.map { .channel($0) },
+            isolation: isolation,
+            process: process
+        )
+    }
+
+    /// Subscribe to list of channel patterns and run closure with subscription
+    ///
+    /// When the closure is exited the patterns are automatically unsubscribed from.
+    ///
+    /// When running subscribe from `ValkeyClient` a single connection is used for
+    /// all subscriptions.
+    ///
+    /// - Parameters:
+    ///   - patterns: list of channel patterns to subscribe to
+    ///   - isolation: Actor isolation
+    ///   - process: Closure that is called with subscription async sequence
+    /// - Returns: Return value of closure
+    @inlinable
+    public func psubscribe<Value>(
+        to patterns: String...,
+        isolation: isolated (any Actor)? = #isolation,
+        process: (Subscription) async throws -> sending Value
+    ) async throws -> sending Value {
+        try await self.psubscribe(to: patterns, isolation: isolation, process: process)
+    }
+
+    /// Subscribe to list of pattern matching channels and run closure with subscription
+    ///
+    /// When the closure is exited the patterns are automatically unsubscribed from.
+    ///
+    /// When running subscribe from `ValkeyClient` a single connection is used for
+    /// all subscriptions.
+    ///
+    /// - Parameters:
+    ///   - patterns: list of channel patterns to subscribe to
+    ///   - isolation: Actor isolation
+    ///   - process: Closure that is called with subscription async sequence
+    /// - Returns: Return value of closure
+    @inlinable
+    public func psubscribe<Value>(
+        to patterns: [String],
+        isolation: isolated (any Actor)? = #isolation,
+        process: (Subscription) async throws -> sending Value
+    ) async throws -> sending Value {
+        try await self._subscribe(
+            command: PSUBSCRIBE(patterns: patterns),
+            filters: patterns.map { .pattern($0) },
+            isolation: isolation,
+            process: process
+        )
+    }
 }

--- a/Sources/_ValkeyCommandsBuilder/ValkeyCommandsRender.swift
+++ b/Sources/_ValkeyCommandsBuilder/ValkeyCommandsRender.swift
@@ -384,8 +384,8 @@ extension String {
             typeName = name.commandTypeName
         }
         let conformance = "ValkeyCommand"
-        let disableGenericParameters = subscribeFunctions.contains(name)
-        let genericTypeParameters = disableGenericParameters ? genericTypeParameters(command.arguments) : ""
+        let enableGenericParameters = !subscribeFunctions.contains(name)
+        let genericTypeParameters = enableGenericParameters ? genericTypeParameters(command.arguments) : ""
         // Comment header
         self.appendCommandCommentHeader(command: command, name: name, tab: tab)
         self.append("\(tab)@_documentation(visibility: internal)\n")
@@ -407,7 +407,7 @@ extension String {
         // Command function
         var commandParametersString =
             arguments
-            .map { "\($0.swiftVariable): \(parameterType($0, names: [], scope: nil, isArray: true, genericStrings: !disableGenericParameters))" }
+            .map { "\($0.swiftVariable): \(parameterType($0, names: [], scope: nil, isArray: true, genericStrings: enableGenericParameters))" }
             .joined(separator: ", ")
         if arguments.first?.shouldRemoveArgumentLabel == true {
             commandParametersString = "_ \(commandParametersString)"
@@ -415,7 +415,7 @@ extension String {
         let commandArguments =
             if let subCommand {
                 ["\"\(commandName)\"", "\"\(subCommand)\""]
-                    + arguments.map { $0.respRepresentable(isArray: true, genericString: !disableGenericParameters) }
+                    + arguments.map { $0.respRepresentable(isArray: true, genericString: enableGenericParameters) }
             } else {
                 ["\"\(commandName)\""] + arguments.map { $0.respRepresentable(isArray: true, genericString: true) }
             }
@@ -428,7 +428,7 @@ extension String {
         if arguments.count > 0 {
             for arg in arguments {
                 self.append(
-                    "\(tab)    public var \(arg.swiftVariable): \(variableType(arg, names: [], scope: nil, isArray: true, genericStrings: !disableGenericParameters))\n"
+                    "\(tab)    public var \(arg.swiftVariable): \(variableType(arg, names: [], scope: nil, isArray: true, genericStrings: enableGenericParameters))\n"
                 )
             }
             self.append("\n")

--- a/Sources/_ValkeyCommandsBuilder/ValkeyCommandsRender.swift
+++ b/Sources/_ValkeyCommandsBuilder/ValkeyCommandsRender.swift
@@ -384,7 +384,8 @@ extension String {
             typeName = name.commandTypeName
         }
         let conformance = "ValkeyCommand"
-        let genericTypeParameters = genericTypeParameters(command.arguments)
+        let disableGenericParameters = subscribeFunctions.contains(name)
+        let genericTypeParameters = disableGenericParameters ? genericTypeParameters(command.arguments) : ""
         // Comment header
         self.appendCommandCommentHeader(command: command, name: name, tab: tab)
         self.append("\(tab)@_documentation(visibility: internal)\n")
@@ -406,14 +407,15 @@ extension String {
         // Command function
         var commandParametersString =
             arguments
-            .map { "\($0.swiftVariable): \(parameterType($0, names: [], scope: nil, isArray: true, genericStrings: true))" }
+            .map { "\($0.swiftVariable): \(parameterType($0, names: [], scope: nil, isArray: true, genericStrings: !disableGenericParameters))" }
             .joined(separator: ", ")
         if arguments.first?.shouldRemoveArgumentLabel == true {
             commandParametersString = "_ \(commandParametersString)"
         }
         let commandArguments =
             if let subCommand {
-                ["\"\(commandName)\"", "\"\(subCommand)\""] + arguments.map { $0.respRepresentable(isArray: true, genericString: true) }
+                ["\"\(commandName)\"", "\"\(subCommand)\""]
+                    + arguments.map { $0.respRepresentable(isArray: true, genericString: !disableGenericParameters) }
             } else {
                 ["\"\(commandName)\""] + arguments.map { $0.respRepresentable(isArray: true, genericString: true) }
             }
@@ -426,7 +428,7 @@ extension String {
         if arguments.count > 0 {
             for arg in arguments {
                 self.append(
-                    "\(tab)    public var \(arg.swiftVariable): \(variableType(arg, names: [], scope: nil, isArray: true, genericStrings: true))\n"
+                    "\(tab)    public var \(arg.swiftVariable): \(variableType(arg, names: [], scope: nil, isArray: true, genericStrings: !disableGenericParameters))\n"
                 )
             }
             self.append("\n")


### PR DESCRIPTION
- Add `_subscribe` functions to `ValkeyClientProtocol`
- Extend `ValkeyClientProtocol` to include `subscribe` and `psubscribe` commands. Any thing that conforms to `ValkeyClientProtocol` will now get these for free.
- Add new protocol `ValkeySubscribeCommand` which add additional requirement `filters` which returns a list of the subcribe command channel filters.
- Extend `SUBSCRIBE`, `PSUBSCRIBE` and `SSUBSCRIBE` to conform to `ValkeySubscribeCommand`