### PR TITLE
Remove slave commands, fixed up issues with generated code

### DIFF
--- a/Sources/Valkey/Commands/ClusterCommands.swift
+++ b/Sources/Valkey/Commands/ClusterCommands.swift
@@ -682,24 +682,6 @@ public enum CLUSTER {
         }
     }
 
-    /// Lists the replica nodes of a primary node.
-    @_documentation(visibility: internal)
-    public struct SLAVES<NodeId: RESPStringRenderable>: ValkeyCommand {
-        public typealias Response = RESPToken.Array
-
-        @inlinable public static var name: String { "CLUSTER SLAVES" }
-
-        public var nodeId: NodeId
-
-        @inlinable public init(nodeId: NodeId) {
-            self.nodeId = nodeId
-        }
-
-        @inlinable public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-            commandEncoder.encodeArray("CLUSTER", "SLAVES", RESPRenderableBulkString(nodeId))
-        }
-    }
-
     /// Return an array of slot usage statistics for slots assigned to the current node.
     @_documentation(visibility: internal)
     public struct SLOTSTATS: ValkeyCommand {
@@ -1113,7 +1095,7 @@ extension ValkeyClientProtocol {
     /// - Documentation: [CLUSTER NODES](https://valkey.io/commands/cluster-nodes)
     /// - Available: 3.0.0
     /// - Complexity: O(N) where N is the total number of Cluster nodes
-    /// - Response: ValkeyClusterNodes: Array of cluster node information.
+    /// - Response: [String]: The serialized cluster configuration.
     @inlinable
     @discardableResult
     public func clusterNodes() async throws -> CLUSTER.NODES.Response {
@@ -1125,10 +1107,10 @@ extension ValkeyClientProtocol {
     /// - Documentation: [CLUSTER REPLICAS](https://valkey.io/commands/cluster-replicas)
     /// - Available: 5.0.0
     /// - Complexity: O(N) where N is the number of replicas.
-    /// - Response: ValkeyClusterNodes: A list of replica nodes replicating from the specified primary node.
+    /// - Response: [Array]: A list of replica nodes replicating from the specified primary node provided in the same format used by CLUSTER NODES.
     @inlinable
     @discardableResult
-    public func clusterReplicas<NodeId: RESPStringRenderable>(nodeId: NodeId) async throws -> CLUSTER.REPLICAS.Response {
+    public func clusterReplicas<NodeId: RESPStringRenderable>(nodeId: NodeId) async throws -> CLUSTER.REPLICASResponse {
         try await execute(CLUSTER.REPLICAS(nodeId: nodeId))
     }
 
@@ -1196,19 +1178,6 @@ extension ValkeyClientProtocol {
     @discardableResult
     public func clusterShards() async throws -> CLUSTER.SHARDS.Response {
         try await execute(CLUSTER.SHARDS())
-    }
-
-    /// Lists the replica nodes of a primary node.
-    ///
-    /// - Documentation: [CLUSTER SLAVES](https://valkey.io/commands/cluster-slaves)
-    /// - Available: 3.0.0
-    /// - Deprecated since: 5.0.0. Replaced by `CLUSTER REPLICAS`.
-    /// - Complexity: O(N) where N is the number of replicas.
-    /// - Response: [Array]: A list of replica nodes replicating from the specified primary node.
-    @inlinable
-    @discardableResult
-    public func clusterSlaves<NodeId: RESPStringRenderable>(nodeId: NodeId) async throws -> RESPToken.Array {
-        try await execute(CLUSTER.SLAVES(nodeId: nodeId))
     }
 
     /// Return an array of slot usage statistics for slots assigned to the current node.

--- a/Sources/Valkey/Commands/Custom/ClusterCustomCommands.swift
+++ b/Sources/Valkey/Commands/Custom/ClusterCustomCommands.swift
@@ -7,6 +7,10 @@
 //
 import NIOCore
 
+extension CLUSTER {
+    public typealias REPLICASResponse = ValkeyClusterNodes
+}
+
 extension CLUSTER.GETKEYSINSLOT {
     public typealias Response = [ValkeyKey]
 }
@@ -40,12 +44,12 @@ extension CLUSTER.NODES {
 }
 
 extension CLUSTER.REPLICAS {
-    public typealias Response = ValkeyClusterNodes
+    public typealias Response = CLUSTER.REPLICASResponse
 }
 
 /// Response type for cluster node listing commands.
 ///
-/// Contains an array of cluster nodes from CLUSTER NODES, CLUSTER SLAVES, or CLUSTER REPLICAS responses.
+/// Contains an array of cluster nodes from CLUSTER NODES, CLUSTER REPLICAS responses.
 public struct ValkeyClusterNodes: Hashable, Sendable, RESPTokenDecodable {
     /// The array of cluster nodes
     public var nodes: [ValkeyClusterNode]
@@ -67,7 +71,7 @@ public struct ValkeyClusterNodes: Hashable, Sendable, RESPTokenDecodable {
             }
 
         case .array(let array):
-            // For CLUSTER SLAVES/REPLICAS response (array of bulk strings)
+            // For CLUSTER REPLICAS response (array of bulk strings)
             return try array.map { nodeToken throws(RESPDecodeError) in
                 let nodeString = try String(nodeToken)
                 return try ValkeyClusterNode.parseNodeLine(nodeString)
@@ -81,15 +85,15 @@ public struct ValkeyClusterNodes: Hashable, Sendable, RESPTokenDecodable {
 
 /// A single node entry from cluster node listing commands.
 ///
-/// Represents a node from CLUSTER NODES, CLUSTER SLAVES, or CLUSTER REPLICAS responses.
+/// Represents a node from CLUSTER NODES or CLUSTER REPLICAS responses.
 /// Each node contains information about its ID, endpoint, role, status, and assigned slots.
 public struct ValkeyClusterNode: Hashable, Sendable, RESPTokenDecodable {
     /// Individual node flag indicating the node's role or status
     public enum Flag: String, Sendable, Hashable, CaseIterable {
-        /// The node is a primary (master)
-        case master
-        /// The node is a replica (slave)
-        case slave
+        /// The node is a primary
+        case primary = "master"
+        /// The node is a replica
+        case replica = "slave"
         /// The node is myself
         case myself
         /// The node is in PFAIL state

--- a/Sources/Valkey/Commands/ServerCommands.swift
+++ b/Sources/Valkey/Commands/ServerCommands.swift
@@ -1496,82 +1496,6 @@ public struct SHUTDOWN: ValkeyCommand {
     }
 }
 
-/// Sets a server as a replica of another, or promotes it to being a primary.
-@_documentation(visibility: internal)
-public struct SLAVEOF: ValkeyCommand {
-    public struct ArgsHostPort: RESPRenderable, Sendable, Hashable {
-        public var host: String
-        public var port: Int
-
-        @inlinable
-        public init(host: String, port: Int) {
-            self.host = host
-            self.port = port
-        }
-
-        @inlinable
-        public var respEntries: Int {
-            host.respEntries + port.respEntries
-        }
-
-        @inlinable
-        public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-            host.encode(into: &commandEncoder)
-            port.encode(into: &commandEncoder)
-        }
-    }
-    public struct ArgsNoOne: RESPRenderable, Sendable, Hashable {
-
-        @inlinable
-        public init() {
-        }
-
-        @inlinable
-        public var respEntries: Int {
-            "NO".respEntries + "ONE".respEntries
-        }
-
-        @inlinable
-        public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-            "NO".encode(into: &commandEncoder)
-            "ONE".encode(into: &commandEncoder)
-        }
-    }
-    public enum Args: RESPRenderable, Sendable, Hashable {
-        case hostPort(ArgsHostPort)
-        case noOne
-
-        @inlinable
-        public var respEntries: Int {
-            switch self {
-            case .hostPort(let hostPort): hostPort.respEntries
-            case .noOne: ArgsNoOne().respEntries
-            }
-        }
-
-        @inlinable
-        public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-            switch self {
-            case .hostPort(let hostPort): hostPort.encode(into: &commandEncoder)
-            case .noOne: ArgsNoOne().encode(into: &commandEncoder)
-            }
-        }
-    }
-    public typealias Response = RESPBulkString
-
-    @inlinable public static var name: String { "SLAVEOF" }
-
-    public var args: Args
-
-    @inlinable public init(args: Args) {
-        self.args = args
-    }
-
-    @inlinable public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-        commandEncoder.encodeArray("SLAVEOF", args)
-    }
-}
-
 /// Swaps two databases.
 @_documentation(visibility: internal)
 public struct SWAPDB: ValkeyCommand {
@@ -2375,19 +2299,6 @@ extension ValkeyClientProtocol {
     @inlinable
     public func shutdown(abortSelector: SHUTDOWN.AbortSelector? = nil) async throws {
         _ = try await execute(SHUTDOWN(abortSelector: abortSelector))
-    }
-
-    /// Sets a server as a replica of another, or promotes it to being a primary.
-    ///
-    /// - Documentation: [SLAVEOF](https://valkey.io/commands/slaveof)
-    /// - Available: 1.0.0
-    /// - Deprecated since: 5.0.0. Replaced by `REPLICAOF`.
-    /// - Complexity: O(1)
-    /// - Response: [String]: SlaveOf status.
-    @inlinable
-    @discardableResult
-    public func slaveof(args: SLAVEOF.Args) async throws -> RESPBulkString {
-        try await execute(SLAVEOF(args: args))
     }
 
     /// Returns the slow log's entries.

--- a/Sources/_ValkeyCommandsBuilder/ValkeyCommandsRender.swift
+++ b/Sources/_ValkeyCommandsBuilder/ValkeyCommandsRender.swift
@@ -82,6 +82,12 @@ let connectionOnlyFunctionNames: Set<String> = [
     "CLIENT TRACKINGINFO",
 ]
 
+/// Skipped functions
+let skippedFunctions: Set<String> = [
+    "CLUSTER SLAVES",
+    "SLAVEOF",
+]
+
 func renderValkeyCommands(_ commands: [String: ValkeyCommand], fullCommandList: ValkeyCommands, module: Bool) -> String {
     var string = """
         //
@@ -135,6 +141,7 @@ func renderValkeyCommands(_ commands: [String: ValkeyCommand], fullCommandList: 
                 // if there is no function assume command is a container command
                 guard !namespaces.contains(key) || command.function != nil else { continue }
                 guard command.docFlags?.contains("SYSCMD") != true else { continue }
+                guard !skippedFunctions.contains(key) else { continue }
                 string.appendCommand(
                     command: command,
                     name: key,
@@ -151,6 +158,7 @@ func renderValkeyCommands(_ commands: [String: ValkeyCommand], fullCommandList: 
         // if there is no function assume command is a container command
         guard !namespaces.contains(key) || command.function != nil else { continue }
         guard command.docFlags?.contains("SYSCMD") != true else { continue }
+        guard !skippedFunctions.contains(key) else { continue }
         string.appendCommand(
             command: command,
             name: key,
@@ -164,7 +172,7 @@ func renderValkeyCommands(_ commands: [String: ValkeyCommand], fullCommandList: 
     keys.removeAll { subscribeFunctions.contains($0) }
 
     let connectionOnlyFunctions = commands.filter { connectionOnlyFunctionNames.contains($0.key) }
-    let clientProtocolFunctions = commands.filter { connectionOnlyFunctions[$0.key] == nil }
+    let clientProtocolFunctions = commands.filter { connectionOnlyFunctions[$0.key] == nil && !skippedFunctions.contains($0.key) }
 
     if clientProtocolFunctions.count > 0 {
         string.append("@available(valkeySwift 1.0, *)\n")

--- a/Tests/ValkeyTests/CommandTests.swift
+++ b/Tests/ValkeyTests/CommandTests.swift
@@ -65,7 +65,7 @@ struct CommandTests {
                     #expect(!clusterNode.nodeId.isEmpty)
                     #expect(!clusterNode.endpoint.isEmpty)
                     #expect(!clusterNode.flags.isEmpty)
-                    if clusterNode.flags.contains(ValkeyClusterNode.Flag.slave) {
+                    if clusterNode.flags.contains(ValkeyClusterNode.Flag.replica) {
                         #expect(clusterNode.primaryId != nil && !clusterNode.primaryId!.isEmpty)
                     } else {
                         #expect(clusterNode.primaryId == nil)


### PR DESCRIPTION
- Added list of commands that shouldn't be rendered
- Changed enum case names
- Fixed up issues with custom responses for generated code, where generated code had originally been edited