### PR TITLE
Declare minimum platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,12 @@ defaultSwiftSettings.append(contentsOf: [
 
 var package = Package(
     name: "valkey-swift",
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v16),
+        .tvOS(.v16),
+        .watchOS(.v9),
+    ],
     products: [
         .library(name: "Valkey", targets: ["Valkey"]),
         .library(name: "ValkeyBloom", targets: ["ValkeyBloom"]),


### PR DESCRIPTION
I was using `1.3.1` in a package and even though I was using  `platforms: [.macOS(.v15)]` it wouldn't work. 

Without explicit `platforms:` in the Package file SwiftPM seems to fallback to a default platform which for current toolchains seems to be macOS 10.13, which in turn makes the new `extension TaskGroup<Void>` and `extension DiscardingTaskGroup` from #382 fail to compile because TaskGroup, DiscardingTaskGroup and CheckedContinuation are only available on macOS 10.15+.