### PR TITLE
Cluster-wide multi-key MGET 

### DIFF
--- a/Sources/Valkey/Cluster/ValkeyClusterClient+MultiKeyCommands.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClient+MultiKeyCommands.swift
@@ -25,7 +25,7 @@ extension ValkeyClusterClient {
     ) async throws(ValkeyClientError) -> Command.Response {
         let keys = command.keysAffected
 
-        // Single-slot fast path
+        // Fast path for single slot or when there are no keys
         guard let partitions = partitionBySlot(keys: keys) else {
             return try await execute(command)
         }
@@ -33,10 +33,10 @@ extension ValkeyClusterClient {
         // Build one sub-command per slot
         let subCommands: [any ValkeyCommand] = partitions.map { command.createSubCommand(for: $0.indices) }
 
-        // Dispatch in parallel using the existing cross-node pipelining path.
+        // Dispatch in parallel using the existing cross-node pipelining path
         let rawResults = await self.execute(subCommands)
 
-        // Unwrap results and pair with original key indices for combineResults.
+        // Unwrap results and pair with original key indices for combineResults
         var slotResults: [(indices: [Int], result: RESPToken)] = []
         slotResults.reserveCapacity(partitions.count)
         for (i, partition) in partitions.enumerated() {

--- a/Sources/Valkey/Cluster/ValkeyClusterClient+MultiKeyCommands.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClient+MultiKeyCommands.swift
@@ -1,0 +1,108 @@
+//
+// This source file is part of the valkey-swift project
+// Copyright (c) 2025 the valkey-swift project authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@available(valkeySwift 1.0, *)
+extension ValkeyClusterClient {
+
+    // MARK: - Scatter-gather execute
+
+    /// Executes a multi-key command against the cluster using scatter-gather.
+    ///
+    /// Keys are partitioned by hash slot. One sub-command is dispatched per slot,
+    /// all slots are executed in parallel, and results are reassembled in the
+    /// original key order via ``ValkeyClusterMultiKeyCommand/assemble(originalKeyCount:slotResults:)``.
+    ///
+    /// - Parameter command: A command conforming to ``ValkeyClusterMultiKeyCommand``.
+    /// - Returns: The assembled command response in original key order.
+    /// - Throws: ``ValkeyClientError`` if execution on any node fails.
+    @inlinable
+    public func execute<Command: ValkeyClusterMultiKeyCommand>(
+        _ command: Command
+    ) async throws(ValkeyClientError) -> Command.Response {
+        let keys = command.keysAffected
+        let partitions = partitionBySlot(keys: keys)
+
+        // Build one sub-command per slot, cast to the type-erased protocol.
+        let subCommands: [any ValkeyCommand] = partitions.map { command.subCommand(for: $0.indices) }
+
+        // Dispatch in parallel using the existing cross-node pipelining path.
+        // Each sub-command contains only same-slot keys, so hashSlot() never
+        // throws keysInCommandRequireMultipleHashSlots for sub-commands.
+        let rawResults = await self.execute(subCommands)
+
+        // Map each raw Result<RESPToken, ValkeyClientError> to the typed Response.
+        let slotResults = partitions.enumerated().map { i, partition in
+            (indices: partition.indices, result: rawResults[i].convertFromRESP(to: Command.Response.self))
+        }
+
+        return try Command.assemble(originalKeyCount: keys.count, slotResults: slotResults)
+    }
+
+    // MARK: - Concrete mget / mset (shadow ValkeyClientProtocol extension methods)
+    //
+    // These concrete methods are preferred over the protocol-extension defaults
+    // for static dispatch on ValkeyClusterClient. They call execute(_:) which
+    // resolves — via static dispatch — to the constrained
+    // execute<Command: ValkeyClusterMultiKeyCommand> overload above, enabling
+    // transparent cross-slot scatter/gather.
+
+    /// Atomically returns the string values of one or more keys, transparently
+    /// routing sub-commands across cluster nodes for keys in different hash slots.
+    ///
+    /// - Documentation: [MGET](https://valkey.io/commands/mget)
+    /// - Complexity: O(N) where N is the number of keys to retrieve.
+    /// - Parameter keys: The keys whose values to retrieve.
+    /// - Returns: A ``RESPToken/Array`` with values in the same order as `keys`.
+    ///   Null tokens represent absent keys.
+    /// - Throws: ``ValkeyClientError`` if any node fails.
+    @inlinable
+    public func mget(keys: [ValkeyKey]) async throws(ValkeyClientError) -> RESPToken.Array {
+        try await execute(MGET(keys: keys))
+    }
+
+    /// Sets the string values of one or more keys, transparently routing
+    /// sub-commands across cluster nodes for keys in different hash slots.
+    ///
+    /// - Documentation: [MSET](https://valkey.io/commands/mset)
+    /// - Complexity: O(N) where N is the number of keys to set.
+    /// - Important: Cross-slot `MSET` is **not atomic**. Keys on different nodes
+    ///   may be written at different times. Use hash tags to co-locate keys that
+    ///   need to be set atomically.
+    /// - Parameter data: Key-value pairs to set.
+    /// - Throws: ``ValkeyClientError`` if any node fails. Keys already written
+    ///   to other nodes are **not** rolled back.
+    @inlinable
+    public func mset<Value: RESPStringRenderable>(data: [MSET<Value>.Data]) async throws(ValkeyClientError) {
+        _ = try await execute(MSET(data: data))
+    }
+
+    // MARK: - Internal helpers
+
+    /// Groups key indices by hash slot, preserving insertion order of first occurrence.
+    ///
+    /// - Returns: An array of `(indices, slot)` pairs, one per unique slot, in the
+    ///   order the slots were first encountered while iterating `keys`.
+    @usableFromInline
+    /* private */ func partitionBySlot(
+        keys: some Collection<ValkeyKey>
+    ) -> [(indices: [Int], slot: HashSlot)] {
+        var slotOrder: [HashSlot] = []
+        var slotIndices: [HashSlot: [Int]] = [:]
+
+        for (i, key) in keys.enumerated() {
+            let slot = HashSlot(key: key)
+            if slotIndices[slot] == nil {
+                slotOrder.append(slot)
+                slotIndices[slot] = []
+            }
+            slotIndices[slot]!.append(i)
+        }
+
+        return slotOrder.map { (indices: slotIndices[$0]!, slot: $0) }
+    }
+}

--- a/Sources/Valkey/Cluster/ValkeyClusterClient+MultiKeyCommands.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClient+MultiKeyCommands.swift
@@ -20,26 +20,22 @@ extension ValkeyClusterClient {
     /// - Parameter command: A command conforming to ``ValkeyClusterMultiKeyCommand``.
     /// - Returns: The assembled command response in original key order.
     /// - Throws: ``ValkeyClientError`` if execution on any node fails.
-    @inlinable
-    public func execute<Command: ValkeyClusterMultiKeyCommand>(
+    package func execute<Command: ValkeyClusterMultiKeyCommand>(
         _ command: Command
     ) async throws(ValkeyClientError) -> Command.Response {
         let keys = command.keysAffected
+
         let partitions = partitionBySlot(keys: keys)
 
-        // Single-slot fast path: all keys hash to the same slot, so execute
-        // the original command directly via the standard code path.
-        // This avoids sub-command creation and result recombination.
+        // Single-slot fast path
         if partitions.count <= 1 {
             return try await executeSingleCommand(command)
         }
 
-        // Build one sub-command per slot, cast to the type-erased protocol.
+        // Build one sub-command per slot
         let subCommands: [any ValkeyCommand] = partitions.map { command.createSubCommand(for: $0.indices) }
 
         // Dispatch in parallel using the existing cross-node pipelining path.
-        // Each sub-command contains only same-slot keys, so hashSlot() never
-        // throws keysInCommandRequireMultipleHashSlots for sub-commands.
         let rawResults = await self.execute(subCommands)
 
         // Pair each raw result with its original key indices for combineResults.
@@ -67,7 +63,6 @@ extension ValkeyClusterClient {
     /// - Returns: A ``RESPToken/Array`` with values in the same order as `keys`.
     ///   Null tokens represent absent keys.
     /// - Throws: ``ValkeyClientError`` if any node fails.
-    @inlinable
     public func mget(keys: [ValkeyKey]) async throws(ValkeyClientError) -> RESPToken.Array {
         try await execute(MGET(keys: keys))
     }
@@ -80,8 +75,7 @@ extension ValkeyClusterClient {
     /// would otherwise recursively call itself — Swift overload resolution prefers
     /// the more constrained overload. Inside this helper the compiler only sees
     /// `Command: ValkeyCommand`, so it resolves to the base `execute` overload.
-    @usableFromInline
-    /* private */ func executeSingleCommand<Command: ValkeyCommand>(
+    private func executeSingleCommand<Command: ValkeyCommand>(
         _ command: Command
     ) async throws(ValkeyClientError) -> Command.Response {
         try await self.execute(command)
@@ -90,8 +84,7 @@ extension ValkeyClusterClient {
     /// Groups key indices by hash slot.
     ///
     /// - Returns: An array of `(slot, indices)` pairs, one per unique slot.
-    @usableFromInline
-    /* private */ func partitionBySlot(
+    private func partitionBySlot(
         keys: some Collection<ValkeyKey>
     ) -> [(slot: HashSlot, indices: [Int])] {
         var slotIndices: [HashSlot: [Int]] = [:]

--- a/Sources/Valkey/Cluster/ValkeyClusterClient+MultiKeyCommands.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClient+MultiKeyCommands.swift
@@ -15,7 +15,7 @@ extension ValkeyClusterClient {
     ///
     /// Keys are partitioned by hash slot. One sub-command is dispatched per slot,
     /// all slots are executed in parallel, and results are reassembled in the
-    /// original key order via ``ValkeyClusterMultiKeyCommand/assemble(originalKeyCount:slotResults:)``.
+    /// original key order via ``ValkeyClusterMultiKeyCommand/combineResults(originalKeyCount:slotResults:)``.
     ///
     /// - Parameter command: A command conforming to ``ValkeyClusterMultiKeyCommand``.
     /// - Returns: The assembled command response in original key order.

--- a/Sources/Valkey/Cluster/ValkeyClusterClient+MultiKeyCommands.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClient+MultiKeyCommands.swift
@@ -20,16 +20,14 @@ extension ValkeyClusterClient {
     /// - Parameter command: A command conforming to ``ValkeyClusterMultiKeyCommand``.
     /// - Returns: The assembled command response in original key order.
     /// - Throws: ``ValkeyClientError`` if execution on any node fails.
-    package func execute<Command: ValkeyClusterMultiKeyCommand>(
+    package func executeMultiKeyCommand<Command: ValkeyClusterMultiKeyCommand>(
         _ command: Command
     ) async throws(ValkeyClientError) -> Command.Response {
         let keys = command.keysAffected
 
-        let partitions = partitionBySlot(keys: keys)
-
         // Single-slot fast path
-        if partitions.count <= 1 {
-            return try await executeSingleCommand(command)
+        guard let partitions = partitionBySlot(keys: keys) else {
+            return try await execute(command)
         }
 
         // Build one sub-command per slot
@@ -38,62 +36,46 @@ extension ValkeyClusterClient {
         // Dispatch in parallel using the existing cross-node pipelining path.
         let rawResults = await self.execute(subCommands)
 
-        // Pair each raw result with its original key indices for combineResults.
-        let slotResults = partitions.enumerated().map { i, partition in
-            (indices: partition.indices, result: rawResults[i])
+        // Unwrap results and pair with original key indices for combineResults.
+        var slotResults: [(indices: [Int], result: RESPToken)] = []
+        slotResults.reserveCapacity(partitions.count)
+        for (i, partition) in partitions.enumerated() {
+            let token = try rawResults[i].get()
+            slotResults.append((indices: partition.indices, result: token))
         }
 
-        return try Command.combineResults(originalKeyCount: keys.count, slotResults: slotResults)
-    }
-
-    // MARK: - Concrete mget (shadow ValkeyClientProtocol extension method)
-    //
-    // This concrete method is preferred over the protocol-extension default
-    // for static dispatch on ValkeyClusterClient. It calls execute(_:) which
-    // resolves — via static dispatch — to the constrained
-    // execute<Command: ValkeyClusterMultiKeyCommand> overload above, enabling
-    // transparent cross-slot scatter/gather.
-
-    /// Atomically returns the string values of one or more keys, transparently
-    /// routing sub-commands across cluster nodes for keys in different hash slots.
-    ///
-    /// - Documentation: [MGET](https://valkey.io/commands/mget)
-    /// - Complexity: O(N) where N is the number of keys to retrieve.
-    /// - Parameter keys: The keys whose values to retrieve.
-    /// - Returns: A ``RESPToken/Array`` with values in the same order as `keys`.
-    ///   Null tokens represent absent keys.
-    /// - Throws: ``ValkeyClientError`` if any node fails.
-    public func mget(keys: [ValkeyKey]) async throws(ValkeyClientError) -> RESPToken.Array {
-        try await execute(MGET(keys: keys))
-    }
-
-    // MARK: - Internal helpers
-
-    /// Executes a single command via the standard ``ValkeyCommand`` code path.
-    ///
-    /// This trampoline exists because `execute<C: ValkeyClusterMultiKeyCommand>`
-    /// would otherwise recursively call itself — Swift overload resolution prefers
-    /// the more constrained overload. Inside this helper the compiler only sees
-    /// `Command: ValkeyCommand`, so it resolves to the base `execute` overload.
-    private func executeSingleCommand<Command: ValkeyCommand>(
-        _ command: Command
-    ) async throws(ValkeyClientError) -> Command.Response {
-        try await self.execute(command)
+        do {
+            return try Command.combineResults(originalKeyCount: keys.count, slotResults: slotResults)
+        } catch {
+            throw ValkeyClientError(.respDecodeError, error: error)
+        }
     }
 
     /// Groups key indices by hash slot.
     ///
-    /// - Returns: An array of `(slot, indices)` pairs, one per unique slot.
+    /// Returns `nil` when all keys belong to a single slot (or there are no keys),
+    /// otherwise returns an array containing slot and indices for keys belonging to the slot.
+    ///
+    /// - Returns: An array of `(slot, indices)` pairs when keys span multiple slots, or `nil`.
     private func partitionBySlot(
         keys: some Collection<ValkeyKey>
-    ) -> [(slot: HashSlot, indices: [Int])] {
-        var slotIndices: [HashSlot: [Int]] = [:]
+    ) -> [(slot: HashSlot, indices: [Int])]? {
+        guard let firstKey = keys.first else { return nil }
+
+        let firstSlot = HashSlot(key: firstKey)
+        var slotIndices: [HashSlot: [Int]]?
 
         for (i, key) in keys.enumerated() {
             let slot = HashSlot(key: key)
-            slotIndices[slot, default: []].append(i)
+            if slotIndices != nil {
+                slotIndices![slot, default: []].append(i)
+            } else if slot != firstSlot {
+                // Second distinct slot found — backfill indices for firstSlot
+                slotIndices = [firstSlot: Array(0..<i), slot: [i]]
+            }
         }
 
+        guard let slotIndices else { return nil }
         return slotIndices.map { (slot: $0.key, indices: $0.value) }
     }
 }

--- a/Sources/Valkey/Cluster/ValkeyClusterClient+MultiKeyCommands.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClient+MultiKeyCommands.swift
@@ -27,26 +27,33 @@ extension ValkeyClusterClient {
         let keys = command.keysAffected
         let partitions = partitionBySlot(keys: keys)
 
+        // Single-slot fast path: all keys hash to the same slot, so execute
+        // the original command directly via the standard code path.
+        // This avoids sub-command creation and result recombination.
+        if partitions.count <= 1 {
+            return try await executeSingleCommand(command)
+        }
+
         // Build one sub-command per slot, cast to the type-erased protocol.
-        let subCommands: [any ValkeyCommand] = partitions.map { command.subCommand(for: $0.indices) }
+        let subCommands: [any ValkeyCommand] = partitions.map { command.createSubCommand(for: $0.indices) }
 
         // Dispatch in parallel using the existing cross-node pipelining path.
         // Each sub-command contains only same-slot keys, so hashSlot() never
         // throws keysInCommandRequireMultipleHashSlots for sub-commands.
         let rawResults = await self.execute(subCommands)
 
-        // Map each raw Result<RESPToken, ValkeyClientError> to the typed Response.
+        // Pair each raw result with its original key indices for combineResults.
         let slotResults = partitions.enumerated().map { i, partition in
-            (indices: partition.indices, result: rawResults[i].convertFromRESP(to: Command.Response.self))
+            (indices: partition.indices, result: rawResults[i])
         }
 
-        return try Command.assemble(originalKeyCount: keys.count, slotResults: slotResults)
+        return try Command.combineResults(originalKeyCount: keys.count, slotResults: slotResults)
     }
 
-    // MARK: - Concrete mget / mset (shadow ValkeyClientProtocol extension methods)
+    // MARK: - Concrete mget (shadow ValkeyClientProtocol extension method)
     //
-    // These concrete methods are preferred over the protocol-extension defaults
-    // for static dispatch on ValkeyClusterClient. They call execute(_:) which
+    // This concrete method is preferred over the protocol-extension default
+    // for static dispatch on ValkeyClusterClient. It calls execute(_:) which
     // resolves — via static dispatch — to the constrained
     // execute<Command: ValkeyClusterMultiKeyCommand> overload above, enabling
     // transparent cross-slot scatter/gather.
@@ -65,44 +72,35 @@ extension ValkeyClusterClient {
         try await execute(MGET(keys: keys))
     }
 
-    /// Sets the string values of one or more keys, transparently routing
-    /// sub-commands across cluster nodes for keys in different hash slots.
-    ///
-    /// - Documentation: [MSET](https://valkey.io/commands/mset)
-    /// - Complexity: O(N) where N is the number of keys to set.
-    /// - Important: Cross-slot `MSET` is **not atomic**. Keys on different nodes
-    ///   may be written at different times. Use hash tags to co-locate keys that
-    ///   need to be set atomically.
-    /// - Parameter data: Key-value pairs to set.
-    /// - Throws: ``ValkeyClientError`` if any node fails. Keys already written
-    ///   to other nodes are **not** rolled back.
-    @inlinable
-    public func mset<Value: RESPStringRenderable>(data: [MSET<Value>.Data]) async throws(ValkeyClientError) {
-        _ = try await execute(MSET(data: data))
-    }
-
     // MARK: - Internal helpers
 
-    /// Groups key indices by hash slot, preserving insertion order of first occurrence.
+    /// Executes a single command via the standard ``ValkeyCommand`` code path.
     ///
-    /// - Returns: An array of `(indices, slot)` pairs, one per unique slot, in the
-    ///   order the slots were first encountered while iterating `keys`.
+    /// This trampoline exists because `execute<C: ValkeyClusterMultiKeyCommand>`
+    /// would otherwise recursively call itself — Swift overload resolution prefers
+    /// the more constrained overload. Inside this helper the compiler only sees
+    /// `Command: ValkeyCommand`, so it resolves to the base `execute` overload.
+    @usableFromInline
+    /* private */ func executeSingleCommand<Command: ValkeyCommand>(
+        _ command: Command
+    ) async throws(ValkeyClientError) -> Command.Response {
+        try await self.execute(command)
+    }
+
+    /// Groups key indices by hash slot.
+    ///
+    /// - Returns: An array of `(slot, indices)` pairs, one per unique slot.
     @usableFromInline
     /* private */ func partitionBySlot(
         keys: some Collection<ValkeyKey>
-    ) -> [(indices: [Int], slot: HashSlot)] {
-        var slotOrder: [HashSlot] = []
+    ) -> [(slot: HashSlot, indices: [Int])] {
         var slotIndices: [HashSlot: [Int]] = [:]
 
         for (i, key) in keys.enumerated() {
             let slot = HashSlot(key: key)
-            if slotIndices[slot] == nil {
-                slotOrder.append(slot)
-                slotIndices[slot] = []
-            }
-            slotIndices[slot]!.append(i)
+            slotIndices[slot, default: []].append(i)
         }
 
-        return slotOrder.map { (indices: slotIndices[$0]!, slot: $0) }
+        return slotIndices.map { (slot: $0.key, indices: $0.value) }
     }
 }

--- a/Sources/Valkey/Cluster/ValkeyClusterMultiKeyCommand.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterMultiKeyCommand.swift
@@ -1,0 +1,42 @@
+//
+// This source file is part of the valkey-swift project
+// Copyright (c) 2025 the valkey-swift project authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// A Valkey command that operates on multiple keys and can be transparently
+/// scattered across cluster nodes when keys span multiple hash slots.
+///
+/// When executed against a ``ValkeyClusterClient``, the client partitions keys by
+/// hash slot, dispatches one sub-command per slot in parallel, and reassembles
+/// results in the original key order.
+///
+/// Conforming types must implement two requirements:
+/// - ``subCommand(for:)`` — produce a sub-command scoped to a subset of keys.
+/// - ``assemble(originalKeyCount:slotResults:)`` — merge per-slot results back
+///   into the full command response.
+@available(valkeySwift 1.0, *)
+public protocol ValkeyClusterMultiKeyCommand: ValkeyCommand {
+
+    /// Returns a sub-command containing only the keys at the given indices.
+    ///
+    /// - Parameter indices: Positions into this command's full key list that
+    ///   belong to a single hash slot.
+    /// - Returns: A new command of the same type scoped to those keys.
+    func subCommand(for indices: [Int]) -> Self
+
+    /// Assembles per-slot sub-results into the final command response.
+    ///
+    /// - Parameters:
+    ///   - originalKeyCount: Total number of keys in the original command.
+    ///   - slotResults: One entry per slot, each containing the original key
+    ///     indices for that slot and the sub-command result.
+    /// - Returns: The fully assembled response in original key order.
+    /// - Throws: ``ValkeyClientError`` if any sub-result is a failure.
+    static func assemble(
+        originalKeyCount: Int,
+        slotResults: [(indices: [Int], result: Result<Self.Response, ValkeyClientError>)]
+    ) throws(ValkeyClientError) -> Self.Response
+}

--- a/Sources/Valkey/Cluster/ValkeyClusterMultiKeyCommand.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterMultiKeyCommand.swift
@@ -18,7 +18,7 @@
 /// - ``combineResults(originalKeyCount:slotResults:)`` — merge per-slot results back
 ///   into the full command response.
 @available(valkeySwift 1.0, *)
-public protocol ValkeyClusterMultiKeyCommand: ValkeyCommand {
+package protocol ValkeyClusterMultiKeyCommand: ValkeyCommand {
 
     /// Returns a sub-command containing only the keys at the given indices.
     ///

--- a/Sources/Valkey/Cluster/ValkeyClusterMultiKeyCommand.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterMultiKeyCommand.swift
@@ -36,11 +36,11 @@ package protocol ValkeyClusterMultiKeyCommand: ValkeyCommand {
     /// - Parameters:
     ///   - originalKeyCount: Total number of keys in the original command.
     ///   - slotResults: One entry per slot, each containing the original key
-    ///     indices for that slot and the raw RESP result.
+    ///     indices for that slot and the successful RESP token.
     /// - Returns: The fully combined response in original key order.
-    /// - Throws: ``ValkeyClientError`` if any sub-result is a failure.
+    /// - Throws: ``RESPDecodeError`` if any sub-result cannot be decoded.
     static func combineResults(
         originalKeyCount: Int,
-        slotResults: [(indices: [Int], result: Result<RESPToken, ValkeyClientError>)]
-    ) throws(ValkeyClientError) -> Self.Response
+        slotResults: [(indices: [Int], result: RESPToken)]
+    ) throws(RESPDecodeError) -> Self.Response
 }

--- a/Sources/Valkey/Cluster/ValkeyClusterMultiKeyCommand.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterMultiKeyCommand.swift
@@ -14,8 +14,8 @@
 /// results in the original key order.
 ///
 /// Conforming types must implement two requirements:
-/// - ``subCommand(for:)`` — produce a sub-command scoped to a subset of keys.
-/// - ``assemble(originalKeyCount:slotResults:)`` — merge per-slot results back
+/// - ``createSubCommand(for:)`` — produce a sub-command scoped to a subset of keys.
+/// - ``combineResults(originalKeyCount:slotResults:)`` — merge per-slot results back
 ///   into the full command response.
 @available(valkeySwift 1.0, *)
 public protocol ValkeyClusterMultiKeyCommand: ValkeyCommand {
@@ -25,18 +25,22 @@ public protocol ValkeyClusterMultiKeyCommand: ValkeyCommand {
     /// - Parameter indices: Positions into this command's full key list that
     ///   belong to a single hash slot.
     /// - Returns: A new command of the same type scoped to those keys.
-    func subCommand(for indices: [Int]) -> Self
+    func createSubCommand(for indices: [Int]) -> Self
 
-    /// Assembles per-slot sub-results into the final command response.
+    /// Combines per-slot raw RESP results into the final command response.
+    ///
+    /// Conforming types receive the raw ``RESPToken`` from each sub-command,
+    /// avoiding an intermediate conversion to the typed `Response`. This lets
+    /// implementations parse RESP directly and reduce allocations.
     ///
     /// - Parameters:
     ///   - originalKeyCount: Total number of keys in the original command.
     ///   - slotResults: One entry per slot, each containing the original key
-    ///     indices for that slot and the sub-command result.
-    /// - Returns: The fully assembled response in original key order.
+    ///     indices for that slot and the raw RESP result.
+    /// - Returns: The fully combined response in original key order.
     /// - Throws: ``ValkeyClientError`` if any sub-result is a failure.
-    static func assemble(
+    static func combineResults(
         originalKeyCount: Int,
-        slotResults: [(indices: [Int], result: Result<Self.Response, ValkeyClientError>)]
+        slotResults: [(indices: [Int], result: Result<RESPToken, ValkeyClientError>)]
     ) throws(ValkeyClientError) -> Self.Response
 }

--- a/Sources/Valkey/Commands/Custom/ClusterStringCommands.swift
+++ b/Sources/Valkey/Commands/Custom/ClusterStringCommands.swift
@@ -64,7 +64,7 @@ extension MGET: ValkeyClusterMultiKeyCommand {
 @available(valkeySwift 1.0, *)
 extension ValkeyClusterClient {
 
-    /// Atomically returns the string values of one or more keys, transparently
+    /// Returns the string values of one or more keys, transparently
     /// routing sub-commands across cluster nodes for keys in different hash slots.
     ///
     /// - Documentation: [MGET](https://valkey.io/commands/mget)

--- a/Sources/Valkey/Commands/Custom/ClusterStringCommands.swift
+++ b/Sources/Valkey/Commands/Custom/ClusterStringCommands.swift
@@ -13,7 +13,7 @@ import NIOCore
 @available(valkeySwift 1.0, *)
 extension MGET: ValkeyClusterMultiKeyCommand {
 
-    public func createSubCommand(for indices: [Int]) -> MGET {
+    package func createSubCommand(for indices: [Int]) -> MGET {
         MGET(keys: indices.map { self.keys[$0] })
     }
 
@@ -21,7 +21,7 @@ extension MGET: ValkeyClusterMultiKeyCommand {
     ///
     /// Each element in the returned array corresponds to the key at the same
     /// position in the original `MGET`. Null tokens represent absent keys.
-    public static func combineResults(
+    package static func combineResults(
         originalKeyCount: Int,
         slotResults: [(indices: [Int], result: Result<RESPToken, ValkeyClientError>)]
     ) throws(ValkeyClientError) -> RESPToken.Array {

--- a/Sources/Valkey/Commands/Custom/ClusterStringCommands.swift
+++ b/Sources/Valkey/Commands/Custom/ClusterStringCommands.swift
@@ -13,28 +13,35 @@ import NIOCore
 @available(valkeySwift 1.0, *)
 extension MGET: ValkeyClusterMultiKeyCommand {
 
-    public func subCommand(for indices: [Int]) -> MGET {
+    public func createSubCommand(for indices: [Int]) -> MGET {
         MGET(keys: indices.map { self.keys[$0] })
     }
 
-    /// Assembles per-slot MGET results into a single ``RESPToken/Array``.
+    /// Combines per-slot MGET results into a single ``RESPToken/Array``.
     ///
     /// Each element in the returned array corresponds to the key at the same
     /// position in the original `MGET`. Null tokens represent absent keys.
-    public static func assemble(
+    public static func combineResults(
         originalKeyCount: Int,
-        slotResults: [(indices: [Int], result: Result<RESPToken.Array, ValkeyClientError>)]
+        slotResults: [(indices: [Int], result: Result<RESPToken, ValkeyClientError>)]
     ) throws(ValkeyClientError) -> RESPToken.Array {
         // Pre-fill every position with a RESP3 null token (`_\r\n`).
         // Positions are overwritten with actual values as sub-results arrive.
         var tokenBases = [ByteBuffer](repeating: RESPToken.nullToken.base, count: originalKeyCount)
 
         for (indices, result) in slotResults {
-            let resultArray = try result.get()
+            let token = try result.get()
+            let resultArray: RESPToken.Array
+            do {
+                resultArray = try RESPToken.Array(token)
+            } catch {
+                throw ValkeyClientError(.respDecodeError, error: error)
+            }
+
             var resultIterator = resultArray.makeIterator()
             for originalIndex in indices {
-                guard let token = resultIterator.next() else { break }
-                tokenBases[originalIndex] = token.base
+                guard let element = resultIterator.next() else { break }
+                tokenBases[originalIndex] = element.base
             }
         }
 
@@ -51,37 +58,5 @@ extension MGET: ValkeyClusterMultiKeyCommand {
         } catch {
             throw ValkeyClientError(.respDecodeError, error: error)
         }
-    }
-}
-
-// MARK: - MSET
-
-@available(valkeySwift 1.0, *)
-extension MSET: ValkeyClusterMultiKeyCommand {
-
-    public func subCommand(for indices: [Int]) -> MSET<Value> {
-        MSET(data: indices.map { self.data[$0] })
-    }
-
-    /// Checks that every per-slot MSET succeeded and returns the last OK token.
-    ///
-    /// - Important: Cross-slot `MSET` is **not atomic**. Keys on different nodes
-    ///   may be written at different times. If any node fails, an error is thrown
-    ///   but keys already written to other nodes are **not** rolled back.
-    public static func assemble(
-        originalKeyCount: Int,
-        slotResults: [(indices: [Int], result: Result<RESPToken, ValkeyClientError>)]
-    ) throws(ValkeyClientError) -> RESPToken {
-        var lastToken: RESPToken?
-        for (_, result) in slotResults {
-            lastToken = try result.get()
-        }
-        guard let token = lastToken else {
-            // No sub-commands were run (empty data). Synthesise an OK response.
-            var okBuffer = ByteBuffer()
-            okBuffer.writeStaticString("+OK\r\n")
-            return RESPToken(validated: okBuffer)
-        }
-        return token
     }
 }

--- a/Sources/Valkey/Commands/Custom/ClusterStringCommands.swift
+++ b/Sources/Valkey/Commands/Custom/ClusterStringCommands.swift
@@ -1,0 +1,87 @@
+//
+// This source file is part of the valkey-swift project
+// Copyright (c) 2025 the valkey-swift project authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import NIOCore
+
+// MARK: - MGET
+
+@available(valkeySwift 1.0, *)
+extension MGET: ValkeyClusterMultiKeyCommand {
+
+    public func subCommand(for indices: [Int]) -> MGET {
+        MGET(keys: indices.map { self.keys[$0] })
+    }
+
+    /// Assembles per-slot MGET results into a single ``RESPToken/Array``.
+    ///
+    /// Each element in the returned array corresponds to the key at the same
+    /// position in the original `MGET`. Null tokens represent absent keys.
+    public static func assemble(
+        originalKeyCount: Int,
+        slotResults: [(indices: [Int], result: Result<RESPToken.Array, ValkeyClientError>)]
+    ) throws(ValkeyClientError) -> RESPToken.Array {
+        // Pre-fill every position with a RESP3 null token (`_\r\n`).
+        // Positions are overwritten with actual values as sub-results arrive.
+        var tokenBases = [ByteBuffer](repeating: RESPToken.nullToken.base, count: originalKeyCount)
+
+        for (indices, result) in slotResults {
+            let resultArray = try result.get()
+            var resultIterator = resultArray.makeIterator()
+            for originalIndex in indices {
+                guard let token = resultIterator.next() else { break }
+                tokenBases[originalIndex] = token.base
+            }
+        }
+
+        // Build wire-format RESP3 array: `*N\r\n` followed by each element's bytes.
+        var buffer = ByteBuffer()
+        buffer.writeString("*\(originalKeyCount)\r\n")
+        for base in tokenBases {
+            buffer.writeImmutableBuffer(base)
+        }
+
+        let arrayToken = RESPToken(validated: buffer)
+        do {
+            return try RESPToken.Array(arrayToken)
+        } catch {
+            throw ValkeyClientError(.respDecodeError, error: error)
+        }
+    }
+}
+
+// MARK: - MSET
+
+@available(valkeySwift 1.0, *)
+extension MSET: ValkeyClusterMultiKeyCommand {
+
+    public func subCommand(for indices: [Int]) -> MSET<Value> {
+        MSET(data: indices.map { self.data[$0] })
+    }
+
+    /// Checks that every per-slot MSET succeeded and returns the last OK token.
+    ///
+    /// - Important: Cross-slot `MSET` is **not atomic**. Keys on different nodes
+    ///   may be written at different times. If any node fails, an error is thrown
+    ///   but keys already written to other nodes are **not** rolled back.
+    public static func assemble(
+        originalKeyCount: Int,
+        slotResults: [(indices: [Int], result: Result<RESPToken, ValkeyClientError>)]
+    ) throws(ValkeyClientError) -> RESPToken {
+        var lastToken: RESPToken?
+        for (_, result) in slotResults {
+            lastToken = try result.get()
+        }
+        guard let token = lastToken else {
+            // No sub-commands were run (empty data). Synthesise an OK response.
+            var okBuffer = ByteBuffer()
+            okBuffer.writeStaticString("+OK\r\n")
+            return RESPToken(validated: okBuffer)
+        }
+        return token
+    }
+}

--- a/Sources/Valkey/Commands/Custom/ClusterStringCommands.swift
+++ b/Sources/Valkey/Commands/Custom/ClusterStringCommands.swift
@@ -23,40 +23,57 @@ extension MGET: ValkeyClusterMultiKeyCommand {
     /// position in the original `MGET`. Null tokens represent absent keys.
     package static func combineResults(
         originalKeyCount: Int,
-        slotResults: [(indices: [Int], result: Result<RESPToken, ValkeyClientError>)]
-    ) throws(ValkeyClientError) -> RESPToken.Array {
+        slotResults: [(indices: [Int], result: RESPToken)]
+    ) throws(RESPDecodeError) -> RESPToken.Array {
         // Pre-fill every position with a RESP3 null token (`_\r\n`).
         // Positions are overwritten with actual values as sub-results arrive.
         var tokenBases = [ByteBuffer](repeating: RESPToken.nullToken.base, count: originalKeyCount)
 
         for (indices, result) in slotResults {
-            let token = try result.get()
-            let resultArray: RESPToken.Array
-            do {
-                resultArray = try RESPToken.Array(token)
-            } catch {
-                throw ValkeyClientError(.respDecodeError, error: error)
-            }
+            let resultArray = try RESPToken.Array(result)
 
             var resultIterator = resultArray.makeIterator()
             for originalIndex in indices {
-                guard let element = resultIterator.next() else { break }
+                guard let element = resultIterator.next() else {
+                    throw RESPDecodeError(
+                        .invalidArraySize,
+                        token: result,
+                        message: "Mismatch between key count: \(indices.count) and response count: \(resultArray.count) for indices: \(indices)"
+                    )
+                }
                 tokenBases[originalIndex] = element.base
             }
         }
 
         // Build wire-format RESP3 array: `*N\r\n` followed by each element's bytes.
+        let header = "*\(originalKeyCount)\r\n"
+        let totalSize = header.utf8.count + tokenBases.reduce(0) { $0 + $1.readableBytes }
         var buffer = ByteBuffer()
-        buffer.writeString("*\(originalKeyCount)\r\n")
+        buffer.reserveCapacity(totalSize)
+        buffer.writeString(header)
         for base in tokenBases {
             buffer.writeImmutableBuffer(base)
         }
 
-        let arrayToken = RESPToken(validated: buffer)
-        do {
-            return try RESPToken.Array(arrayToken)
-        } catch {
-            throw ValkeyClientError(.respDecodeError, error: error)
-        }
+        return try RESPToken.Array(RESPToken(validated: buffer))
+    }
+}
+
+// MARK: - ValkeyClusterClient + MGET
+
+@available(valkeySwift 1.0, *)
+extension ValkeyClusterClient {
+
+    /// Atomically returns the string values of one or more keys, transparently
+    /// routing sub-commands across cluster nodes for keys in different hash slots.
+    ///
+    /// - Documentation: [MGET](https://valkey.io/commands/mget)
+    /// - Complexity: O(N) where N is the number of keys to retrieve.
+    /// - Parameter keys: The keys whose values to retrieve.
+    /// - Returns: A ``RESPToken/Array`` with values in the same order as `keys`.
+    ///   Null tokens represent absent keys.
+    /// - Throws: ``ValkeyClientError`` if any node fails.
+    public func mget(keys: [ValkeyKey]) async throws(ValkeyClientError) -> RESPToken.Array {
+        try await executeMultiKeyCommand(MGET(keys: keys))
     }
 }

--- a/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
+++ b/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
@@ -1002,7 +1002,7 @@ struct ClusterIntegrationTests {
 
     @Test
     @available(valkeySwift 1.0, *)
-    func testCusterWideMGET() async throws {
+    func testClusterWideMGET() async throws {
         var logger = Logger(label: "ValkeyCluster")
         logger.logLevel = .trace
         let firstNodeHostname = clusterFirstNodeHostname!

--- a/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
+++ b/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
@@ -1000,6 +1000,31 @@ struct ClusterIntegrationTests {
         }
     }
 
+    @Test
+    @available(valkeySwift 1.0, *)
+    func testCusterWideMGET() async throws {
+        var logger = Logger(label: "ValkeyCluster")
+        logger.logLevel = .trace
+        let firstNodeHostname = clusterFirstNodeHostname!
+        let firstNodePort = clusterFirstNodePort ?? 6379
+        try await Self.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) { client in
+            // Use different hash tags to ensure keys land in different slots.
+            try await Self.withKeys(connection: client, suffixes: ["{1}", "{2}", "{3}", "-missing{4}"]) { keys in
+                try await client.set(keys[0], value: "val1", expiration: .seconds(60))
+                try await client.set(keys[1], value: "val2", expiration: .seconds(60))
+                try await client.set(keys[2], value: "val3", expiration: .seconds(60))
+
+                let result = try await client.mget(keys: keys)
+                let values = Array(result)
+                #expect(values.count == 4)
+                #expect(values[0].value == .bulkString(ByteBuffer(string: "val1")))
+                #expect(values[1].value == .bulkString(ByteBuffer(string: "val2")))
+                #expect(values[2].value == .bulkString(ByteBuffer(string: "val3")))
+                #expect(values[3].value == .null)
+            }
+        }
+    }
+
     @available(valkeySwift 1.0, *)
     static func withKey<Value>(
         connection: some ValkeyClientProtocol,
@@ -1014,6 +1039,26 @@ struct ClusterIntegrationTests {
             result = .failure(error)
         }
         try await connection.del(keys: [key])
+        return try result.get()
+    }
+
+    @available(valkeySwift 1.0, *)
+    static func withKeys<Value>(
+        connection: some ValkeyClientProtocol,
+        suffixes: [String],
+        _ operation: ([ValkeyKey]) async throws -> Value
+    ) async throws -> Value {
+        let prefix = UUID().uuidString
+        let keys = suffixes.map { ValkeyKey(prefix + $0) }
+        let result: Result<Value, any Error>
+        do {
+            result = try await .success(operation(keys))
+        } catch {
+            result = .failure(error)
+        }
+        for key in keys {
+            try await connection.del(keys: [key])
+        }
         return try result.get()
     }
 

--- a/Tests/ValkeyTests/Cluster/ValkeyClusterClientTests.swift
+++ b/Tests/ValkeyTests/Cluster/ValkeyClusterClientTests.swift
@@ -247,6 +247,48 @@ actor TestCluster {
                 }
                 await self.setKey(key, value: value)
                 return .simpleString("OK")
+            case "MGET":
+                var keys: [String] = []
+                while let key = iterator.next() {
+                    keys.append(key)
+                }
+                var values: [RESP3Value] = []
+                for key in keys {
+                    let hashSlot = HashSlot(key: key.utf8)
+                    guard let shard = await self.getShard(hashSlot) else {
+                        values.append(.null)
+                        continue
+                    }
+                    let addressDetails = await self.addressMap[address]
+                    if shard.index != addressDetails?.shardIndex {
+                        return .bulkError("MOVED \(hashSlot.rawValue) \(shard.shard.primary.address)")
+                    }
+                    if key.hasPrefix("$address") {
+                        values.append(.bulkString(address.description))
+                    } else {
+                        values.append(await self.getKey(key).map { .bulkString($0) } ?? .null)
+                    }
+                }
+                return .array(values)
+
+            case "MSET":
+                var pairs: [(key: String, value: String)] = []
+                while let key = iterator.next(), let value = iterator.next() {
+                    pairs.append((key: key, value: value))
+                }
+                for (key, _) in pairs {
+                    let hashSlot = HashSlot(key: key.utf8)
+                    guard let shard = await self.getShard(hashSlot) else { continue }
+                    let addressDetails = await self.addressMap[address]
+                    if shard.index != addressDetails?.shardIndex || addressDetails?.role == .replica {
+                        return .bulkError("MOVED \(hashSlot.rawValue) \(shard.shard.primary.address)")
+                    }
+                }
+                for (key, value) in pairs {
+                    await self.setKey(key, value: value)
+                }
+                return .simpleString("OK")
+
             case "CLUSTER":
                 switch iterator.next() {
                 case "SHARDS":
@@ -613,6 +655,147 @@ struct ValkeyClusterClientTests {
             }
             let clusterError = try #require(error?.underlyingError as? ValkeyClusterError)
             #expect(clusterError == .clusterIsMissingNode)
+        }
+    }
+
+    // MARK: - MGET cross-slot tests
+
+    // Hash-tag reference for sixNodeHealthyCluster:
+    //   {3} → slot 1584 → shard 0...5460     (primary 16000, replica 16001)
+    //   {1} → slot 9842 → shard 5461...10922  (primary 16002, replica 16003)
+    //   {4} → slot 13898 → shard 10923...16383 (primary 16004, replica 16005)
+
+    @available(valkeySwift 1.0, *)
+    @Test
+    func testMGETCrossSlot() async throws {
+        var logger = Logger(label: "Valkey")
+        logger.logLevel = .debug
+        let cluster = await self.sixNodeHealthyCluster
+        let mockConnections = await cluster.mock(logger: logger)
+        async let _ = mockConnections.run()
+        try await withValkeyClusterClient(
+            (host: "127.0.0.1", port: 16000),
+            mockConnections: mockConnections,
+            logger: logger
+        ) { client in
+            // Populate keys across three shards
+            _ = try await client.set("key{3}", value: "value3")
+            _ = try await client.set("key{1}", value: "value1")
+            _ = try await client.set("key{4}", value: "value4")
+
+            // key{2} is not set — its slot (5649) is in shard 5461...10922
+            let result = try await client.mget(keys: ["key{3}", "key{1}", "key{2}", "key{4}"])
+            let tokens = Swift.Array(result)
+
+            #expect(try String(tokens[0]) == "value3")
+            #expect(try String(tokens[1]) == "value1")
+            #expect(tokens[2].value == .null)
+            #expect(try String(tokens[3]) == "value4")
+        }
+    }
+
+    @available(valkeySwift 1.0, *)
+    @Test
+    func testMGETKeyOrderIsPreserved() async throws {
+        // Verifies that results are returned in the original key order
+        // even though sub-commands execute on different nodes concurrently.
+        var logger = Logger(label: "Valkey")
+        logger.logLevel = .debug
+        let cluster = await self.sixNodeHealthyCluster
+        let mockConnections = await cluster.mock(logger: logger)
+        async let _ = mockConnections.run()
+        try await withValkeyClusterClient(
+            (host: "127.0.0.1", port: 16000),
+            mockConnections: mockConnections,
+            logger: logger
+        ) { client in
+            _ = try await client.set("key{4}", value: "first")
+            _ = try await client.set("key{3}", value: "second")
+
+            // key{4} (slot 13898, shard 2) is passed first, key{3} (slot 1584, shard 0) second.
+            // Regardless of which node responds first, result[0] must be "first".
+            let result = try await client.mget(keys: ["key{4}", "key{3}"])
+            let tokens = Swift.Array(result)
+
+            #expect(try String(tokens[0]) == "first")
+            #expect(try String(tokens[1]) == "second")
+        }
+    }
+
+    @available(valkeySwift 1.0, *)
+    @Test
+    func testMGETSameSlot() async throws {
+        // Single-slot path: all keys share the same hash tag.
+        var logger = Logger(label: "Valkey")
+        logger.logLevel = .debug
+        let cluster = await self.sixNodeHealthyCluster
+        let mockConnections = await cluster.mock(logger: logger)
+        async let _ = mockConnections.run()
+        try await withValkeyClusterClient(
+            (host: "127.0.0.1", port: 16000),
+            mockConnections: mockConnections,
+            logger: logger
+        ) { client in
+            _ = try await client.set("a{1}", value: "alpha")
+            _ = try await client.set("b{1}", value: "beta")
+
+            let result = try await client.mget(keys: ["a{1}", "b{1}"])
+            let tokens = Swift.Array(result)
+
+            #expect(try String(tokens[0]) == "alpha")
+            #expect(try String(tokens[1]) == "beta")
+        }
+    }
+
+    // MARK: - MSET cross-slot tests
+
+    @available(valkeySwift 1.0, *)
+    @Test
+    func testMSETCrossSlot() async throws {
+        var logger = Logger(label: "Valkey")
+        logger.logLevel = .debug
+        let cluster = await self.sixNodeHealthyCluster
+        let mockConnections = await cluster.mock(logger: logger)
+        async let _ = mockConnections.run()
+        try await withValkeyClusterClient(
+            (host: "127.0.0.1", port: 16000),
+            mockConnections: mockConnections,
+            logger: logger
+        ) { client in
+            // Set keys across three shards in one call
+            try await client.mset(data: [
+                .init(key: "mset{3}", value: "v3"),
+                .init(key: "mset{1}", value: "v1"),
+                .init(key: "mset{4}", value: "v4"),
+            ])
+
+            // Verify each key landed on its correct node via single-key GET
+            #expect(try await client.get("mset{3}").map { String($0) } == "v3")
+            #expect(try await client.get("mset{1}").map { String($0) } == "v1")
+            #expect(try await client.get("mset{4}").map { String($0) } == "v4")
+        }
+    }
+
+    @available(valkeySwift 1.0, *)
+    @Test
+    func testMSETSameSlot() async throws {
+        var logger = Logger(label: "Valkey")
+        logger.logLevel = .debug
+        let cluster = await self.sixNodeHealthyCluster
+        let mockConnections = await cluster.mock(logger: logger)
+        async let _ = mockConnections.run()
+        try await withValkeyClusterClient(
+            (host: "127.0.0.1", port: 16000),
+            mockConnections: mockConnections,
+            logger: logger
+        ) { client in
+            try await client.mset(data: [
+                .init(key: "a{1}", value: "alpha"),
+                .init(key: "b{1}", value: "beta"),
+            ])
+
+            #expect(try await client.get("a{1}").map { String($0) } == "alpha")
+            #expect(try await client.get("b{1}").map { String($0) } == "beta")
         }
     }
 }

--- a/Tests/ValkeyTests/Cluster/ValkeyClusterClientTests.swift
+++ b/Tests/ValkeyTests/Cluster/ValkeyClusterClientTests.swift
@@ -746,58 +746,6 @@ struct ValkeyClusterClientTests {
             #expect(try String(tokens[1]) == "beta")
         }
     }
-
-    // MARK: - MSET cross-slot tests
-
-    @available(valkeySwift 1.0, *)
-    @Test
-    func testMSETCrossSlot() async throws {
-        var logger = Logger(label: "Valkey")
-        logger.logLevel = .debug
-        let cluster = await self.sixNodeHealthyCluster
-        let mockConnections = await cluster.mock(logger: logger)
-        async let _ = mockConnections.run()
-        try await withValkeyClusterClient(
-            (host: "127.0.0.1", port: 16000),
-            mockConnections: mockConnections,
-            logger: logger
-        ) { client in
-            // Set keys across three shards in one call
-            try await client.mset(data: [
-                .init(key: "mset{3}", value: "v3"),
-                .init(key: "mset{1}", value: "v1"),
-                .init(key: "mset{4}", value: "v4"),
-            ])
-
-            // Verify each key landed on its correct node via single-key GET
-            #expect(try await client.get("mset{3}").map { String($0) } == "v3")
-            #expect(try await client.get("mset{1}").map { String($0) } == "v1")
-            #expect(try await client.get("mset{4}").map { String($0) } == "v4")
-        }
-    }
-
-    @available(valkeySwift 1.0, *)
-    @Test
-    func testMSETSameSlot() async throws {
-        var logger = Logger(label: "Valkey")
-        logger.logLevel = .debug
-        let cluster = await self.sixNodeHealthyCluster
-        let mockConnections = await cluster.mock(logger: logger)
-        async let _ = mockConnections.run()
-        try await withValkeyClusterClient(
-            (host: "127.0.0.1", port: 16000),
-            mockConnections: mockConnections,
-            logger: logger
-        ) { client in
-            try await client.mset(data: [
-                .init(key: "a{1}", value: "alpha"),
-                .init(key: "b{1}", value: "beta"),
-            ])
-
-            #expect(try await client.get("a{1}").map { String($0) } == "alpha")
-            #expect(try await client.get("b{1}").map { String($0) } == "beta")
-        }
-    }
 }
 
 extension ClosedRange<UInt16> {

--- a/Tests/ValkeyTests/Cluster/ValkeyClusterClientTests.swift
+++ b/Tests/ValkeyTests/Cluster/ValkeyClusterClientTests.swift
@@ -271,24 +271,6 @@ actor TestCluster {
                 }
                 return .array(values)
 
-            case "MSET":
-                var pairs: [(key: String, value: String)] = []
-                while let key = iterator.next(), let value = iterator.next() {
-                    pairs.append((key: key, value: value))
-                }
-                for (key, _) in pairs {
-                    let hashSlot = HashSlot(key: key.utf8)
-                    guard let shard = await self.getShard(hashSlot) else { continue }
-                    let addressDetails = await self.addressMap[address]
-                    if shard.index != addressDetails?.shardIndex || addressDetails?.role == .replica {
-                        return .bulkError("MOVED \(hashSlot.rawValue) \(shard.shard.primary.address)")
-                    }
-                }
-                for (key, value) in pairs {
-                    await self.setKey(key, value: value)
-                }
-                return .simpleString("OK")
-
             case "CLUSTER":
                 switch iterator.next() {
                 case "SHARDS":
@@ -660,11 +642,6 @@ struct ValkeyClusterClientTests {
 
     // MARK: - MGET cross-slot tests
 
-    // Hash-tag reference for sixNodeHealthyCluster:
-    //   {3} → slot 1584 → shard 0...5460     (primary 16000, replica 16001)
-    //   {1} → slot 9842 → shard 5461...10922  (primary 16002, replica 16003)
-    //   {4} → slot 13898 → shard 10923...16383 (primary 16004, replica 16005)
-
     @available(valkeySwift 1.0, *)
     @Test
     func testMGETCrossSlot() async throws {
@@ -683,67 +660,26 @@ struct ValkeyClusterClientTests {
             _ = try await client.set("key{1}", value: "value1")
             _ = try await client.set("key{4}", value: "value4")
 
-            // key{2} is not set — its slot (5649) is in shard 5461...10922
+            // Verifies scatter-gather dispatches sub-commands and reassembles
+            // results in original key order with null for absent keys.
             let result = try await client.mget(keys: ["key{3}", "key{1}", "key{2}", "key{4}"])
-            let tokens = Swift.Array(result)
+            let tokens = Array(result)
 
             #expect(try String(tokens[0]) == "value3")
             #expect(try String(tokens[1]) == "value1")
             #expect(tokens[2].value == .null)
             #expect(try String(tokens[3]) == "value4")
-        }
-    }
 
-    @available(valkeySwift 1.0, *)
-    @Test
-    func testMGETKeyOrderIsPreserved() async throws {
-        // Verifies that results are returned in the original key order
-        // even though sub-commands execute on different nodes concurrently.
-        var logger = Logger(label: "Valkey")
-        logger.logLevel = .debug
-        let cluster = await self.sixNodeHealthyCluster
-        let mockConnections = await cluster.mock(logger: logger)
-        async let _ = mockConnections.run()
-        try await withValkeyClusterClient(
-            (host: "127.0.0.1", port: 16000),
-            mockConnections: mockConnections,
-            logger: logger
-        ) { client in
-            _ = try await client.set("key{4}", value: "first")
-            _ = try await client.set("key{3}", value: "second")
-
-            // key{4} (slot 13898, shard 2) is passed first, key{3} (slot 1584, shard 0) second.
-            // Regardless of which node responds first, result[0] must be "first".
-            let result = try await client.mget(keys: ["key{4}", "key{3}"])
-            let tokens = Swift.Array(result)
-
-            #expect(try String(tokens[0]) == "first")
-            #expect(try String(tokens[1]) == "second")
-        }
-    }
-
-    @available(valkeySwift 1.0, *)
-    @Test
-    func testMGETSameSlot() async throws {
-        // Single-slot path: all keys share the same hash tag.
-        var logger = Logger(label: "Valkey")
-        logger.logLevel = .debug
-        let cluster = await self.sixNodeHealthyCluster
-        let mockConnections = await cluster.mock(logger: logger)
-        async let _ = mockConnections.run()
-        try await withValkeyClusterClient(
-            (host: "127.0.0.1", port: 16000),
-            mockConnections: mockConnections,
-            logger: logger
-        ) { client in
+            // Same-slot fast path: all keys share the same hash tag,
+            // so the command goes through the standard execute path.
             _ = try await client.set("a{1}", value: "alpha")
             _ = try await client.set("b{1}", value: "beta")
 
-            let result = try await client.mget(keys: ["a{1}", "b{1}"])
-            let tokens = Swift.Array(result)
+            let sameSlotResult = try await client.mget(keys: ["a{1}", "b{1}"])
+            let sameSlotTokens = Array(sameSlotResult)
 
-            #expect(try String(tokens[0]) == "alpha")
-            #expect(try String(tokens[1]) == "beta")
+            #expect(try String(sameSlotTokens[0]) == "alpha")
+            #expect(try String(sameSlotTokens[1]) == "beta")
         }
     }
 }

--- a/Tests/ValkeyTests/Cluster/ValkeyClusterClientTests.swift
+++ b/Tests/ValkeyTests/Cluster/ValkeyClusterClientTests.swift
@@ -247,22 +247,34 @@ actor TestCluster {
                 }
                 await self.setKey(key, value: value)
                 return .simpleString("OK")
+
             case "MGET":
                 var keys: [String] = []
+                var slot: HashSlot?
+
+                // Verify all keys belong to the same slot
                 while let key = iterator.next() {
+                    let keySlot = HashSlot(key: ValkeyKey(key))
+                    if let existingSlot = slot, existingSlot != keySlot {
+                        return .bulkError("CROSSSLOT Keys in request don't hash to the same slot")
+                    } else {
+                        slot = keySlot
+                    }
                     keys.append(key)
+                }
+
+                guard let hashSlot = slot else {
+                    return .bulkError("ERR wrong number of arguments for 'mget' command")
+                }
+                guard let shard = await self.getShard(hashSlot) else {
+                    return .array(keys.map { _ in .null })
+                }
+                let addressDetails = await self.addressMap[address]
+                if shard.index != addressDetails?.shardIndex {
+                    return .bulkError("MOVED \(hashSlot.rawValue) \(shard.shard.primary.address)")
                 }
                 var values: [RESP3Value] = []
                 for key in keys {
-                    let hashSlot = HashSlot(key: key.utf8)
-                    guard let shard = await self.getShard(hashSlot) else {
-                        values.append(.null)
-                        continue
-                    }
-                    let addressDetails = await self.addressMap[address]
-                    if shard.index != addressDetails?.shardIndex {
-                        return .bulkError("MOVED \(hashSlot.rawValue) \(shard.shard.primary.address)")
-                    }
                     if key.hasPrefix("$address") {
                         values.append(.bulkString(address.description))
                     } else {

--- a/Tests/ValkeyTests/CommandTests.swift
+++ b/Tests/ValkeyTests/CommandTests.swift
@@ -2977,6 +2977,58 @@ struct CommandTests {
             }
         }
     }
+
+    // MARK: - Multi-key cluster commands
+
+    struct MultiKeyCommands {
+
+        @Test
+        @available(valkeySwift 1.0, *)
+        func mgetScatterGather() throws {
+            // Simulate MGET with 4 keys split across 2 slots: [0, 2] and [1, 3].
+            let command = MGET(keys: ["a", "b", "c", "d"])
+
+            // createSubCommand picks the right keys for each slot.
+            let sub1 = command.createSubCommand(for: [0, 2])
+            #expect(sub1.keys == [ValkeyKey("a"), ValkeyKey("c")])
+            let sub2 = command.createSubCommand(for: [1, 3])
+            #expect(sub2.keys == [ValkeyKey("b"), ValkeyKey("d")])
+
+            // Simulate per-slot RESP responses (values match key names).
+            let slot1Response = RESPToken(.array([.bulkString("a"), .bulkString("c")]))
+            let slot2Response = RESPToken(.array([.null, .bulkString("d")]))
+
+            // combineResults reassembles in original key order.
+            let combined = try MGET.combineResults(
+                originalKeyCount: 4,
+                slotResults: [
+                    (indices: [0, 2], result: .success(slot1Response)),
+                    (indices: [1, 3], result: .success(slot2Response)),
+                ]
+            )
+            let values = Array(combined)
+            #expect(values.count == 4)
+            #expect(values[0].value == .bulkString(ByteBuffer(string: "a")))
+            #expect(values[1].value == .null)
+            #expect(values[2].value == .bulkString(ByteBuffer(string: "c")))
+            #expect(values[3].value == .bulkString(ByteBuffer(string: "d")))
+
+            // combineResults propagates errors from any slot.
+            #expect(throws: ValkeyClientError.self) {
+                try MGET.combineResults(
+                    originalKeyCount: 2,
+                    slotResults: [
+                        (indices: [0], result: .success(slot1Response)),
+                        (indices: [1], result: .failure(ValkeyClientError(.cancelled))),
+                    ]
+                )
+            }
+
+            // Empty keys produces empty result.
+            let empty = try MGET.combineResults(originalKeyCount: 0, slotResults: [])
+            #expect(empty.count == 0)
+        }
+    }
 }
 
 @available(valkeySwift 1.0, *)

--- a/Tests/ValkeyTests/CommandTests.swift
+++ b/Tests/ValkeyTests/CommandTests.swift
@@ -2977,58 +2977,6 @@ struct CommandTests {
             }
         }
     }
-
-    // MARK: - Multi-key cluster commands
-
-    struct MultiKeyCommands {
-
-        @Test
-        @available(valkeySwift 1.0, *)
-        func mgetScatterGather() throws {
-            // Simulate MGET with 4 keys split across 2 slots: [0, 2] and [1, 3].
-            let command = MGET(keys: ["a", "b", "c", "d"])
-
-            // createSubCommand picks the right keys for each slot.
-            let sub1 = command.createSubCommand(for: [0, 2])
-            #expect(sub1.keys == [ValkeyKey("a"), ValkeyKey("c")])
-            let sub2 = command.createSubCommand(for: [1, 3])
-            #expect(sub2.keys == [ValkeyKey("b"), ValkeyKey("d")])
-
-            // Simulate per-slot RESP responses (values match key names).
-            let slot1Response = RESPToken(.array([.bulkString("a"), .bulkString("c")]))
-            let slot2Response = RESPToken(.array([.null, .bulkString("d")]))
-
-            // combineResults reassembles in original key order.
-            let combined = try MGET.combineResults(
-                originalKeyCount: 4,
-                slotResults: [
-                    (indices: [0, 2], result: .success(slot1Response)),
-                    (indices: [1, 3], result: .success(slot2Response)),
-                ]
-            )
-            let values = Array(combined)
-            #expect(values.count == 4)
-            #expect(values[0].value == .bulkString(ByteBuffer(string: "a")))
-            #expect(values[1].value == .null)
-            #expect(values[2].value == .bulkString(ByteBuffer(string: "c")))
-            #expect(values[3].value == .bulkString(ByteBuffer(string: "d")))
-
-            // combineResults propagates errors from any slot.
-            #expect(throws: ValkeyClientError.self) {
-                try MGET.combineResults(
-                    originalKeyCount: 2,
-                    slotResults: [
-                        (indices: [0], result: .success(slot1Response)),
-                        (indices: [1], result: .failure(ValkeyClientError(.cancelled))),
-                    ]
-                )
-            }
-
-            // Empty keys produces empty result.
-            let empty = try MGET.combineResults(originalKeyCount: 0, slotResults: [])
-            #expect(empty.count == 0)
-        }
-    }
 }
 
 @available(valkeySwift 1.0, *)


### PR DESCRIPTION
  **Summary**

  - Add `ValkeyClusterMultiKeyCommand` protocol for commands that operate on keys spanning multiple hash slots
  - Implement cluster-wide `MGET` that transparently scatters sub-commands across nodes and reassembles results in original key order
  - Single-slot fast path skips scatter-gather and routes directly through the standard execute path
  - In future iterations this can be further optimized by opening per-node pipelines instead of per-slot pipeline. 