### PR TITLE
Fields type includes a count and an array. Replace with just an array

### DIFF
--- a/Sources/Valkey/Commands/Custom/HashCustomCommands.swift
+++ b/Sources/Valkey/Commands/Custom/HashCustomCommands.swift
@@ -284,7 +284,14 @@ extension HSETEX {
             data.encode(into: &commandEncoder)
         }
     }
-    @available(*, deprecated, message: "Use init with `fields: [Field]` parameter")
+
+    @available(*, deprecated, renamed: "fieldsData")
+    var fields: Fields {
+        get { .init(numfields: self.fieldsData.count, data: self.fieldsData) }
+        set { self.fieldsData = newValue.data }
+    }
+
+    @available(*, deprecated, renamed: "hsetex(_:fieldsCondition:expiration:fieldsData:)")
     @inlinable
     public init(_ key: ValkeyKey, fieldsCondition: FieldsCondition? = nil, expiration: Expiration? = nil, fields: Fields) {
         self.key = key
@@ -463,7 +470,7 @@ extension ValkeyClientProtocol {
     ///     * 1: All the fields value and or expiration time was set.
     @inlinable
     @discardableResult
-    @available(*, deprecated, message: "Use version with `fields: [Field]` parameter")
+    @available(*, deprecated, renamed: "hsetex(_:fieldsCondition:expiration:fieldsData:)")
     public func hsetex<Field: RESPStringRenderable, Value: RESPStringRenderable>(
         _ key: ValkeyKey,
         fieldsCondition: HSETEX<Field, Value>.FieldsCondition? = nil,

--- a/Sources/Valkey/Commands/Custom/HashCustomCommands.swift
+++ b/Sources/Valkey/Commands/Custom/HashCustomCommands.swift
@@ -197,7 +197,8 @@ extension HTTL.Fields: ExpressibleByArrayLiteral {
 
 // MARK: Backwards compatibility
 
-@available(*, deprecated, message: "Use alternative APIs that take [Field]")
+@available(*, deprecated, message: "Fields has been deprecated in favor of Array<Field>")
+@_documentation(visibility: internal)
 public struct HashFields<Field: RESPStringRenderable>: RESPRenderable, Sendable, Hashable {
     public var numfields: Int
     public var fields: [Field]

--- a/Sources/Valkey/Commands/Custom/HashCustomCommands.swift
+++ b/Sources/Valkey/Commands/Custom/HashCustomCommands.swift
@@ -7,6 +7,8 @@
 //
 import NIOCore
 
+// MARK: Custom responses
+
 /// Sorted set entry
 @_documentation(visibility: internal)
 public struct HashEntry: RESPTokenDecodable, Sendable {
@@ -125,5 +127,162 @@ extension HRANDFIELD {
                 throw RESPDecodeError.tokenMismatch(expected: [.null, .array], token: token)
             }
         }
+    }
+}
+
+// MARK: Additional API
+
+extension HEXPIRETIME.Fields: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: Field...) {
+        self.numfields = elements.count
+        self.fields = elements
+    }
+}
+
+extension HGETEX.Fields: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: Field...) {
+        self.numfields = elements.count
+        self.fields = elements
+    }
+}
+
+extension HPERSIST.Fields: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: Field...) {
+        self.numfields = elements.count
+        self.fields = elements
+    }
+}
+
+extension HPEXPIRE.Fields: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: Field...) {
+        self.numfields = elements.count
+        self.fields = elements
+    }
+}
+
+extension HPEXPIREAT.Fields: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: Field...) {
+        self.numfields = elements.count
+        self.fields = elements
+    }
+}
+
+extension HPEXPIRETIME.Fields: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: Field...) {
+        self.numfields = elements.count
+        self.fields = elements
+    }
+}
+
+extension HPTTL.Fields: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: Field...) {
+        self.numfields = elements.count
+        self.fields = elements
+    }
+}
+
+extension HSETEX.Fields: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: HSETEX.FieldsData...) {
+        self.numfields = elements.count
+        self.data = elements
+    }
+}
+
+extension HTTL.Fields: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: Field...) {
+        self.numfields = elements.count
+        self.fields = elements
+    }
+}
+
+// MARK: Backwards compatibility
+
+@available(*, deprecated, message: "Use alternative APIs that take [Field]")
+public struct HashFields<Field: RESPStringRenderable>: RESPRenderable, Sendable, Hashable {
+    public var numfields: Int
+    public var fields: [Field]
+
+    @inlinable
+    public init(numfields: Int, fields: [Field]) {
+        self.numfields = numfields
+        self.fields = fields
+    }
+
+    @inlinable
+    public var respEntries: Int {
+        numfields.respEntries + fields.map { RESPRenderableBulkString($0) }.respEntries
+    }
+
+    @inlinable
+    public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
+        numfields.encode(into: &commandEncoder)
+        fields.map { RESPRenderableBulkString($0) }.encode(into: &commandEncoder)
+    }
+}
+
+extension HEXPIRE {
+    @available(*, deprecated, message: "Fields has been deprecated in favor of Array<Field>")
+    public typealias Fields = HashFields<Field>
+    @available(*, deprecated, message: "Use init with `field: [Field]` parameter")
+    @inlinable public init(_ key: ValkeyKey, seconds: Int, condition: Condition? = nil, fields: Fields) {
+        self.key = key
+        self.seconds = seconds
+        self.condition = condition
+        self.fields = fields.fields
+    }
+}
+
+@available(valkeySwift 1.0, *)
+extension ValkeyClientProtocol {
+    /// Set expiry time on hash fields.
+    ///
+    /// - Documentation: [HEXPIRE](https://valkey.io/commands/hexpire)
+    /// - Available: 9.0.0
+    /// - Complexity: O(N) where N is the number of specified fields.
+    /// - Returns: List of integer codes indicating the result of setting expiry on each specified field, in the same order as the fields are requested.
+    @inlinable
+    @discardableResult
+    @available(*, deprecated, message: "Use version with `field: [Field]` parameter")
+    public func hexpire<Field: RESPStringRenderable>(
+        _ key: ValkeyKey,
+        seconds: Int,
+        condition: HEXPIRE<Field>.Condition? = nil,
+        fields: HEXPIRE<Field>.Fields
+    ) async throws(ValkeyClientError) -> RESPToken.Array {
+        try await execute(HEXPIRE(key, seconds: seconds, condition: condition, fields: fields))
+    }
+}
+
+extension HEXPIREAT {
+    @available(*, deprecated, message: "Fields has been deprecated in favor of Array<Field>")
+    public typealias Fields = HashFields<Field>
+    @inlinable
+    @available(*, deprecated, message: "Use init with `field: [Field]` parameter")
+    public init(_ key: ValkeyKey, unixTimeSeconds: Int, condition: Condition? = nil, fields: Fields) {
+        self.key = key
+        self.unixTimeSeconds = unixTimeSeconds
+        self.condition = condition
+        self.fields = fields.fields
+    }
+}
+
+@available(valkeySwift 1.0, *)
+extension ValkeyClientProtocol {
+    /// Set expiry time on hash fields.
+    ///
+    /// - Documentation: [HEXPIREAT](https://valkey.io/commands/hexpireat)
+    /// - Available: 9.0.0
+    /// - Complexity: O(N) where N is the number of specified fields.
+    /// - Returns: List of integer codes indicating the result of setting expiry on each specified field, in the same order as the fields are requested.
+    @inlinable
+    @discardableResult
+    @available(*, deprecated, message: "Use version with `field: [Field]` parameter")
+    public func hexpireat<Field: RESPStringRenderable>(
+        _ key: ValkeyKey,
+        unixTimeSeconds: Int,
+        condition: HEXPIREAT<Field>.Condition? = nil,
+        fields: HEXPIREAT<Field>.Fields
+    ) async throws(ValkeyClientError) -> RESPToken.Array {
+        try await execute(HEXPIREAT(key, unixTimeSeconds: unixTimeSeconds, condition: condition, fields: fields))
     }
 }

--- a/Sources/Valkey/Commands/Custom/HashCustomCommands.swift
+++ b/Sources/Valkey/Commands/Custom/HashCustomCommands.swift
@@ -286,7 +286,7 @@ extension HSETEX {
     }
 
     @available(*, deprecated, renamed: "fieldsData")
-    var fields: Fields {
+    public var fields: Fields {
         get { .init(numfields: self.fieldsData.count, data: self.fieldsData) }
         set { self.fieldsData = newValue.data }
     }

--- a/Sources/Valkey/Commands/Custom/HashCustomCommands.swift
+++ b/Sources/Valkey/Commands/Custom/HashCustomCommands.swift
@@ -130,71 +130,6 @@ extension HRANDFIELD {
     }
 }
 
-// MARK: Additional API
-
-extension HEXPIRETIME.Fields: ExpressibleByArrayLiteral {
-    public init(arrayLiteral elements: Field...) {
-        self.numfields = elements.count
-        self.fields = elements
-    }
-}
-
-extension HGETEX.Fields: ExpressibleByArrayLiteral {
-    public init(arrayLiteral elements: Field...) {
-        self.numfields = elements.count
-        self.fields = elements
-    }
-}
-
-extension HPERSIST.Fields: ExpressibleByArrayLiteral {
-    public init(arrayLiteral elements: Field...) {
-        self.numfields = elements.count
-        self.fields = elements
-    }
-}
-
-extension HPEXPIRE.Fields: ExpressibleByArrayLiteral {
-    public init(arrayLiteral elements: Field...) {
-        self.numfields = elements.count
-        self.fields = elements
-    }
-}
-
-extension HPEXPIREAT.Fields: ExpressibleByArrayLiteral {
-    public init(arrayLiteral elements: Field...) {
-        self.numfields = elements.count
-        self.fields = elements
-    }
-}
-
-extension HPEXPIRETIME.Fields: ExpressibleByArrayLiteral {
-    public init(arrayLiteral elements: Field...) {
-        self.numfields = elements.count
-        self.fields = elements
-    }
-}
-
-extension HPTTL.Fields: ExpressibleByArrayLiteral {
-    public init(arrayLiteral elements: Field...) {
-        self.numfields = elements.count
-        self.fields = elements
-    }
-}
-
-extension HSETEX.Fields: ExpressibleByArrayLiteral {
-    public init(arrayLiteral elements: HSETEX.FieldsData...) {
-        self.numfields = elements.count
-        self.data = elements
-    }
-}
-
-extension HTTL.Fields: ExpressibleByArrayLiteral {
-    public init(arrayLiteral elements: Field...) {
-        self.numfields = elements.count
-        self.fields = elements
-    }
-}
-
 // MARK: Backwards compatibility
 
 @available(*, deprecated, message: "Fields has been deprecated in favor of Array<Field>")
@@ -224,11 +159,148 @@ public struct HashFields<Field: RESPStringRenderable>: RESPRenderable, Sendable,
 extension HEXPIRE {
     @available(*, deprecated, message: "Fields has been deprecated in favor of Array<Field>")
     public typealias Fields = HashFields<Field>
-    @available(*, deprecated, message: "Use init with `field: [Field]` parameter")
+    @available(*, deprecated, message: "Use init with `fields: [Field]` parameter")
     @inlinable public init(_ key: ValkeyKey, seconds: Int, condition: Condition? = nil, fields: Fields) {
         self.key = key
         self.seconds = seconds
         self.condition = condition
+        self.fields = fields.fields
+    }
+}
+
+extension HEXPIREAT {
+    @available(*, deprecated, message: "Fields has been deprecated in favor of Array<Field>")
+    public typealias Fields = HashFields<Field>
+    @inlinable
+    @available(*, deprecated, message: "Use init with `fields: [Field]` parameter")
+    public init(_ key: ValkeyKey, unixTimeSeconds: Int, condition: Condition? = nil, fields: Fields) {
+        self.key = key
+        self.unixTimeSeconds = unixTimeSeconds
+        self.condition = condition
+        self.fields = fields.fields
+    }
+}
+
+extension HEXPIRETIME {
+    @available(*, deprecated, message: "Fields has been deprecated in favor of Array<Field>")
+    public typealias Fields = HashFields<Field>
+    @inlinable
+    @available(*, deprecated, message: "Use init with `fields: [Field]` parameter")
+    public init(_ key: ValkeyKey, fields: Fields) {
+        self.key = key
+        self.fields = fields.fields
+    }
+}
+
+extension HGETEX {
+    @available(*, deprecated, message: "Fields has been deprecated in favor of Array<Field>")
+    public typealias Fields = HashFields<Field>
+    @inlinable
+    @available(*, deprecated, message: "Use init with `fields: [Field]` parameter")
+    public init(_ key: ValkeyKey, expiration: Expiration? = nil, fields: Fields) {
+        self.key = key
+        self.expiration = expiration
+        self.fields = fields.fields
+    }
+}
+
+extension HPERSIST {
+    @available(*, deprecated, message: "Fields has been deprecated in favor of Array<Field>")
+    public typealias Fields = HashFields<Field>
+    @inlinable
+    @available(*, deprecated, message: "Use init with `fields: [Field]` parameter")
+    public init(_ key: ValkeyKey, fields: Fields) {
+        self.key = key
+        self.fields = fields.fields
+    }
+}
+
+extension HPEXPIRE {
+    @available(*, deprecated, message: "Fields has been deprecated in favor of Array<Field>")
+    public typealias Fields = HashFields<Field>
+    @available(*, deprecated, message: "Use init with `fields: [Field]` parameter")
+    @inlinable public init(_ key: ValkeyKey, milliseconds: Int, condition: Condition? = nil, fields: Fields) {
+        self.key = key
+        self.milliseconds = milliseconds
+        self.condition = condition
+        self.fields = fields.fields
+    }
+}
+
+extension HPEXPIREAT {
+    @available(*, deprecated, message: "Fields has been deprecated in favor of Array<Field>")
+    public typealias Fields = HashFields<Field>
+    @inlinable
+    @available(*, deprecated, message: "Use init with `fields: [Field]` parameter")
+    public init(_ key: ValkeyKey, unixTimeMilliseconds: Int, condition: Condition? = nil, fields: Fields) {
+        self.key = key
+        self.unixTimeMilliseconds = unixTimeMilliseconds
+        self.condition = condition
+        self.fields = fields.fields
+    }
+}
+
+extension HPEXPIRETIME {
+    @available(*, deprecated, message: "Fields has been deprecated in favor of Array<Field>")
+    public typealias Fields = HashFields<Field>
+    @inlinable
+    @available(*, deprecated, message: "Use init with `fields: [Field]` parameter")
+    public init(_ key: ValkeyKey, fields: Fields) {
+        self.key = key
+        self.fields = fields.fields
+    }
+}
+
+extension HPTTL {
+    @available(*, deprecated, message: "Fields has been deprecated in favor of Array<Field>")
+    public typealias Fields = HashFields<Field>
+    @inlinable
+    @available(*, deprecated, message: "Use init with `fields: [Field]` parameter")
+    public init(_ key: ValkeyKey, fields: Fields) {
+        self.key = key
+        self.fields = fields.fields
+    }
+}
+
+extension HSETEX {
+    public struct Fields: RESPRenderable, Sendable, Hashable {
+        public var numfields: Int
+        public var data: [FieldsData]
+
+        @inlinable
+        public init(numfields: Int, data: [FieldsData]) {
+            self.numfields = numfields
+            self.data = data
+        }
+
+        @inlinable
+        public var respEntries: Int {
+            numfields.respEntries + data.respEntries
+        }
+
+        @inlinable
+        public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
+            numfields.encode(into: &commandEncoder)
+            data.encode(into: &commandEncoder)
+        }
+    }
+    @available(*, deprecated, message: "Use init with `fields: [Field]` parameter")
+    @inlinable
+    public init(_ key: ValkeyKey, fieldsCondition: FieldsCondition? = nil, expiration: Expiration? = nil, fields: Fields) {
+        self.key = key
+        self.fieldsCondition = fieldsCondition
+        self.expiration = expiration
+        self.fieldsData = fields.data
+    }
+}
+
+extension HTTL {
+    @available(*, deprecated, message: "Fields has been deprecated in favor of Array<Field>")
+    public typealias Fields = HashFields<Field>
+    @inlinable
+    @available(*, deprecated, message: "Use init with `fields: [Field]` parameter")
+    public init(_ key: ValkeyKey, fields: Fields) {
+        self.key = key
         self.fields = fields.fields
     }
 }
@@ -243,7 +315,7 @@ extension ValkeyClientProtocol {
     /// - Returns: List of integer codes indicating the result of setting expiry on each specified field, in the same order as the fields are requested.
     @inlinable
     @discardableResult
-    @available(*, deprecated, message: "Use version with `field: [Field]` parameter")
+    @available(*, deprecated, message: "Use version with `fields: [Field]` parameter")
     public func hexpire<Field: RESPStringRenderable>(
         _ key: ValkeyKey,
         seconds: Int,
@@ -252,23 +324,6 @@ extension ValkeyClientProtocol {
     ) async throws(ValkeyClientError) -> RESPToken.Array {
         try await execute(HEXPIRE(key, seconds: seconds, condition: condition, fields: fields))
     }
-}
-
-extension HEXPIREAT {
-    @available(*, deprecated, message: "Fields has been deprecated in favor of Array<Field>")
-    public typealias Fields = HashFields<Field>
-    @inlinable
-    @available(*, deprecated, message: "Use init with `field: [Field]` parameter")
-    public init(_ key: ValkeyKey, unixTimeSeconds: Int, condition: Condition? = nil, fields: Fields) {
-        self.key = key
-        self.unixTimeSeconds = unixTimeSeconds
-        self.condition = condition
-        self.fields = fields.fields
-    }
-}
-
-@available(valkeySwift 1.0, *)
-extension ValkeyClientProtocol {
     /// Set expiry time on hash fields.
     ///
     /// - Documentation: [HEXPIREAT](https://valkey.io/commands/hexpireat)
@@ -277,7 +332,7 @@ extension ValkeyClientProtocol {
     /// - Returns: List of integer codes indicating the result of setting expiry on each specified field, in the same order as the fields are requested.
     @inlinable
     @discardableResult
-    @available(*, deprecated, message: "Use version with `field: [Field]` parameter")
+    @available(*, deprecated, message: "Use version with `fields: [Field]` parameter")
     public func hexpireat<Field: RESPStringRenderable>(
         _ key: ValkeyKey,
         unixTimeSeconds: Int,
@@ -285,5 +340,148 @@ extension ValkeyClientProtocol {
         fields: HEXPIREAT<Field>.Fields
     ) async throws(ValkeyClientError) -> RESPToken.Array {
         try await execute(HEXPIREAT(key, unixTimeSeconds: unixTimeSeconds, condition: condition, fields: fields))
+    }
+
+    /// Returns Unix timestamps in seconds since the epoch at which the given key's field(s) will expire
+    ///
+    /// - Documentation: [HEXPIRETIME](https://valkey.io/commands/hexpiretime)
+    /// - Available: 9.0.0
+    /// - Complexity: O(N) where N is the number of specified fields.
+    /// - Returns: List of values associated with the result of getting the absolute expiry timestamp of the specific fields, in the same order as they are requested.
+    @inlinable
+    @available(*, deprecated, message: "Use version with `fields: [Field]` parameter")
+    public func hexpiretime<Field: RESPStringRenderable>(
+        _ key: ValkeyKey,
+        fields: HEXPIRETIME<Field>.Fields
+    ) async throws(ValkeyClientError) -> RESPToken.Array {
+        try await execute(HEXPIRETIME(key, fields: fields))
+    }
+
+    /// Get the value of one or more fields of a given hash key, and optionally set their expiration time or time-to-live (TTL).
+    ///
+    /// - Documentation: [HGETEX](https://valkey.io/commands/hgetex)
+    /// - Available: 9.0.0
+    /// - Complexity: O(N) where N is the number of specified fields.
+    /// - Returns: List of values associated with the given fields, in the same order as they are requested.
+    @inlinable
+    @discardableResult
+    @available(*, deprecated, message: "Use version with `fields: [Field]` parameter")
+    public func hgetex<Field: RESPStringRenderable>(
+        _ key: ValkeyKey,
+        expiration: HGETEX<Field>.Expiration? = nil,
+        fields: HGETEX<Field>.Fields
+    ) async throws(ValkeyClientError) -> RESPToken.Array {
+        try await execute(HGETEX(key, expiration: expiration, fields: fields))
+    }
+
+    /// Remove the existing expiration on a hash key's field(s).
+    ///
+    /// - Documentation: [HPERSIST](https://valkey.io/commands/hpersist)
+    /// - Available: 9.0.0
+    /// - Complexity: O(N) where N is the number of specified fields.
+    /// - Returns: List of integer codes indicating the result of setting expiry on each specified field, in the same order as the fields are requested.
+    @inlinable
+    @discardableResult
+    @available(*, deprecated, message: "Use version with `fields: [Field]` parameter")
+    public func hpersist<Field: RESPStringRenderable>(
+        _ key: ValkeyKey,
+        fields: HPERSIST<Field>.Fields
+    ) async throws(ValkeyClientError) -> RESPToken.Array {
+        try await execute(HPERSIST(key, fields: fields))
+    }
+
+    /// Set expiry time on hash object.
+    ///
+    /// - Documentation: [HPEXPIRE](https://valkey.io/commands/hpexpire)
+    /// - Available: 9.0.0
+    /// - Complexity: O(N) where N is the number of specified fields.
+    /// - Returns: List of integer codes indicating the result of setting expiry on each specified field, in the same order as the fields are requested.
+    @inlinable
+    @discardableResult
+    @available(*, deprecated, message: "Use version with `fields: [Field]` parameter")
+    public func hpexpire<Field: RESPStringRenderable>(
+        _ key: ValkeyKey,
+        milliseconds: Int,
+        condition: HPEXPIRE<Field>.Condition? = nil,
+        fields: HPEXPIRE<Field>.Fields
+    ) async throws(ValkeyClientError) -> RESPToken.Array {
+        try await execute(HPEXPIRE(key, milliseconds: milliseconds, condition: condition, fields: fields))
+    }
+
+    /// Set expiration time on hash field.
+    ///
+    /// - Documentation: [HPEXPIREAT](https://valkey.io/commands/hpexpireat)
+    /// - Available: 9.0.0
+    /// - Complexity: O(N) where N is the number of specified fields.
+    /// - Returns: List of integer codes indicating the result of setting expiry on each specified field, in the same order as the fields are requested.
+    @inlinable
+    @discardableResult
+    @available(*, deprecated, message: "Use version with `fields: [Field]` parameter")
+    public func hpexpireat<Field: RESPStringRenderable>(
+        _ key: ValkeyKey,
+        unixTimeMilliseconds: Int,
+        condition: HPEXPIREAT<Field>.Condition? = nil,
+        fields: HPEXPIREAT<Field>.Fields
+    ) async throws(ValkeyClientError) -> RESPToken.Array {
+        try await execute(HPEXPIREAT(key, unixTimeMilliseconds: unixTimeMilliseconds, condition: condition, fields: fields))
+    }
+
+    /// Returns the Unix timestamp in milliseconds since Unix epoch at which the given key's field(s) will expire
+    ///
+    /// - Documentation: [HPEXPIRETIME](https://valkey.io/commands/hpexpiretime)
+    /// - Available: 9.0.0
+    /// - Complexity: O(N) where N is the number of specified fields.
+    /// - Returns: List of values associated with the result of getting the absolute expiry timestamp of the specific fields, in the same order as they are requested.
+    @inlinable
+    @available(*, deprecated, message: "Use version with `fields: [Field]` parameter")
+    public func hpexpiretime<Field: RESPStringRenderable>(
+        _ key: ValkeyKey,
+        fields: HPEXPIRETIME<Field>.Fields
+    ) async throws(ValkeyClientError) -> RESPToken.Array {
+        try await execute(HPEXPIRETIME(key, fields: fields))
+    }
+
+    /// Returns the remaining time to live in milliseconds of a hash key's field(s) that have an associated expiration.
+    ///
+    /// - Documentation: [HPTTL](https://valkey.io/commands/hpttl)
+    /// - Available: 9.0.0
+    /// - Complexity: O(N) where N is the number of specified fields.
+    /// - Returns: List of values associated with the result of getting the remaining time-to-live of the specific fields, in the same order as they are requested.
+    @inlinable
+    @available(*, deprecated, message: "Use version with `fields: [Field]` parameter")
+    public func hpttl<Field: RESPStringRenderable>(_ key: ValkeyKey, fields: HPTTL<Field>.Fields) async throws(ValkeyClientError) -> RESPToken.Array {
+        try await execute(HPTTL(key, fields: fields))
+    }
+
+    /// Set the value of one or more fields of a given hash key, and optionally set their expiration time.
+    ///
+    /// - Documentation: [HSETEX](https://valkey.io/commands/hsetex)
+    /// - Available: 9.0.0
+    /// - Complexity: O(N) where N is the number of specified fields.
+    /// - Returns: One of the following
+    ///     * 0: None of the provided fields value and or expiration time was set.
+    ///     * 1: All the fields value and or expiration time was set.
+    @inlinable
+    @discardableResult
+    @available(*, deprecated, message: "Use version with `fields: [Field]` parameter")
+    public func hsetex<Field: RESPStringRenderable, Value: RESPStringRenderable>(
+        _ key: ValkeyKey,
+        fieldsCondition: HSETEX<Field, Value>.FieldsCondition? = nil,
+        expiration: HSETEX<Field, Value>.Expiration? = nil,
+        fields: HSETEX<Field, Value>.Fields
+    ) async throws(ValkeyClientError) -> Int {
+        try await execute(HSETEX(key, fieldsCondition: fieldsCondition, expiration: expiration, fields: fields))
+    }
+
+    /// Returns the remaining time to live (in seconds) of a hash key's field(s) that have an associated expiration.
+    ///
+    /// - Documentation: [HTTL](https://valkey.io/commands/httl)
+    /// - Available: 9.0.0
+    /// - Complexity: O(N) where N is the number of specified fields.
+    /// - Returns: List of values associated with the result of getting the remaining time-to-live of the specific fields, in the same order as they are requested.
+    @inlinable
+    @available(*, deprecated, message: "Use version with `fields: [Field]` parameter")
+    public func httl<Field: RESPStringRenderable>(_ key: ValkeyKey, fields: HTTL<Field>.Fields) async throws(ValkeyClientError) -> RESPToken.Array {
+        try await execute(HTTL(key, fields: fields))
     }
 }

--- a/Sources/Valkey/Commands/HashCommands.swift
+++ b/Sources/Valkey/Commands/HashCommands.swift
@@ -166,35 +166,14 @@ public struct HEXPIREAT<Field: RESPStringRenderable>: ValkeyCommand {
 /// Returns Unix timestamps in seconds since the epoch at which the given key's field(s) will expire
 @_documentation(visibility: internal)
 public struct HEXPIRETIME<Field: RESPStringRenderable>: ValkeyCommand {
-    public struct Fields: RESPRenderable, Sendable, Hashable {
-        public var numfields: Int
-        public var fields: [Field]
-
-        @inlinable
-        public init(numfields: Int, fields: [Field]) {
-            self.numfields = numfields
-            self.fields = fields
-        }
-
-        @inlinable
-        public var respEntries: Int {
-            numfields.respEntries + fields.map { RESPRenderableBulkString($0) }.respEntries
-        }
-
-        @inlinable
-        public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-            numfields.encode(into: &commandEncoder)
-            fields.map { RESPRenderableBulkString($0) }.encode(into: &commandEncoder)
-        }
-    }
     public typealias Response = RESPToken.Array
 
     @inlinable public static var name: String { "HEXPIRETIME" }
 
     public var key: ValkeyKey
-    public var fields: Fields
+    public var fields: [Field]
 
-    @inlinable public init(_ key: ValkeyKey, fields: Fields) {
+    @inlinable public init(_ key: ValkeyKey, fields: [Field]) {
         self.key = key
         self.fields = fields
     }
@@ -204,7 +183,7 @@ public struct HEXPIRETIME<Field: RESPStringRenderable>: ValkeyCommand {
     public var isReadOnly: Bool { true }
 
     @inlinable public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-        commandEncoder.encodeArray("HEXPIRETIME", key, RESPWithToken("FIELDS", fields))
+        commandEncoder.encodeArray("HEXPIRETIME", key, RESPArrayWithTokenAndCount("FIELDS", fields.map { RESPRenderableBulkString($0) }))
     }
 }
 
@@ -289,36 +268,15 @@ public struct HGETEX<Field: RESPStringRenderable>: ValkeyCommand {
             }
         }
     }
-    public struct Fields: RESPRenderable, Sendable, Hashable {
-        public var numfields: Int
-        public var fields: [Field]
-
-        @inlinable
-        public init(numfields: Int, fields: [Field]) {
-            self.numfields = numfields
-            self.fields = fields
-        }
-
-        @inlinable
-        public var respEntries: Int {
-            numfields.respEntries + fields.map { RESPRenderableBulkString($0) }.respEntries
-        }
-
-        @inlinable
-        public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-            numfields.encode(into: &commandEncoder)
-            fields.map { RESPRenderableBulkString($0) }.encode(into: &commandEncoder)
-        }
-    }
     public typealias Response = RESPToken.Array
 
     @inlinable public static var name: String { "HGETEX" }
 
     public var key: ValkeyKey
     public var expiration: Expiration?
-    public var fields: Fields
+    public var fields: [Field]
 
-    @inlinable public init(_ key: ValkeyKey, expiration: Expiration? = nil, fields: Fields) {
+    @inlinable public init(_ key: ValkeyKey, expiration: Expiration? = nil, fields: [Field]) {
         self.key = key
         self.expiration = expiration
         self.fields = fields
@@ -327,7 +285,7 @@ public struct HGETEX<Field: RESPStringRenderable>: ValkeyCommand {
     public var keysAffected: CollectionOfOne<ValkeyKey> { .init(key) }
 
     @inlinable public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-        commandEncoder.encodeArray("HGETEX", key, expiration, RESPWithToken("FIELDS", fields))
+        commandEncoder.encodeArray("HGETEX", key, expiration, RESPArrayWithTokenAndCount("FIELDS", fields.map { RESPRenderableBulkString($0) }))
     }
 }
 
@@ -491,35 +449,14 @@ public struct HMSET<Field: RESPStringRenderable, Value: RESPStringRenderable>: V
 /// Remove the existing expiration on a hash key's field(s).
 @_documentation(visibility: internal)
 public struct HPERSIST<Field: RESPStringRenderable>: ValkeyCommand {
-    public struct Fields: RESPRenderable, Sendable, Hashable {
-        public var numfields: Int
-        public var fields: [Field]
-
-        @inlinable
-        public init(numfields: Int, fields: [Field]) {
-            self.numfields = numfields
-            self.fields = fields
-        }
-
-        @inlinable
-        public var respEntries: Int {
-            numfields.respEntries + fields.map { RESPRenderableBulkString($0) }.respEntries
-        }
-
-        @inlinable
-        public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-            numfields.encode(into: &commandEncoder)
-            fields.map { RESPRenderableBulkString($0) }.encode(into: &commandEncoder)
-        }
-    }
     public typealias Response = RESPToken.Array
 
     @inlinable public static var name: String { "HPERSIST" }
 
     public var key: ValkeyKey
-    public var fields: Fields
+    public var fields: [Field]
 
-    @inlinable public init(_ key: ValkeyKey, fields: Fields) {
+    @inlinable public init(_ key: ValkeyKey, fields: [Field]) {
         self.key = key
         self.fields = fields
     }
@@ -527,7 +464,7 @@ public struct HPERSIST<Field: RESPStringRenderable>: ValkeyCommand {
     public var keysAffected: CollectionOfOne<ValkeyKey> { .init(key) }
 
     @inlinable public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-        commandEncoder.encodeArray("HPERSIST", key, RESPWithToken("FIELDS", fields))
+        commandEncoder.encodeArray("HPERSIST", key, RESPArrayWithTokenAndCount("FIELDS", fields.map { RESPRenderableBulkString($0) }))
     }
 }
 
@@ -553,27 +490,6 @@ public struct HPEXPIRE<Field: RESPStringRenderable>: ValkeyCommand {
             }
         }
     }
-    public struct Fields: RESPRenderable, Sendable, Hashable {
-        public var numfields: Int
-        public var fields: [Field]
-
-        @inlinable
-        public init(numfields: Int, fields: [Field]) {
-            self.numfields = numfields
-            self.fields = fields
-        }
-
-        @inlinable
-        public var respEntries: Int {
-            numfields.respEntries + fields.map { RESPRenderableBulkString($0) }.respEntries
-        }
-
-        @inlinable
-        public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-            numfields.encode(into: &commandEncoder)
-            fields.map { RESPRenderableBulkString($0) }.encode(into: &commandEncoder)
-        }
-    }
     public typealias Response = RESPToken.Array
 
     @inlinable public static var name: String { "HPEXPIRE" }
@@ -581,9 +497,9 @@ public struct HPEXPIRE<Field: RESPStringRenderable>: ValkeyCommand {
     public var key: ValkeyKey
     public var milliseconds: Int
     public var condition: Condition?
-    public var fields: Fields
+    public var fields: [Field]
 
-    @inlinable public init(_ key: ValkeyKey, milliseconds: Int, condition: Condition? = nil, fields: Fields) {
+    @inlinable public init(_ key: ValkeyKey, milliseconds: Int, condition: Condition? = nil, fields: [Field]) {
         self.key = key
         self.milliseconds = milliseconds
         self.condition = condition
@@ -593,7 +509,13 @@ public struct HPEXPIRE<Field: RESPStringRenderable>: ValkeyCommand {
     public var keysAffected: CollectionOfOne<ValkeyKey> { .init(key) }
 
     @inlinable public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-        commandEncoder.encodeArray("HPEXPIRE", key, milliseconds, condition, RESPWithToken("FIELDS", fields))
+        commandEncoder.encodeArray(
+            "HPEXPIRE",
+            key,
+            milliseconds,
+            condition,
+            RESPArrayWithTokenAndCount("FIELDS", fields.map { RESPRenderableBulkString($0) })
+        )
     }
 }
 
@@ -619,27 +541,6 @@ public struct HPEXPIREAT<Field: RESPStringRenderable>: ValkeyCommand {
             }
         }
     }
-    public struct Fields: RESPRenderable, Sendable, Hashable {
-        public var numfields: Int
-        public var fields: [Field]
-
-        @inlinable
-        public init(numfields: Int, fields: [Field]) {
-            self.numfields = numfields
-            self.fields = fields
-        }
-
-        @inlinable
-        public var respEntries: Int {
-            numfields.respEntries + fields.map { RESPRenderableBulkString($0) }.respEntries
-        }
-
-        @inlinable
-        public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-            numfields.encode(into: &commandEncoder)
-            fields.map { RESPRenderableBulkString($0) }.encode(into: &commandEncoder)
-        }
-    }
     public typealias Response = RESPToken.Array
 
     @inlinable public static var name: String { "HPEXPIREAT" }
@@ -647,9 +548,9 @@ public struct HPEXPIREAT<Field: RESPStringRenderable>: ValkeyCommand {
     public var key: ValkeyKey
     public var unixTimeMilliseconds: Int
     public var condition: Condition?
-    public var fields: Fields
+    public var fields: [Field]
 
-    @inlinable public init(_ key: ValkeyKey, unixTimeMilliseconds: Int, condition: Condition? = nil, fields: Fields) {
+    @inlinable public init(_ key: ValkeyKey, unixTimeMilliseconds: Int, condition: Condition? = nil, fields: [Field]) {
         self.key = key
         self.unixTimeMilliseconds = unixTimeMilliseconds
         self.condition = condition
@@ -659,42 +560,27 @@ public struct HPEXPIREAT<Field: RESPStringRenderable>: ValkeyCommand {
     public var keysAffected: CollectionOfOne<ValkeyKey> { .init(key) }
 
     @inlinable public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-        commandEncoder.encodeArray("HPEXPIREAT", key, unixTimeMilliseconds, condition, RESPWithToken("FIELDS", fields))
+        commandEncoder.encodeArray(
+            "HPEXPIREAT",
+            key,
+            unixTimeMilliseconds,
+            condition,
+            RESPArrayWithTokenAndCount("FIELDS", fields.map { RESPRenderableBulkString($0) })
+        )
     }
 }
 
 /// Returns the Unix timestamp in milliseconds since Unix epoch at which the given key's field(s) will expire
 @_documentation(visibility: internal)
 public struct HPEXPIRETIME<Field: RESPStringRenderable>: ValkeyCommand {
-    public struct Fields: RESPRenderable, Sendable, Hashable {
-        public var numfields: Int
-        public var fields: [Field]
-
-        @inlinable
-        public init(numfields: Int, fields: [Field]) {
-            self.numfields = numfields
-            self.fields = fields
-        }
-
-        @inlinable
-        public var respEntries: Int {
-            numfields.respEntries + fields.map { RESPRenderableBulkString($0) }.respEntries
-        }
-
-        @inlinable
-        public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-            numfields.encode(into: &commandEncoder)
-            fields.map { RESPRenderableBulkString($0) }.encode(into: &commandEncoder)
-        }
-    }
     public typealias Response = RESPToken.Array
 
     @inlinable public static var name: String { "HPEXPIRETIME" }
 
     public var key: ValkeyKey
-    public var fields: Fields
+    public var fields: [Field]
 
-    @inlinable public init(_ key: ValkeyKey, fields: Fields) {
+    @inlinable public init(_ key: ValkeyKey, fields: [Field]) {
         self.key = key
         self.fields = fields
     }
@@ -704,42 +590,21 @@ public struct HPEXPIRETIME<Field: RESPStringRenderable>: ValkeyCommand {
     public var isReadOnly: Bool { true }
 
     @inlinable public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-        commandEncoder.encodeArray("HPEXPIRETIME", key, RESPWithToken("FIELDS", fields))
+        commandEncoder.encodeArray("HPEXPIRETIME", key, RESPArrayWithTokenAndCount("FIELDS", fields.map { RESPRenderableBulkString($0) }))
     }
 }
 
 /// Returns the remaining time to live in milliseconds of a hash key's field(s) that have an associated expiration.
 @_documentation(visibility: internal)
 public struct HPTTL<Field: RESPStringRenderable>: ValkeyCommand {
-    public struct Fields: RESPRenderable, Sendable, Hashable {
-        public var numfields: Int
-        public var fields: [Field]
-
-        @inlinable
-        public init(numfields: Int, fields: [Field]) {
-            self.numfields = numfields
-            self.fields = fields
-        }
-
-        @inlinable
-        public var respEntries: Int {
-            numfields.respEntries + fields.map { RESPRenderableBulkString($0) }.respEntries
-        }
-
-        @inlinable
-        public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-            numfields.encode(into: &commandEncoder)
-            fields.map { RESPRenderableBulkString($0) }.encode(into: &commandEncoder)
-        }
-    }
     public typealias Response = RESPToken.Array
 
     @inlinable public static var name: String { "HPTTL" }
 
     public var key: ValkeyKey
-    public var fields: Fields
+    public var fields: [Field]
 
-    @inlinable public init(_ key: ValkeyKey, fields: Fields) {
+    @inlinable public init(_ key: ValkeyKey, fields: [Field]) {
         self.key = key
         self.fields = fields
     }
@@ -749,7 +614,7 @@ public struct HPTTL<Field: RESPStringRenderable>: ValkeyCommand {
     public var isReadOnly: Bool { true }
 
     @inlinable public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-        commandEncoder.encodeArray("HPTTL", key, RESPWithToken("FIELDS", fields))
+        commandEncoder.encodeArray("HPTTL", key, RESPArrayWithTokenAndCount("FIELDS", fields.map { RESPRenderableBulkString($0) }))
     }
 }
 
@@ -945,27 +810,6 @@ public struct HSETEX<Field: RESPStringRenderable, Value: RESPStringRenderable>: 
             RESPRenderableBulkString(value).encode(into: &commandEncoder)
         }
     }
-    public struct Fields: RESPRenderable, Sendable, Hashable {
-        public var numfields: Int
-        public var data: [FieldsData]
-
-        @inlinable
-        public init(numfields: Int, data: [FieldsData]) {
-            self.numfields = numfields
-            self.data = data
-        }
-
-        @inlinable
-        public var respEntries: Int {
-            numfields.respEntries + data.respEntries
-        }
-
-        @inlinable
-        public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-            numfields.encode(into: &commandEncoder)
-            data.encode(into: &commandEncoder)
-        }
-    }
     public typealias Response = Int
 
     @inlinable public static var name: String { "HSETEX" }
@@ -973,19 +817,19 @@ public struct HSETEX<Field: RESPStringRenderable, Value: RESPStringRenderable>: 
     public var key: ValkeyKey
     public var fieldsCondition: FieldsCondition?
     public var expiration: Expiration?
-    public var fields: Fields
+    public var fieldsData: [FieldsData]
 
-    @inlinable public init(_ key: ValkeyKey, fieldsCondition: FieldsCondition? = nil, expiration: Expiration? = nil, fields: Fields) {
+    @inlinable public init(_ key: ValkeyKey, fieldsCondition: FieldsCondition? = nil, expiration: Expiration? = nil, fieldsData: [FieldsData]) {
         self.key = key
         self.fieldsCondition = fieldsCondition
         self.expiration = expiration
-        self.fields = fields
+        self.fieldsData = fieldsData
     }
 
     public var keysAffected: CollectionOfOne<ValkeyKey> { .init(key) }
 
     @inlinable public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-        commandEncoder.encodeArray("HSETEX", key, fieldsCondition, expiration, RESPWithToken("FIELDS", fields))
+        commandEncoder.encodeArray("HSETEX", key, fieldsCondition, expiration, RESPArrayWithTokenAndCount("FIELDS", fieldsData))
     }
 }
 
@@ -1040,35 +884,14 @@ public struct HSTRLEN<Field: RESPStringRenderable>: ValkeyCommand {
 /// Returns the remaining time to live (in seconds) of a hash key's field(s) that have an associated expiration.
 @_documentation(visibility: internal)
 public struct HTTL<Field: RESPStringRenderable>: ValkeyCommand {
-    public struct Fields: RESPRenderable, Sendable, Hashable {
-        public var numfields: Int
-        public var fields: [Field]
-
-        @inlinable
-        public init(numfields: Int, fields: [Field]) {
-            self.numfields = numfields
-            self.fields = fields
-        }
-
-        @inlinable
-        public var respEntries: Int {
-            numfields.respEntries + fields.map { RESPRenderableBulkString($0) }.respEntries
-        }
-
-        @inlinable
-        public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-            numfields.encode(into: &commandEncoder)
-            fields.map { RESPRenderableBulkString($0) }.encode(into: &commandEncoder)
-        }
-    }
     public typealias Response = RESPToken.Array
 
     @inlinable public static var name: String { "HTTL" }
 
     public var key: ValkeyKey
-    public var fields: Fields
+    public var fields: [Field]
 
-    @inlinable public init(_ key: ValkeyKey, fields: Fields) {
+    @inlinable public init(_ key: ValkeyKey, fields: [Field]) {
         self.key = key
         self.fields = fields
     }
@@ -1078,7 +901,7 @@ public struct HTTL<Field: RESPStringRenderable>: ValkeyCommand {
     public var isReadOnly: Bool { true }
 
     @inlinable public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-        commandEncoder.encodeArray("HTTL", key, RESPWithToken("FIELDS", fields))
+        commandEncoder.encodeArray("HTTL", key, RESPArrayWithTokenAndCount("FIELDS", fields.map { RESPRenderableBulkString($0) }))
     }
 }
 
@@ -1174,10 +997,7 @@ extension ValkeyClientProtocol {
     /// - Complexity: O(N) where N is the number of specified fields.
     /// - Returns: List of values associated with the result of getting the absolute expiry timestamp of the specific fields, in the same order as they are requested.
     @inlinable
-    public func hexpiretime<Field: RESPStringRenderable>(
-        _ key: ValkeyKey,
-        fields: HEXPIRETIME<Field>.Fields
-    ) async throws(ValkeyClientError) -> RESPToken.Array {
+    public func hexpiretime<Field: RESPStringRenderable>(_ key: ValkeyKey, fields: [Field]) async throws(ValkeyClientError) -> RESPToken.Array {
         try await execute(HEXPIRETIME(key, fields: fields))
     }
 
@@ -1216,7 +1036,7 @@ extension ValkeyClientProtocol {
     public func hgetex<Field: RESPStringRenderable>(
         _ key: ValkeyKey,
         expiration: HGETEX<Field>.Expiration? = nil,
-        fields: HGETEX<Field>.Fields
+        fields: [Field]
     ) async throws(ValkeyClientError) -> RESPToken.Array {
         try await execute(HGETEX(key, expiration: expiration, fields: fields))
     }
@@ -1303,10 +1123,7 @@ extension ValkeyClientProtocol {
     /// - Returns: List of integer codes indicating the result of setting expiry on each specified field, in the same order as the fields are requested.
     @inlinable
     @discardableResult
-    public func hpersist<Field: RESPStringRenderable>(
-        _ key: ValkeyKey,
-        fields: HPERSIST<Field>.Fields
-    ) async throws(ValkeyClientError) -> RESPToken.Array {
+    public func hpersist<Field: RESPStringRenderable>(_ key: ValkeyKey, fields: [Field]) async throws(ValkeyClientError) -> RESPToken.Array {
         try await execute(HPERSIST(key, fields: fields))
     }
 
@@ -1322,7 +1139,7 @@ extension ValkeyClientProtocol {
         _ key: ValkeyKey,
         milliseconds: Int,
         condition: HPEXPIRE<Field>.Condition? = nil,
-        fields: HPEXPIRE<Field>.Fields
+        fields: [Field]
     ) async throws(ValkeyClientError) -> RESPToken.Array {
         try await execute(HPEXPIRE(key, milliseconds: milliseconds, condition: condition, fields: fields))
     }
@@ -1339,7 +1156,7 @@ extension ValkeyClientProtocol {
         _ key: ValkeyKey,
         unixTimeMilliseconds: Int,
         condition: HPEXPIREAT<Field>.Condition? = nil,
-        fields: HPEXPIREAT<Field>.Fields
+        fields: [Field]
     ) async throws(ValkeyClientError) -> RESPToken.Array {
         try await execute(HPEXPIREAT(key, unixTimeMilliseconds: unixTimeMilliseconds, condition: condition, fields: fields))
     }
@@ -1351,10 +1168,7 @@ extension ValkeyClientProtocol {
     /// - Complexity: O(N) where N is the number of specified fields.
     /// - Returns: List of values associated with the result of getting the absolute expiry timestamp of the specific fields, in the same order as they are requested.
     @inlinable
-    public func hpexpiretime<Field: RESPStringRenderable>(
-        _ key: ValkeyKey,
-        fields: HPEXPIRETIME<Field>.Fields
-    ) async throws(ValkeyClientError) -> RESPToken.Array {
+    public func hpexpiretime<Field: RESPStringRenderable>(_ key: ValkeyKey, fields: [Field]) async throws(ValkeyClientError) -> RESPToken.Array {
         try await execute(HPEXPIRETIME(key, fields: fields))
     }
 
@@ -1365,7 +1179,7 @@ extension ValkeyClientProtocol {
     /// - Complexity: O(N) where N is the number of specified fields.
     /// - Returns: List of values associated with the result of getting the remaining time-to-live of the specific fields, in the same order as they are requested.
     @inlinable
-    public func hpttl<Field: RESPStringRenderable>(_ key: ValkeyKey, fields: HPTTL<Field>.Fields) async throws(ValkeyClientError) -> RESPToken.Array {
+    public func hpttl<Field: RESPStringRenderable>(_ key: ValkeyKey, fields: [Field]) async throws(ValkeyClientError) -> RESPToken.Array {
         try await execute(HPTTL(key, fields: fields))
     }
 
@@ -1432,9 +1246,9 @@ extension ValkeyClientProtocol {
         _ key: ValkeyKey,
         fieldsCondition: HSETEX<Field, Value>.FieldsCondition? = nil,
         expiration: HSETEX<Field, Value>.Expiration? = nil,
-        fields: HSETEX<Field, Value>.Fields
+        fieldsData: [HSETEX<Field, Value>.FieldsData]
     ) async throws(ValkeyClientError) -> Int {
-        try await execute(HSETEX(key, fieldsCondition: fieldsCondition, expiration: expiration, fields: fields))
+        try await execute(HSETEX(key, fieldsCondition: fieldsCondition, expiration: expiration, fieldsData: fieldsData))
     }
 
     /// Sets the value of a field in a hash only when the field doesn't exist.
@@ -1473,7 +1287,7 @@ extension ValkeyClientProtocol {
     /// - Complexity: O(N) where N is the number of specified fields.
     /// - Returns: List of values associated with the result of getting the remaining time-to-live of the specific fields, in the same order as they are requested.
     @inlinable
-    public func httl<Field: RESPStringRenderable>(_ key: ValkeyKey, fields: HTTL<Field>.Fields) async throws(ValkeyClientError) -> RESPToken.Array {
+    public func httl<Field: RESPStringRenderable>(_ key: ValkeyKey, fields: [Field]) async throws(ValkeyClientError) -> RESPToken.Array {
         try await execute(HTTL(key, fields: fields))
     }
 

--- a/Sources/Valkey/Commands/HashCommands.swift
+++ b/Sources/Valkey/Commands/HashCommands.swift
@@ -83,27 +83,6 @@ public struct HEXPIRE<Field: RESPStringRenderable>: ValkeyCommand {
             }
         }
     }
-    public struct Fields: RESPRenderable, Sendable, Hashable {
-        public var numfields: Int
-        public var fields: [Field]
-
-        @inlinable
-        public init(numfields: Int, fields: [Field]) {
-            self.numfields = numfields
-            self.fields = fields
-        }
-
-        @inlinable
-        public var respEntries: Int {
-            numfields.respEntries + fields.map { RESPRenderableBulkString($0) }.respEntries
-        }
-
-        @inlinable
-        public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-            numfields.encode(into: &commandEncoder)
-            fields.map { RESPRenderableBulkString($0) }.encode(into: &commandEncoder)
-        }
-    }
     public typealias Response = RESPToken.Array
 
     @inlinable public static var name: String { "HEXPIRE" }
@@ -111,9 +90,9 @@ public struct HEXPIRE<Field: RESPStringRenderable>: ValkeyCommand {
     public var key: ValkeyKey
     public var seconds: Int
     public var condition: Condition?
-    public var fields: Fields
+    public var fields: [Field]
 
-    @inlinable public init(_ key: ValkeyKey, seconds: Int, condition: Condition? = nil, fields: Fields) {
+    @inlinable public init(_ key: ValkeyKey, seconds: Int, condition: Condition? = nil, fields: [Field]) {
         self.key = key
         self.seconds = seconds
         self.condition = condition
@@ -123,7 +102,13 @@ public struct HEXPIRE<Field: RESPStringRenderable>: ValkeyCommand {
     public var keysAffected: CollectionOfOne<ValkeyKey> { .init(key) }
 
     @inlinable public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-        commandEncoder.encodeArray("HEXPIRE", key, seconds, condition, RESPWithToken("FIELDS", fields))
+        commandEncoder.encodeArray(
+            "HEXPIRE",
+            key,
+            seconds,
+            condition,
+            RESPArrayWithTokenAndCount("FIELDS", fields.map { RESPRenderableBulkString($0) })
+        )
     }
 }
 
@@ -149,27 +134,6 @@ public struct HEXPIREAT<Field: RESPStringRenderable>: ValkeyCommand {
             }
         }
     }
-    public struct Fields: RESPRenderable, Sendable, Hashable {
-        public var numfields: Int
-        public var fields: [Field]
-
-        @inlinable
-        public init(numfields: Int, fields: [Field]) {
-            self.numfields = numfields
-            self.fields = fields
-        }
-
-        @inlinable
-        public var respEntries: Int {
-            numfields.respEntries + fields.map { RESPRenderableBulkString($0) }.respEntries
-        }
-
-        @inlinable
-        public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-            numfields.encode(into: &commandEncoder)
-            fields.map { RESPRenderableBulkString($0) }.encode(into: &commandEncoder)
-        }
-    }
     public typealias Response = RESPToken.Array
 
     @inlinable public static var name: String { "HEXPIREAT" }
@@ -177,9 +141,9 @@ public struct HEXPIREAT<Field: RESPStringRenderable>: ValkeyCommand {
     public var key: ValkeyKey
     public var unixTimeSeconds: Int
     public var condition: Condition?
-    public var fields: Fields
+    public var fields: [Field]
 
-    @inlinable public init(_ key: ValkeyKey, unixTimeSeconds: Int, condition: Condition? = nil, fields: Fields) {
+    @inlinable public init(_ key: ValkeyKey, unixTimeSeconds: Int, condition: Condition? = nil, fields: [Field]) {
         self.key = key
         self.unixTimeSeconds = unixTimeSeconds
         self.condition = condition
@@ -189,7 +153,13 @@ public struct HEXPIREAT<Field: RESPStringRenderable>: ValkeyCommand {
     public var keysAffected: CollectionOfOne<ValkeyKey> { .init(key) }
 
     @inlinable public func encode(into commandEncoder: inout ValkeyCommandEncoder) {
-        commandEncoder.encodeArray("HEXPIREAT", key, unixTimeSeconds, condition, RESPWithToken("FIELDS", fields))
+        commandEncoder.encodeArray(
+            "HEXPIREAT",
+            key,
+            unixTimeSeconds,
+            condition,
+            RESPArrayWithTokenAndCount("FIELDS", fields.map { RESPRenderableBulkString($0) })
+        )
     }
 }
 
@@ -1175,7 +1145,7 @@ extension ValkeyClientProtocol {
         _ key: ValkeyKey,
         seconds: Int,
         condition: HEXPIRE<Field>.Condition? = nil,
-        fields: HEXPIRE<Field>.Fields
+        fields: [Field]
     ) async throws(ValkeyClientError) -> RESPToken.Array {
         try await execute(HEXPIRE(key, seconds: seconds, condition: condition, fields: fields))
     }
@@ -1192,7 +1162,7 @@ extension ValkeyClientProtocol {
         _ key: ValkeyKey,
         unixTimeSeconds: Int,
         condition: HEXPIREAT<Field>.Condition? = nil,
-        fields: HEXPIREAT<Field>.Fields
+        fields: [Field]
     ) async throws(ValkeyClientError) -> RESPToken.Array {
         try await execute(HEXPIREAT(key, unixTimeSeconds: unixTimeSeconds, condition: condition, fields: fields))
     }

--- a/Sources/_ValkeyCommandsBuilder/ValkeyCommandsRender.swift
+++ b/Sources/_ValkeyCommandsBuilder/ValkeyCommandsRender.swift
@@ -945,7 +945,7 @@ extension ValkeyCommand.Argument {
     /// Name we use for rendered variable. Appends an "s" for array arguments
     var renderedName: String {
         if self.multiple {
-            if self.name == "data" || self.name.last == "s" || self.name.last == "S" {
+            if self.name.hasSuffix("data") || self.name.last == "s" || self.name.last == "S" {
                 name
             } else if self.name.last == "y", self.name.dropLast().last != "e" {
                 "\(self.name.dropLast())ies"

--- a/Sources/_ValkeyCommandsBuilder/app.swift
+++ b/Sources/_ValkeyCommandsBuilder/app.swift
@@ -20,13 +20,16 @@ struct App {
         if #available(valkeySwift 1.0, *) {
             let resourceFolder = Bundle.module.resourceURL!
             let commands = try load(fileURL: resourceFolder.appending(path: "valkey-commands.json"), as: ValkeyCommands.self)
+            try commands.patch(.standardCommandPatches)
             try writeValkeyCommands(toFolder: "Sources/Valkey/Commands/", commands: commands, module: false)
             let bloomCommands = try load(fileURL: resourceFolder.appending(path: "valkey-bloom-commands.json"), as: ValkeyCommands.self)
+            try bloomCommands.patch(.bloomCommandPatches)
             try writeValkeyCommands(toFolder: "Sources/ValkeyBloom/", commands: bloomCommands, module: true)
             let jsonCommands = try load(fileURL: resourceFolder.appending(path: "valkey-json-commands.json"), as: ValkeyCommands.self)
+            try jsonCommands.patch(.jsonCommandPatches)
             try writeValkeyCommands(toFolder: "Sources/ValkeyJSON/", commands: jsonCommands, module: true)
             let searchCommands = try load(fileURL: resourceFolder.appending(path: "valkey-search-commands.json"), as: ValkeyCommands.self)
-            try searchCommands.patch(.searchPatches)
+            try searchCommands.patch(.searchCommandPatches)
             try writeValkeyCommands(toFolder: "Sources/ValkeySearch/", commands: searchCommands, module: true)
         }
     }

--- a/Sources/_ValkeyCommandsBuilder/patch.swift
+++ b/Sources/_ValkeyCommandsBuilder/patch.swift
@@ -10,14 +10,14 @@ struct ValkeyPatchError: Error {}
 
 /// Patch to apply to argument
 protocol ArgumentPatch {
-    func apply(to: ValkeyCommand.Argument) -> ValkeyCommand.Argument
+    func apply(to: ValkeyCommand.Argument) -> ValkeyCommand.Argument?
 }
 
 /// Patch that replaces argument
 struct ReplaceArgumentPatch: ArgumentPatch {
     let replacement: ValkeyCommand.Argument
 
-    func apply(to: ValkeyCommand.Argument) -> ValkeyCommand.Argument {
+    func apply(to: ValkeyCommand.Argument) -> ValkeyCommand.Argument? {
         replacement
     }
 }
@@ -28,12 +28,25 @@ extension ArgumentPatch where Self == ReplaceArgumentPatch {
     }
 }
 
+/// Patch that replaces argument
+struct RemoveArgumentPatch: ArgumentPatch {
+    func apply(to: ValkeyCommand.Argument) -> ValkeyCommand.Argument? {
+        nil
+    }
+}
+
+extension ArgumentPatch where Self == RemoveArgumentPatch {
+    static func remove() -> RemoveArgumentPatch {
+        .init()
+    }
+}
+
 /// Patch that sets a single field in the parameter
 struct SetFieldPatch<Value>: ArgumentPatch {
     let keyPath: WritableKeyPath<ValkeyCommand.Argument, Value>
     let value: Value
 
-    func apply(to original: ValkeyCommand.Argument) -> ValkeyCommand.Argument {
+    func apply(to original: ValkeyCommand.Argument) -> ValkeyCommand.Argument? {
         var argument = original
         argument[keyPath: keyPath] = value
         return argument
@@ -83,7 +96,11 @@ extension ValkeyCommand {
         guard let arguments = self.arguments else { throw ValkeyPatchError() }
         guard let index = self.arguments?.firstIndex(where: { $0.name == path.first }) else { throw ValkeyPatchError() }
         if path.count == 1 {
-            self.arguments?[index] = patch.apply(to: arguments[index])
+            if let patchedArgument = patch.apply(to: arguments[index]) {
+                self.arguments?[index] = patchedArgument
+            } else {
+                self.arguments?.remove(at: index)
+            }
         } else {
             try self.arguments?[index].patch(path.dropFirst(), patch: patch)
         }
@@ -96,7 +113,11 @@ extension ValkeyCommand.Argument {
         guard let arguments = self.arguments else { throw ValkeyPatchError() }
         guard let index = self.arguments?.firstIndex(where: { $0.name == path.first }) else { throw ValkeyPatchError() }
         if path.count == 1 {
-            self.arguments?[index] = patch.apply(to: arguments[index])
+            if let patchedArgument = patch.apply(to: arguments[index]) {
+                self.arguments?[index] = patchedArgument
+            } else {
+                self.arguments?.remove(at: index)
+            }
         } else {
             try self.arguments?[index].patch(path.dropFirst(), patch: patch)
         }
@@ -119,8 +140,52 @@ extension ValkeyCommands {
 }
 
 extension [CommandPatch] {
+    /// Patches applied to standard commands
+    static var standardCommandPatches: [CommandPatch] {
+        [
+            // HEXPIRE group field count with fields
+            .init(
+                "HEXPIRE",
+                path: ["fields"],
+                patch: .replace(
+                    .init(
+                        name: "field",
+                        type: .string,
+                        multiple: true,
+                        token: "FIELDS",
+                        combinedWithCount: .itemCount
+                    )
+                )
+            ),
+            // HEXPIREAT group field count with fields
+            .init(
+                "HEXPIREAT",
+                path: ["fields"],
+                patch: .replace(
+                    .init(
+                        name: "field",
+                        type: .string,
+                        multiple: true,
+                        token: "FIELDS",
+                        combinedWithCount: .itemCount
+                    )
+                )
+            ),
+        ]
+    }
+
+    /// Patches applied to ValkeyBloom module
+    static var bloomCommandPatches: [CommandPatch] {
+        []
+    }
+
+    /// Patches applied to ValkeyJson module
+    static var jsonCommandPatches: [CommandPatch] {
+        []
+    }
+
     /// Patches applied to ValkeySearch module
-    static var searchPatches: [CommandPatch] {
+    static var searchCommandPatches: [CommandPatch] {
         [
             // FT.AGGREGATE sort parameters are not grouped into expression and direction
             .init(

--- a/Sources/_ValkeyCommandsBuilder/patch.swift
+++ b/Sources/_ValkeyCommandsBuilder/patch.swift
@@ -147,29 +147,79 @@ extension [CommandPatch] {
             .init(
                 "HEXPIRE",
                 path: ["fields"],
-                patch: .replace(
-                    .init(
-                        name: "field",
-                        type: .string,
-                        multiple: true,
-                        token: "FIELDS",
-                        combinedWithCount: .itemCount
-                    )
-                )
+                patch: .replace(.init(name: "field", type: .string, multiple: true, token: "FIELDS", combinedWithCount: .itemCount))
             ),
             // HEXPIREAT group field count with fields
             .init(
                 "HEXPIREAT",
                 path: ["fields"],
+                patch: .replace(.init(name: "field", type: .string, multiple: true, token: "FIELDS", combinedWithCount: .itemCount))
+            ),
+            // HEXPIRETIME group field count with fields
+            .init(
+                "HEXPIRETIME",
+                path: ["fields"],
+                patch: .replace(.init(name: "field", type: .string, multiple: true, token: "FIELDS", combinedWithCount: .itemCount))
+            ),
+            // HGETEX group field count with fields
+            .init(
+                "HGETEX",
+                path: ["fields"],
+                patch: .replace(.init(name: "field", type: .string, multiple: true, token: "FIELDS", combinedWithCount: .itemCount))
+            ),
+            // HPERSIST group field count with fields
+            .init(
+                "HPERSIST",
+                path: ["fields"],
+                patch: .replace(.init(name: "field", type: .string, multiple: true, token: "FIELDS", combinedWithCount: .itemCount))
+            ),
+            // HPEXPIRE group field count with fields
+            .init(
+                "HPEXPIRE",
+                path: ["fields"],
+                patch: .replace(.init(name: "field", type: .string, multiple: true, token: "FIELDS", combinedWithCount: .itemCount))
+            ),
+            // HPEXPIREAT group field count with fields
+            .init(
+                "HPEXPIREAT",
+                path: ["fields"],
+                patch: .replace(.init(name: "field", type: .string, multiple: true, token: "FIELDS", combinedWithCount: .itemCount))
+            ),
+            // HPEXPIRETIME group field count with fields
+            .init(
+                "HPEXPIRETIME",
+                path: ["fields"],
+                patch: .replace(.init(name: "field", type: .string, multiple: true, token: "FIELDS", combinedWithCount: .itemCount))
+            ),
+            // HPTTL group field count with fields
+            .init(
+                "HPTTL",
+                path: ["fields"],
+                patch: .replace(.init(name: "field", type: .string, multiple: true, token: "FIELDS", combinedWithCount: .itemCount))
+            ),
+            // HSETEX group field count with fields
+            .init(
+                "HSETEX",
+                path: ["fields"],
                 patch: .replace(
                     .init(
-                        name: "field",
-                        type: .string,
+                        name: "fields_data",
+                        type: .block,
                         multiple: true,
                         token: "FIELDS",
+                        arguments: [
+                            .init(name: "field", type: .string),
+                            .init(name: "value", type: .string),
+                        ],
                         combinedWithCount: .itemCount
                     )
                 )
+            ),
+            // HTTL group field count with fields
+            .init(
+                "HTTL",
+                path: ["fields"],
+                patch: .replace(.init(name: "field", type: .string, multiple: true, token: "FIELDS", combinedWithCount: .itemCount))
             ),
         ]
     }

--- a/Tests/ValkeyTests/CommandTests.swift
+++ b/Tests/ValkeyTests/CommandTests.swift
@@ -1541,6 +1541,39 @@ struct CommandTests {
     struct HashCommands {
         @Test
         @available(valkeySwift 1.0, *)
+        func hexpire() async throws {
+            try await testCommandEncodesDecodes(
+                (
+                    request: .command(["HEXPIRE", "myhash", "10000", "NX", "FIELDS", "2", "f2", "f3"]),
+                    response: .array([.number(1), .number(1)])
+                ),
+            ) { connection in
+                let result = try await connection.hexpire("myhash", seconds: 10000, condition: .nx, fields: ["f2", "f3"]).decode(as: [Int].self)
+                #expect(result == [1, 1])
+            }
+        }
+
+        @Test
+        @available(valkeySwift 1.0, *)
+        func hsetex() async throws {
+            try await testCommandEncodesDecodes(
+                (
+                    request: .command(["HSETEX", "myhash", "FNX", "EX", "10", "FIELDS", "2", "f2", "v2", "f3", "v3"]),
+                    response: .number(1)
+                ),
+            ) { connection in
+                let result = try await connection.hsetex(
+                    "myhash",
+                    fieldsCondition: .fnx,
+                    expiration: .seconds(10),
+                    fields: [.init(field: "f2", value: "v2"), .init(field: "f3", value: "v3")]
+                )
+                #expect(result == 1)
+            }
+        }
+
+        @Test
+        @available(valkeySwift 1.0, *)
         func hscan() async throws {
             try await testCommandEncodesDecodes(
                 (

--- a/Tests/ValkeyTests/CommandTests.swift
+++ b/Tests/ValkeyTests/CommandTests.swift
@@ -1555,6 +1555,21 @@ struct CommandTests {
 
         @Test
         @available(valkeySwift 1.0, *)
+        func hgetex() async throws {
+            try await testCommandEncodesDecodes(
+                (
+                    request: .command(["HGETEX", "myhash", "EX", "0", "FIELDS", "3", "f1", "f2", "f3"]),
+                    response: .array([.bulkError("v1"), .bulkString("v2"), .bulkString("v3")])
+                ),
+            ) { connection in
+                let result = try await connection.hgetex("myhash", expiration: .seconds(0), fields: ["f1", "f2", "f3"])
+                let strings = try result.decode(as: [String].self)
+                #expect(strings == ["v1", "v2", "v3"])
+            }
+        }
+
+        @Test
+        @available(valkeySwift 1.0, *)
         func hsetex() async throws {
             try await testCommandEncodesDecodes(
                 (
@@ -1566,7 +1581,7 @@ struct CommandTests {
                     "myhash",
                     fieldsCondition: .fnx,
                     expiration: .seconds(10),
-                    fields: [.init(field: "f2", value: "v2"), .init(field: "f3", value: "v3")]
+                    fieldsData: [.init(field: "f2", value: "v2"), .init(field: "f3", value: "v3")]
                 )
                 #expect(result == 1)
             }


### PR DESCRIPTION
Currently a number of the hash commands include a `Fields` object that includes a count of fields and then the array of fields. The count is unnecessary and could cause bugs, as it could be out of sync with the array count. 

It would be preferable to call 
```swift
try await connection.hexpire(
  "myhash", 
  seconds: 10000, 
  fields: ["f2", "f3"]
)
```
over what we currently have
```swift
try await connection.hexpire(
  "myhash", 
  seconds: 10000, 
  fields: .init(numfields: 2, fields: ["f2", "f3"])
)
```
There are two ways to get the first call signature

- The first is to add `ExpressibleByArrayLiteral` to all the HCOMMAND.Fields types. This is a small change but, autocomplete will still recommend the old style API and it still allows users to create a Fields type where the `numfields` is different from the  actual fields count.
- The second is to patch the standard commands to replace the `Fields` type with `[Field]`. The new API would be recommended by autocomplete and it wouldn't be possible to setup an array with a count that is incorrect. This is a breaking change and would require some support for backwards compatibility. This is a bigger change.
 
In this PR you can see both alternatives in HashCustomCommands.swift. The first is in under the mark ["Additional API"](https://github.com/valkey-io/valkey-swift/pull/376/changes#diff-edf39d4839f93534822a8213849282bcfb6402a5473014c90cf27af83d292240R133), the second is under the mark ["Backwards Compatibility"](https://github.com/valkey-io/valkey-swift/pull/376/changes#diff-edf39d4839f93534822a8213849282bcfb6402a5473014c90cf27af83d292240R198).
