### PR TITLE
GEOSEARCH: Convert to array in initializer

### DIFF
--- a/Sources/Valkey/Commands/Custom/GeoCustomCommands.swift
+++ b/Sources/Valkey/Commands/Custom/GeoCustomCommands.swift
@@ -53,11 +53,19 @@ extension GEORADIUSRO {
 
 public struct GeoSearchEntries: RESPTokenDecodable, Sendable {
 
-    private let token: RESPToken
+    private let array: RESPToken.Array
 
     public init(_ token: RESPToken) throws {
-        self.token = token
+        switch token.value {
+        case .array(let array):
+            self.array = array
+        default:
+            throw RESPDecodeError.tokenMismatch(expected: [.array], token: token)
+        }
     }
+
+    /// Number of entries
+    public var count: Int { self.array.count }
 
     /// Decode the GEOSEARCH / GEORADIUS response entries based on the options used in the command.
     ///
@@ -65,12 +73,7 @@ public struct GeoSearchEntries: RESPTokenDecodable, Sendable {
     /// - Returns: An array of decoded ``Entry`` objects.
     /// - Throws: ``RESPDecodeError`` if the response cannot be decoded.
     public func decode(options: Set<Option>) throws -> [Entry] {
-        switch token.value {
-        case .array(let array):
-            return try array.map { try Entry.decode($0, options: options) }
-        default:
-            throw RESPDecodeError.tokenMismatch(expected: [.array], token: token)
-        }
+        try self.array.map { try Entry.decode($0, options: options) }
     }
 
     /// Options for GEOSEARCH / GEORADIUS command that affect the response structure.

--- a/Tests/IntegrationTests/CommandIntegrationTests.swift
+++ b/Tests/IntegrationTests/CommandIntegrationTests.swift
@@ -143,11 +143,13 @@ struct CommandIntegratedTests {
                 let geoSearchEntries = try await client.geosearch(
                     key,
                     from: .fromlonlat(.init(longitude: 0.0, latitude: 53.0)),
-                    by: .circle(.init(radius: 10000, unit: .mi)),
+                    by: .circle(.init(radius: 1000, unit: .mi)),
                     withcoord: true,
                     withdist: true,
                     withhash: true
                 )
+
+                #expect(geoSearchEntries.count == 2)
 
                 for entry in try geoSearchEntries.decode(options: [.withDist, .withHash, .withCoord]) {
                     #expect(!entry.member.isEmpty)


### PR DESCRIPTION
This allows for count to be available without decoding the entries