### PR TITLE
Add @available markup in again, which got removed by mistake

### DIFF
--- a/Sources/ValkeyConnectionPool/ConnectionPool.swift
+++ b/Sources/ValkeyConnectionPool/ConnectionPool.swift
@@ -622,6 +622,7 @@ extension DiscardingTaskGroup: TaskGroupProtocol {
     }
 }
 
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 extension TaskGroup<Void>: TaskGroupProtocol {
     @inlinable
     mutating func addTask_(operation: @isolated(any) @escaping @Sendable () async -> Void) {

--- a/Sources/ValkeyConnectionPool/ConnectionRequest.swift
+++ b/Sources/ValkeyConnectionPool/ConnectionRequest.swift
@@ -1,3 +1,4 @@
+@available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)
 public struct ConnectionRequest<Connection: PooledConnection>: ConnectionRequestProtocol {
     public typealias ID = Int
 


### PR DESCRIPTION
Added https://github.com/vapor/postgres-nio/pull/644 so hopefully this doesn't happen again