### PR TITLE
Fix continuation leak when idle-timer reschedules

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -129,6 +129,13 @@ var package = Package(
             ],
             swiftSettings: defaultSwiftSettings
         ),
+        .testTarget(
+            name: "ConnectionPoolTests",
+            dependencies: [
+                "_ValkeyConnectionPool"
+            ],
+            swiftSettings: defaultSwiftSettings
+        ),
     ]
 )
 

--- a/Sources/ValkeyConnectionPool/PoolStateMachine+ConnectionGroup.swift
+++ b/Sources/ValkeyConnectionPool/PoolStateMachine+ConnectionGroup.swift
@@ -585,7 +585,7 @@ extension PoolStateMachine {
         }
 
         @inlinable
-        mutating func rescheduleIdleTimer(_ connectionID: Connection.ID) -> ConnectionTimer? {
+        mutating func rescheduleIdleTimer(_ connectionID: Connection.ID) -> (ConnectionTimer, TimerCancellationToken?)? {
             guard let index = self.connections.firstIndex(where: { $0.id == connectionID }) else {
                 // because of a race this connection (connection close runs against trigger of timeout)
                 // was already removed from the state machine.

--- a/Sources/ValkeyConnectionPool/PoolStateMachine+ConnectionState.swift
+++ b/Sources/ValkeyConnectionPool/PoolStateMachine+ConnectionState.swift
@@ -322,16 +322,16 @@ extension PoolStateMachine {
         }
 
         @inlinable
-        mutating func rescheduleIdleTimer() -> ConnectionTimer? {
+        mutating func rescheduleIdleTimer() -> (ConnectionTimer, TimerCancellationToken?)? {
             switch self.state {
             case .backingOff, .starting:
                 preconditionFailure("Invalid state: \(self.state)")
 
-            case .idle(let connection, let maxStreams, let keepAlive, .some):
+            case .idle(let connection, let maxStreams, let keepAlive, .some(let oldIdleTimer)):
                 let idleTimerState = self._nextTimer()
                 let idleTimer = ConnectionTimer(timerID: idleTimerState.timerID, connectionID: self.id, usecase: .idleTimeout)
                 self.state = .idle(connection, maxStreams: maxStreams, keepAlive: keepAlive, idleTimer: idleTimerState)
-                return idleTimer
+                return (idleTimer, oldIdleTimer.cancellationContinuation)
 
             case .idle(_, _, _, .none):
                 return nil

--- a/Sources/ValkeyConnectionPool/PoolStateMachine.swift
+++ b/Sources/ValkeyConnectionPool/PoolStateMachine.swift
@@ -611,8 +611,26 @@ where
             // might pickup the lease request (which would cancel the idle timeout) or the lease request might
             // already be handled by another (currently busy connection), in which case the idle timeout can
             // trigger eventually.
-            let timer = self.connections.rescheduleIdleTimer(connectionID)
-            return .init(request: .none, connection: .scheduleTimers(timer.map { [self.mapTimers($0)] } ?? []))
+            guard let (newTimer, oldCancellationToken) = self.connections.rescheduleIdleTimer(connectionID) else {
+                return .none()
+            }
+            let scheduledTimers = Max2Sequence(self.mapTimers(newTimer))
+            // We must propagate the old idle timer's cancellation continuation so that the
+            // `ConnectionPool.runTimer` child task that stored it can be resumed. Dropping it here
+            // produces a "SWIFT TASK CONTINUATION MISUSE: runTimer(_:in:) leaked its continuation
+            // without resuming it" runtime warning (the stored `CheckedContinuation` is never
+            // resumed and eventually deallocated).
+            if let oldCancellationToken {
+                return .init(
+                    request: .none,
+                    connection: .makeConnectionsCancelAndScheduleTimers(
+                        .init(),
+                        .init(element: oldCancellationToken),
+                        scheduledTimers
+                    )
+                )
+            }
+            return .init(request: .none, connection: .scheduleTimers(scheduledTimers))
         }
 
         guard let closeAction = self.connections.closeConnectionIfIdle(connectionID) else {

--- a/Tests/ConnectionPoolTests/IdleTimerRescheduleTests.swift
+++ b/Tests/ConnectionPoolTests/IdleTimerRescheduleTests.swift
@@ -1,0 +1,176 @@
+//
+// This source file is part of the valkey-swift project
+// Copyright (c) 2025-2026 the valkey-swift project authors
+//
+// See LICENSE.txt for license information
+// SPDX-License-Identifier: Apache-2.0
+//
+import Testing
+
+@testable import _ValkeyConnectionPool
+
+/// Simple Sendable token used in place of `CheckedContinuation` so we can
+/// observe timer cancellation flow in unit tests without going through the
+/// Swift concurrency runtime.
+struct TestTimerCancellationToken: Sendable, Equatable, Hashable {
+    let id: Int
+}
+
+final class TestPooledConnection: PooledConnection, @unchecked Sendable {
+    typealias ID = Int
+    let id: Int
+    init(id: Int) { self.id = id }
+    func onClose(_ closure: @escaping @Sendable ((any Error)?) -> Void) {}
+    func close() {}
+}
+
+final class TestConnectionRequest: ConnectionRequestProtocol, @unchecked Sendable {
+    typealias ID = Int
+    typealias Connection = TestPooledConnection
+    let id: Int
+    init(id: Int) { self.id = id }
+    func complete(with: Result<ConnectionLease<TestPooledConnection>, ConnectionPoolError>) {}
+}
+
+@Suite("Idle timer reschedule")
+struct IdleTimerRescheduleTests {
+    typealias StateMachine = PoolStateMachine<
+        TestPooledConnection,
+        ConnectionIDGenerator,
+        Int,
+        TestConnectionRequest,
+        Int,
+        TestTimerCancellationToken,
+        ContinuousClock,
+        ContinuousClock.Instant
+    >
+
+    /// When the idle-timeout timer fires while a request is waiting in the queue, the state
+    /// machine reschedules a new idle timer for the connection. Before the fix this code path
+    /// dropped the old idle timer's `cancellationContinuation` on the floor, which later
+    /// triggered a "SWIFT TASK CONTINUATION MISUSE: runTimer(_:in:) leaked its continuation
+    /// without resuming it" runtime warning because the continuation stored in
+    /// `ConnectionPool.runTimer`'s child task was never resumed.
+    ///
+    /// This test drives the state machine into that exact scenario and asserts that the
+    /// `.timerTriggered` action propagates the old idle timer's cancellation token so the
+    /// caller can resume its continuation.
+    @Test
+    func reschedulingIdleTimerReturnsOldCancellationToken() {
+        var config = PoolConfiguration()
+        config.minimumConnectionCount = 0
+        config.maximumConnectionSoftLimit = 1
+        config.maximumConnectionHardLimit = 1
+        config.keepAliveDuration = .seconds(30)
+        config.idleTimeoutDuration = .seconds(60)
+
+        var sm = StateMachine(
+            configuration: config,
+            generator: ConnectionIDGenerator(),
+            timerCancellationTokenType: TestTimerCancellationToken.self,
+            clock: ContinuousClock()
+        )
+
+        // 1. Leasing a request when no connection exists triggers creation of a demand
+        //    connection.
+        let firstRequest = TestConnectionRequest(id: 1)
+        let leaseAction = sm.leaseConnection(firstRequest)
+        guard case .makeConnection(let makeRequest, _) = leaseAction.connection else {
+            Issue.record("expected .makeConnection, got \(leaseAction.connection)")
+            return
+        }
+
+        // 2. Establish the connection. Because the request is already queued, the state
+        //    machine leases it immediately.
+        let connection = TestPooledConnection(id: makeRequest.connectionID)
+        let established = sm.connectionEstablished(connection, maxStreams: 1)
+        guard case .leaseConnection(_, _) = established.request else {
+            Issue.record("expected lease, got \(established.request)")
+            return
+        }
+
+        // 3. Release the connection so it parks with both keep-alive and idle timers.
+        let released = sm.releaseConnection(connection, streams: 1)
+        guard case .scheduleTimers(let parkedTimers) = released.connection else {
+            Issue.record("expected .scheduleTimers, got \(released.connection)")
+            return
+        }
+        var keepAliveTimer: StateMachine.Timer?
+        var idleTimer: StateMachine.Timer?
+        for timer in parkedTimers {
+            switch timer.underlying.usecase {
+            case .keepAlive: keepAliveTimer = timer
+            case .idleTimeout: idleTimer = timer
+            case .backoff: Issue.record("unexpected backoff timer")
+            }
+        }
+        guard let keepAliveTimer, let idleTimer else {
+            Issue.record("missing keep-alive or idle timer in \(parkedTimers)")
+            return
+        }
+
+        // 4. Register cancellation tokens for both timers (simulates the child task in
+        //    `ConnectionPool.runTimer` storing its continuation via `timerScheduled`).
+        let keepAliveToken = TestTimerCancellationToken(id: 100)
+        let idleToken = TestTimerCancellationToken(id: 200)
+        #expect(sm.timerScheduled(keepAliveTimer, cancelContinuation: keepAliveToken) == nil)
+        #expect(sm.timerScheduled(idleTimer, cancelContinuation: idleToken) == nil)
+
+        // 5. Keep-alive fires → state transitions to `.idle(keepAlive: .running, idleTimer: .some)`.
+        //    The keep-alive's own token is handed back via `.runKeepAlive` so it can be
+        //    resumed - this path already works correctly.
+        let keepAliveFired = sm.timerTriggered(keepAliveTimer)
+        guard case .runKeepAlive(_, let handedBackKeepAliveToken) = keepAliveFired.connection else {
+            Issue.record("expected .runKeepAlive, got \(keepAliveFired.connection)")
+            return
+        }
+        #expect(handedBackKeepAliveToken == keepAliveToken)
+
+        // 6. Queue a second request. Because the running keep-alive consumes the single
+        //    available stream, this request stays in the queue.
+        let secondRequest = TestConnectionRequest(id: 2)
+        _ = sm.leaseConnection(secondRequest)
+
+        // 7. The idle timer now fires. Because the request queue is non-empty the state
+        //    machine takes the `rescheduleIdleTimer` path: it replaces the old idle timer
+        //    with a fresh one and emits a `.scheduleTimers` action for the new timer.
+        //
+        //    BUG: without the fix the action drops `idleToken` on the floor. The token
+        //    stays stored inside the dropped `State.Timer` and its `CheckedContinuation`
+        //    in the real pool is never resumed, producing the runtime warning.
+        //
+        //    FIX: the action should also carry `idleToken` so the caller can resume it.
+        let idleFired = sm.timerTriggered(idleTimer)
+
+        let collectedCancelledTokens = collectCancelledTokens(idleFired.connection)
+        #expect(
+            collectedCancelledTokens.contains(idleToken),
+            "rescheduling the idle timer must surface the old idle timer's cancellation token so the pool can resume its continuation. Got action: \(idleFired.connection)"
+        )
+    }
+
+    private func collectCancelledTokens(
+        _ action: StateMachine.ConnectionAction
+    ) -> [TestTimerCancellationToken] {
+        switch action {
+        case .scheduleTimers:
+            return []
+        case .makeConnection(_, let tokens):
+            return Array(tokens)
+        case .makeConnectionsCancelAndScheduleTimers(_, let tokens, _):
+            return Array(tokens)
+        case .runKeepAlive(_, let token):
+            return token.map { [$0] } ?? []
+        case .cancelTimers(let tokens):
+            return Array(tokens)
+        case .closeConnection(_, let tokens):
+            return Array(tokens)
+        case .initiateShutdown(let shutdown):
+            return shutdown.timersToCancel
+        case .cancelEventStreamAndFinalCleanup(let tokens):
+            return tokens
+        case .none:
+            return []
+        }
+    }
+}


### PR DESCRIPTION
Running valkey-swift locally produces:

```
SWIFT TASK CONTINUATION MISUSE: runTimer(_:in:) leaked its
continuation without resuming it.
```

### Cause

When the idle-timeout timer fires while a lease request is queued (because a keep-alive is currently consuming the connection's only stream), `connectionIdleTimerTriggered` takes the `rescheduleIdleTimer` path. That path replaced the stale idle timer with a fresh one but dropped the old timer's `cancellationContinuation` on the floor.

The dropped token is a `CheckedContinuation<Void, Never>` that `ConnectionPool.runTimer`'s child task registered via `withCheckedContinuation`. Because the state machine holds it strongly via `State.Timer`, it is only deallocated when the state transition discards the timer — at which point it has never been resumed, and the runtime logs the warning above.

### Fix

- `ConnectionState.rescheduleIdleTimer()` and `ConnectionGroup.rescheduleIdleTimer(_:)` now also return the old idle timer's `TimerCancellationToken`.
- `PoolStateMachine.connectionIdleTimerTriggered(_:)` forwards that token via `.makeConnectionsCancelAndScheduleTimers` so `ConnectionPool.runConnectionAction` resumes the continuation before scheduling the new timer.

### Tests

A new `ConnectionPoolTests` target drives the state machine into the exact race (lease → establish → release → keep-alive fires → queue second request → idle timer fires while keep-alive is running) and asserts the returned action surfaces the old cancellation token. The test fails on `main` and passes with this fix.

Full existing suite (309 tests) continues to pass.