### PR TITLE
Command array arguments that render with a token for each element

### DIFF
--- a/Sources/Valkey/Commands/BitmapCommands.swift
+++ b/Sources/Valkey/Commands/BitmapCommands.swift
@@ -306,7 +306,7 @@ public struct BITFIELDRO: ValkeyCommand {
     public var isReadOnly: Bool { true }
 
     @inlinable public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-        commandEncoder.encodeArray("BITFIELD_RO", key, RESPWithToken("GET", getBlocks))
+        commandEncoder.encodeArray("BITFIELD_RO", key, RESPArrayWithToken("GET", getBlocks))
     }
 }
 

--- a/Sources/Valkey/Commands/ConnectionCommands.swift
+++ b/Sources/Valkey/Commands/ConnectionCommands.swift
@@ -776,7 +776,7 @@ extension CLIENT {
                 "TRACKING",
                 status,
                 RESPWithToken("REDIRECT", clientId),
-                RESPWithToken("PREFIX", prefixes),
+                RESPArrayWithToken("PREFIX", prefixes),
                 RESPPureToken("BCAST", bcast),
                 RESPPureToken("OPTIN", optin),
                 RESPPureToken("OPTOUT", optout),

--- a/Sources/Valkey/Commands/GenericCommands.swift
+++ b/Sources/Valkey/Commands/GenericCommands.swift
@@ -836,7 +836,7 @@ public struct SORT: ValkeyCommand {
             key,
             RESPWithToken("BY", byPattern),
             RESPWithToken("LIMIT", limit),
-            RESPWithToken("GET", getPatterns),
+            RESPArrayWithToken("GET", getPatterns),
             order,
             RESPPureToken("ALPHA", sorting),
             RESPWithToken("STORE", destination)
@@ -920,7 +920,7 @@ public struct SORTRO: ValkeyCommand {
             key,
             RESPWithToken("BY", byPattern),
             RESPWithToken("LIMIT", limit),
-            RESPWithToken("GET", getPatterns),
+            RESPArrayWithToken("GET", getPatterns),
             order,
             RESPPureToken("ALPHA", sorting)
         )

--- a/Sources/Valkey/Commands/HashCommands.swift
+++ b/Sources/Valkey/Commands/HashCommands.swift
@@ -807,7 +807,6 @@ public struct HRANDFIELD: ValkeyCommand {
             RESPPureToken("WITHVALUES", withvalues).encode(into: &commandEncoder)
         }
     }
-
     @inlinable public static var name: String { "HRANDFIELD" }
 
     public var key: ValkeyKey

--- a/Sources/Valkey/Commands/ServerCommands.swift
+++ b/Sources/Valkey/Commands/ServerCommands.swift
@@ -944,7 +944,7 @@ public enum MODULE {
         }
 
         @inlinable public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-            commandEncoder.encodeArray("MODULE", "LOADEX", RESPBulkString(path), RESPWithToken("CONFIG", configs), RESPWithToken("ARGS", args))
+            commandEncoder.encodeArray("MODULE", "LOADEX", RESPBulkString(path), RESPArrayWithToken("CONFIG", configs), RESPWithToken("ARGS", args))
         }
     }
 

--- a/Sources/Valkey/RESP/RESPRenderableHelpers.swift
+++ b/Sources/Valkey/RESP/RESPRenderableHelpers.swift
@@ -58,6 +58,31 @@ package struct RESPWithToken<Value: RESPRenderable>: RESPRenderable {
 }
 
 @usableFromInline
+package struct RESPArrayWithToken<Element: RESPRenderable>: RESPRenderable {
+    @usableFromInline
+    let array: [Element]
+    @usableFromInline
+    let token: String
+
+    @inlinable
+    package init(_ token: String, _ array: [Element]) {
+        self.array = array
+        self.token = token
+    }
+    @inlinable
+    package var respEntries: Int {
+        self.array.respEntries + self.array.count
+    }
+    @inlinable
+    package func encode(into commandEncoder: inout ValkeyCommandEncoder) {
+        for element in self.array {
+            token.encode(into: &commandEncoder)
+            element.encode(into: &commandEncoder)
+        }
+    }
+}
+
+@usableFromInline
 package struct RESPArrayWithCount<Element: RESPRenderable>: RESPRenderable {
     @usableFromInline
     let array: [Element]

--- a/Sources/_ValkeyCommandsBuilder/ValkeyCommandJSON.swift
+++ b/Sources/_ValkeyCommandsBuilder/ValkeyCommandJSON.swift
@@ -32,9 +32,10 @@ struct ValkeyCommand: Decodable {
     struct InternalArgument: Decodable {
         let name: String
         let type: ArgumentType
-        let multiple: Bool?
-        let optional: Bool?
+        let multiple: Bool
+        let optional: Bool
         let token: String?
+        let multipleToken: Bool
         let arguments: [Argument]?
         let keySpecIndex: Int?
 
@@ -51,6 +52,7 @@ struct ValkeyCommand: Decodable {
             }
             self.multiple = multiple
             self.optional = try container.decodeIfPresent(Bool.self, forKey: .optional) ?? false
+            self.multipleToken = try container.decodeIfPresent(Bool.self, forKey: .multipleToken) ?? false
             var token = try container.decodeIfPresent(String.self, forKey: .token)
             if token == "\"\"" {
                 token = ""
@@ -66,6 +68,7 @@ struct ValkeyCommand: Decodable {
             case multiple
             case optional
             case token
+            case multipleToken = "multiple_token"
             case arguments
             case keySpecIndex = "key_spec_index"
         }
@@ -75,6 +78,7 @@ struct ValkeyCommand: Decodable {
         let type: ArgumentType
         let multiple: Bool
         let optional: Bool
+        let multipleToken: Bool
         let token: String?
         let arguments: [Argument]?
         let combinedWithCount: Bool?
@@ -82,8 +86,9 @@ struct ValkeyCommand: Decodable {
         init(argument: InternalArgument, keySpec: KeySpec?) {
             self.name = argument.name
             self.type = argument.type
-            self.multiple = argument.multiple ?? false
-            self.optional = argument.optional ?? false
+            self.multiple = argument.multiple
+            self.optional = argument.optional
+            self.multipleToken = argument.multipleToken
             self.token = argument.token
             self.arguments = argument.arguments
             self.combinedWithCount =
@@ -107,6 +112,7 @@ struct ValkeyCommand: Decodable {
             }
             self.multiple = multiple
             self.optional = try container.decodeIfPresent(Bool.self, forKey: .optional) ?? false
+            self.multipleToken = try container.decodeIfPresent(Bool.self, forKey: .multipleToken) ?? false
             var token = try container.decodeIfPresent(String.self, forKey: .token)
             if token == "\"\"" {
                 token = ""
@@ -121,6 +127,7 @@ struct ValkeyCommand: Decodable {
             case type
             case multiple
             case optional
+            case multipleToken = "multiple_token"
             case token
             case arguments
         }

--- a/Sources/_ValkeyCommandsBuilder/ValkeyCommandsRender.swift
+++ b/Sources/_ValkeyCommandsBuilder/ValkeyCommandsRender.swift
@@ -29,6 +29,7 @@ private let disableResponseCalculationCommands: Set<String> = [
     "GEODIST",
     "GEOPOS",
     "GEOSEARCH",
+    "HRANDFIELD",
     "HSCAN",
     "ROLE",
     "LMOVE",
@@ -847,8 +848,12 @@ extension ValkeyCommand.Argument {
                 }
             }
             if let token = self.token {
-                return "RESPWithToken(\"\(token)\", \(variable))"
-            } else if multiple, combinedWithCount == true {
+                if self.multiple, self.multipleToken {
+                    return "RESPArrayWithToken(\"\(token)\", \(variable))"
+                } else {
+                    return "RESPWithToken(\"\(token)\", \(variable))"
+                }
+            } else if self.multiple, self.combinedWithCount == true {
                 if isArray {
                     return "RESPArrayWithCount(\(variable))"
                 } else {

--- a/Tests/ValkeyTests/CommandTests.swift
+++ b/Tests/ValkeyTests/CommandTests.swift
@@ -15,6 +15,31 @@ import Valkey
 ///
 /// Generally the commands being tested here are ones we have written custom responses for
 struct CommandTests {
+    struct ConnectionCommands {
+        @Test
+        @available(valkeySwift 1.0, *)
+        func clientTracking() async throws {
+            try await testCommandEncodesDecodes(
+                (
+                    request: .command(["CLIENT", "TRACKING", "OFF"]),
+                    response: .simpleString("OK")
+                ),
+                (
+                    request: .command(["CLIENT", "TRACKING", "ON", "REDIRECT", "25", "PREFIX", "test"]),
+                    response: .simpleString("OK")
+                ),
+                (
+                    request: .command(["CLIENT", "TRACKING", "ON", "REDIRECT", "25", "PREFIX", "test", "PREFIX", "this"]),
+                    response: .simpleString("OK")
+                )
+            ) { connection in
+                try await connection.clientTracking(status: .off)
+                try await connection.clientTracking(status: .on, clientId: 25, prefixes: ["test"])
+                try await connection.clientTracking(status: .on, clientId: 25, prefixes: ["test", "this"])
+            }
+        }
+    }
+
     struct ScriptCommands {
         @Test
         @available(valkeySwift 1.0, *)

--- a/Tests/ValkeyTests/RESPTokenRenderableTests.swift
+++ b/Tests/ValkeyTests/RESPTokenRenderableTests.swift
@@ -39,6 +39,18 @@ struct RESPTokenRenderableTests {
     }
 
     @Test
+    func testRESPArrayWithTokens() async throws {
+        var commandEncoder = ValkeyCommandEncoder()
+        var commandEncoder2 = ValkeyCommandEncoder()
+        RESPArrayWithToken("test", ["john", "jane"]).encode(into: &commandEncoder)
+        "test".encode(into: &commandEncoder2)
+        "john".encode(into: &commandEncoder2)
+        "test".encode(into: &commandEncoder2)
+        "jane".encode(into: &commandEncoder2)
+        #expect(String(buffer: commandEncoder.buffer) == String(buffer: commandEncoder2.buffer))
+    }
+
+    @Test
     func testRESPArrayWithCount() async throws {
         var commandEncoder = ValkeyCommandEncoder()
         var commandEncoder2 = ValkeyCommandEncoder()


### PR DESCRIPTION
- Add RESPArrayWithToken that renders each element with token prefix
- Use RESPArrayWithToken for elements with flag `multiple_token`
- Use `CLIENT TRACKING` to test this