### PR TITLE
Error cleanup

### DIFF
--- a/Sources/Valkey/Cluster/ValkeyClusterClient.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClient.swift
@@ -187,7 +187,7 @@ public final class ValkeyClusterClient: Sendable {
                 }
             }
         }
-        throw ValkeyClusterError.clientRequestCancelled
+        throw ValkeyClientError(.cancelled)
     }
 
     /// Pipeline a series of commands to nodes in the Valkey cluster
@@ -284,7 +284,7 @@ public final class ValkeyClusterClient: Sendable {
                     }
                 }
                 var results = [Result<RESPToken, any Error>](
-                    repeating: .failure(ValkeyClusterError.pipelinedResultNotReturned),
+                    repeating: .failure(ValkeyClusterError._pipelinedResultNotReturned),
                     count: commands.count
                 )
                 // get results for each node
@@ -380,7 +380,7 @@ public final class ValkeyClusterClient: Sendable {
                 }
             }
         }
-        throw ValkeyClusterError.clientRequestCancelled
+        throw ValkeyClientError(.cancelled)
     }
 
     struct Redirection {
@@ -459,7 +459,7 @@ public final class ValkeyClusterClient: Sendable {
             }
             retryCommands.removeAll(keepingCapacity: true)
         }
-        throw ValkeyClusterError.clientRequestCancelled
+        throw ValkeyClientError(.cancelled)
     }
 
     /// Get connection from cluster and run operation using connection
@@ -856,7 +856,7 @@ public final class ValkeyClusterClient: Sendable {
                     stateMachine.cancelWaitingForHealthy(id: waiterID)
                 }
 
-                continuation?.resume(throwing: ValkeyClusterError.clientRequestCancelled)
+                continuation?.resume(throwing: ValkeyClientError(.cancelled))
             }
         }
 

--- a/Sources/Valkey/Cluster/ValkeyClusterError.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterError.swift
@@ -54,11 +54,9 @@ public struct ValkeyClusterError: Error, Equatable {
     static public var clusterHasNoNodes: Self { .init(.clusterHasNoNodes) }
     /// Cluster client is shutdown
     static public var clusterClientIsShutDown: Self { .init(.clusterClientIsShutDown) }
-    /// Request was cancelled
-    static public var clientRequestCancelled: Self { .init(.clientRequestCancelled) }
     /// Wait for discovery failed three times after receiving a MOVED error
     static public var waitedForDiscoveryAfterMovedErrorThreeTimes: Self { .init(.waitedForDiscoveryAfterMovedErrorThreeTimes) }
     /// Pipelined result not returned. If you receive this, it is an internal error and should be reported as a bug
-    static public var pipelinedResultNotReturned: Self { .init(.pipelinedResultNotReturned) }
+    static public var _pipelinedResultNotReturned: Self { .init(.pipelinedResultNotReturned) }
 
 }

--- a/Sources/Valkey/Connection/ValkeyConnection.swift
+++ b/Sources/Valkey/Connection/ValkeyConnection.swift
@@ -807,11 +807,8 @@ extension ValkeyClientError {
     /// - SeeAlso: [](https://valkey.io/topics/protocol/#simple-errors)
     @usableFromInline
     var simpleErrorPrefix: Substring? {
-        guard let message else { return nil }
-        var prefixEndIndex = message.startIndex
-        while prefixEndIndex < message.endIndex, message[prefixEndIndex] != " " {
-            message.formIndex(after: &prefixEndIndex)
-        }
+        guard case .commandError = self.errorCode, let message else { return nil }
+        guard let prefixEndIndex = message.firstIndex(of: " ") else { return nil }
         return message[message.startIndex..<prefixEndIndex]
     }
 }

--- a/Sources/Valkey/ValkeyClientError.swift
+++ b/Sources/Valkey/ValkeyClientError.swift
@@ -20,6 +20,7 @@ public struct ValkeyClientError: Error, CustomStringConvertible, Equatable {
             case cancelled
             case connectionClosedDueToCancellation
             case timeout
+            case clientIsShutDown
         }
 
         fileprivate let value: _Internal
@@ -47,6 +48,8 @@ public struct ValkeyClientError: Error, CustomStringConvertible, Equatable {
         public static var connectionClosedDueToCancellation: Self { .init(.connectionClosedDueToCancellation) }
         /// Connection closed because it timed out.
         public static var timeout: Self { .init(.timeout) }
+        /// Client is shutdown.
+        public static var clientIsShutDown: Self { .init(.clientIsShutDown) }
     }
 
     /// The error code
@@ -74,6 +77,7 @@ public struct ValkeyClientError: Error, CustomStringConvertible, Equatable {
         case .cancelled: self.message ?? "Task was cancelled."
         case .connectionClosedDueToCancellation: self.message ?? "Connection was closed because another command was cancelled."
         case .timeout: self.message ?? "Connection was closed because it timed out."
+        case .clientIsShutDown: self.message ?? "Client is shutdown and not serving requests."
         }
     }
 }


### PR DESCRIPTION
- Merge ValkeyClientError(.cancelled) and ValkeyClusterError.clientRequestCancelled
- Add ValkeyClientError(.clientIsShutdown) and catch ConnectionPoolError and convert to ValkeyClientError
- Tidy ValkeyClientError.simpleErrorPrefix