### PR TITLE
Cluster-wide Multi-key MSET

### DIFF
--- a/Sources/Valkey/Commands/Custom/ClusterStringCommands.swift
+++ b/Sources/Valkey/Commands/Custom/ClusterStringCommands.swift
@@ -69,9 +69,9 @@ extension MSET: ValkeyClusterMultiKeyCommand {
         MSET(data: indices.map { self.data[$0] })
     }
 
-    /// Combines per-slot MSET sub-results into a single `+OK` token.
+    /// Combines per-slot MSET sub-results into a single `OK` token.
     ///
-    /// Every sub-result must be the simple string `+OK`; any other response
+    /// Every sub-result must be the simple string `OK`. Any other response
     /// causes a ``RESPDecodeError`` to be thrown.
     package static func combineResults(
         originalKeyCount: Int,
@@ -82,7 +82,7 @@ extension MSET: ValkeyClusterMultiKeyCommand {
                 throw RESPDecodeError(
                     .unexpectedToken,
                     token: result,
-                    message: "Expected '+OK' simple string from MSET sub-command"
+                    message: "Expected 'OK' response from MSET sub-command"
                 )
             }
         }

--- a/Sources/Valkey/Commands/Custom/ClusterStringCommands.swift
+++ b/Sources/Valkey/Commands/Custom/ClusterStringCommands.swift
@@ -59,7 +59,38 @@ extension MGET: ValkeyClusterMultiKeyCommand {
     }
 }
 
-// MARK: - ValkeyClusterClient + MGET
+// MARK: - MSET
+
+private let okResponseBytes = ByteBuffer(string: "+OK\r\n")
+
+@available(valkeySwift 1.0, *)
+extension MSET: ValkeyClusterMultiKeyCommand {
+    package func createSubCommand(for indices: [Int]) -> MSET {
+        MSET(data: indices.map { self.data[$0] })
+    }
+
+    /// Combines per-slot MSET sub-results into a single `+OK` token.
+    ///
+    /// Every sub-result must be the simple string `+OK`; any other response
+    /// causes a ``RESPDecodeError`` to be thrown.
+    package static func combineResults(
+        originalKeyCount: Int,
+        slotResults: [(indices: [Int], result: RESPToken)]
+    ) throws(RESPDecodeError) -> RESPToken {
+        for (_, result) in slotResults {
+            guard result.base == okResponseBytes else {
+                throw RESPDecodeError(
+                    .unexpectedToken,
+                    token: result,
+                    message: "Expected '+OK' simple string from MSET sub-command"
+                )
+            }
+        }
+        return RESPToken(validated: okResponseBytes)
+    }
+}
+
+// MARK: - ValkeyClusterClient + MGET/MSET
 
 @available(valkeySwift 1.0, *)
 extension ValkeyClusterClient {
@@ -75,5 +106,20 @@ extension ValkeyClusterClient {
     /// - Throws: ``ValkeyClientError`` if any node fails.
     public func mget(keys: [ValkeyKey]) async throws(ValkeyClientError) -> RESPToken.Array {
         try await executeMultiKeyCommand(MGET(keys: keys))
+    }
+
+    /// Sets the values of one or more keys, transparently routing
+    /// sub-commands across cluster nodes for keys in different hash slots.
+    ///
+    /// > Warning: Unlike single-node `MSET`, this is **not atomic**. Sub-commands
+    /// > run in parallel against multiple nodes, so partial failures — where some
+    /// > keys are written and others are not — are observable.
+    ///
+    /// - Documentation: [MSET](https://valkey.io/commands/mset)
+    /// - Complexity: O(N) where N is the number of keys to set.
+    /// - Parameter data: The key-value pairs to set.
+    /// - Throws: ``ValkeyClientError`` if any node fails or returns a non-OK response.
+    public func mset<Value: RESPStringRenderable>(data: [MSET<Value>.Data]) async throws(ValkeyClientError) {
+        _ = try await executeMultiKeyCommand(MSET(data: data))
     }
 }

--- a/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
+++ b/Tests/ClusterIntegrationTests/ClusterIntegrationTests.swift
@@ -1025,6 +1025,38 @@ struct ClusterIntegrationTests {
         }
     }
 
+    @Test
+    @available(valkeySwift 1.0, *)
+    func testClusterWideMSET() async throws {
+        var logger = Logger(label: "ValkeyCluster")
+        logger.logLevel = .trace
+        let firstNodeHostname = clusterFirstNodeHostname!
+        let firstNodePort = clusterFirstNodePort ?? 6379
+        try await Self.withValkeyCluster([(host: firstNodeHostname, port: firstNodePort)], logger: logger) { client in
+            // Use different hash tags to ensure keys land in different slots.
+            try await Self.withKeys(connection: client, suffixes: ["{1}", "{2}", "{3}"]) { keys in
+                try await client.mset(
+                    data: [
+                        MSET<String>.Data(key: keys[0], value: "value1"),
+                        MSET<String>.Data(key: keys[1], value: "value2"),
+                        MSET<String>.Data(key: keys[2], value: "value3"),
+                    ]
+                )
+
+                let expected: [(key: ValkeyKey, value: String)] = [
+                    (keys[0], "value1"),
+                    (keys[1], "value2"),
+                    (keys[2], "value3"),
+                ]
+
+                for (key, expectedValue) in expected {
+                    let response = try #require(await client.get(key))
+                    #expect(String(response) == expectedValue)
+                }
+            }
+        }
+    }
+
     @available(valkeySwift 1.0, *)
     static func withKey<Value>(
         connection: some ValkeyClientProtocol,

--- a/Tests/ValkeyTests/Cluster/ValkeyClusterClientTests.swift
+++ b/Tests/ValkeyTests/Cluster/ValkeyClusterClientTests.swift
@@ -283,6 +283,40 @@ actor TestCluster {
                 }
                 return .array(values)
 
+            case "MSET":
+                var pairs: [(key: String, value: String)] = []
+                var slot: HashSlot?
+
+                // Parse alternating key/value pairs and verify all keys share a slot
+                while let key = iterator.next() {
+                    guard let value = iterator.next() else {
+                        return .bulkError("ERR wrong number of arguments for 'mset' command")
+                    }
+                    let keySlot = HashSlot(key: ValkeyKey(key))
+                    if let existingSlot = slot, existingSlot != keySlot {
+                        return .bulkError("CROSSSLOT Keys in request don't hash to the same slot")
+                    } else {
+                        slot = keySlot
+                    }
+                    pairs.append((key: key, value: value))
+                }
+
+                guard let hashSlot = slot else {
+                    return .bulkError("ERR wrong number of arguments for 'mset' command")
+                }
+                guard let shard = await self.getShard(hashSlot) else {
+                    return .bulkError("CLUSTERDOWN Hash slot not served")
+                }
+
+                let addressDetails = await self.addressMap[address]
+                if shard.index != addressDetails?.shardIndex || addressDetails?.role == .replica {
+                    return .bulkError("MOVED \(hashSlot.rawValue) \(shard.shard.primary.address)")
+                }
+                for pair in pairs {
+                    await self.setKey(pair.key, value: pair.value)
+                }
+                return .simpleString("OK")
+
             case "CLUSTER":
                 switch iterator.next() {
                 case "SHARDS":
@@ -692,6 +726,63 @@ struct ValkeyClusterClientTests {
 
             #expect(try String(sameSlotTokens[0]) == "alpha")
             #expect(try String(sameSlotTokens[1]) == "beta")
+        }
+    }
+
+    // MARK: - MSET cross-slot tests
+
+    @available(valkeySwift 1.0, *)
+    @Test
+    func testMSETCrossSlot() async throws {
+        var logger = Logger(label: "Valkey")
+        logger.logLevel = .debug
+        let cluster = await self.sixNodeHealthyCluster
+        let mockConnections = await cluster.mock(logger: logger)
+        async let _ = mockConnections.run()
+        try await withValkeyClusterClient(
+            (host: "127.0.0.1", port: 16000),
+            mockConnections: mockConnections,
+            logger: logger
+        ) { client in
+            // Verifies scatter-gather dispatches MSET sub-commands across shards
+            // and every per-node +OK is consumed without error.
+            try await client.mset(
+                data: [
+                    MSET<String>.Data(key: "key{3}", value: "value3"),
+                    MSET<String>.Data(key: "key{1}", value: "value1"),
+                    MSET<String>.Data(key: "key{4}", value: "value4"),
+                ]
+            )
+
+            var expected: [(key: ValkeyKey, value: String)] = [
+                (ValkeyKey("key{3}"), "value3"),
+                (ValkeyKey("key{1}"), "value1"),
+                (ValkeyKey("key{4}"), "value4"),
+            ]
+
+            for (key, expectedValue) in expected {
+                let response = try #require(await client.get(key))
+                #expect(try String(response) == expectedValue)
+            }
+
+            // Same-slot fast path: all keys share the same hash tag,
+            // so the command goes through the standard execute path.
+            try await client.mset(
+                data: [
+                    MSET<String>.Data(key: "a{1}", value: "alpha"),
+                    MSET<String>.Data(key: "b{1}", value: "beta"),
+                ]
+            )
+
+            expected = [
+                (ValkeyKey("a{1}"), "alpha"),
+                (ValkeyKey("b{1}"), "beta"),
+            ]
+
+            for (key, expectedValue) in expected {
+                let response = try #require(await client.get(key))
+                #expect(try String(response) == expectedValue)
+            }
         }
     }
 }

--- a/Tests/ValkeyTests/Cluster/ValkeyClusterClientTests.swift
+++ b/Tests/ValkeyTests/Cluster/ValkeyClusterClientTests.swift
@@ -748,21 +748,21 @@ struct ValkeyClusterClientTests {
             // and every per-node +OK is consumed without error.
             try await client.mset(
                 data: [
-                    MSET<String>.Data(key: "key{3}", value: "value3"),
                     MSET<String>.Data(key: "key{1}", value: "value1"),
-                    MSET<String>.Data(key: "key{4}", value: "value4"),
+                    MSET<String>.Data(key: "key{2}", value: "value2"),
+                    MSET<String>.Data(key: "key{3}", value: "value3"),
                 ]
             )
 
-            var expected: [(key: ValkeyKey, value: String)] = [
-                (ValkeyKey("key{3}"), "value3"),
+            let expectedMultiSlotResponse: [(key: ValkeyKey, value: String)] = [
                 (ValkeyKey("key{1}"), "value1"),
-                (ValkeyKey("key{4}"), "value4"),
+                (ValkeyKey("key{2}"), "value2"),
+                (ValkeyKey("key{3}"), "value3"),
             ]
 
-            for (key, expectedValue) in expected {
+            for (key, expectedValue) in expectedMultiSlotResponse {
                 let response = try #require(await client.get(key))
-                #expect(try String(response) == expectedValue)
+                #expect(String(response) == expectedValue)
             }
 
             // Same-slot fast path: all keys share the same hash tag,
@@ -774,14 +774,14 @@ struct ValkeyClusterClientTests {
                 ]
             )
 
-            expected = [
+            let expectedSingleSlotResponse = [
                 (ValkeyKey("a{1}"), "alpha"),
                 (ValkeyKey("b{1}"), "beta"),
             ]
 
-            for (key, expectedValue) in expected {
+            for (key, expectedValue) in expectedSingleSlotResponse {
                 let response = try #require(await client.get(key))
-                #expect(try String(response) == expectedValue)
+                #expect(String(response) == expectedValue)
             }
         }
     }


### PR DESCRIPTION
Extending Cluster-wide multi-key commands to also add MSET. 
MSET uses the existing multi-key command splitting and combining logic. 
Unit and Integration tests are added to verify the logic.   