### PR TITLE
fix: Avoids compiler crash on open source MacOS

### DIFF
--- a/Sources/Valkey/Cluster/ValkeyClusterClient.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClient.swift
@@ -485,7 +485,7 @@ public final class ValkeyClusterClient: Sendable {
     /// These array of indices are then used to create collections of commands to
     /// run on each node
     @usableFromInline
-    func splitCommandsAcrossNodes(commands: [any ValkeyCommand]) async throws -> some Collection<NodeAndCommands> {
+    func splitCommandsAcrossNodes(commands: [any ValkeyCommand]) async throws -> [ValkeyServerAddress: NodeAndCommands].Values {
         var nodeMap: [ValkeyServerAddress: NodeAndCommands] = [:]
         var index = commands.startIndex
         var prevAddress: ValkeyServerAddress? = nil


### PR DESCRIPTION
This resolves a compiler crasher on open-source 6.1 and 6.2 toolchains on MacOS. There was apparently some resolution problem with `some Collection<NodeAndCommands>` that was fixed by making the type concrete `[ValkeyServerAddress: NodeAndCommands].Values`. This function is internal and only used in one call site, which required no changes. 

Closes #250 