### PR TITLE
Fix `CLIENT TRACKING` command format for multiple prefixes

### DIFF
--- a/Sources/Valkey/Commands/ConnectionCommands.swift
+++ b/Sources/Valkey/Commands/ConnectionCommands.swift
@@ -776,7 +776,7 @@ extension CLIENT {
                 "TRACKING",
                 status,
                 RESPWithToken("REDIRECT", clientId),
-                RESPWithToken("PREFIX", prefixes),
+                prefixes.map { RESPWithToken("PREFIX", $0) },
                 RESPPureToken("BCAST", bcast),
                 RESPPureToken("OPTIN", optin),
                 RESPPureToken("OPTOUT", optout),


### PR DESCRIPTION
When using `CLIENT TRACKING` with multiple prefixes, the generated Valkey command has invalid syntax.

The current implementation works fine for a single prefix, but fails with multiple prefixes. Valkey expects the format `PREFIX prefix1 PREFIX prefix2` (each prefix needs its own `PREFIX` keyword), which causes a syntax error with our current approach.

See: [valkey.io/commands/client-tracking/](https://valkey.io/commands/client-tracking/)