### PR TITLE
Only store hash value of healthyState of a cluster

### DIFF
--- a/Sources/Valkey/Cluster/ValkeyClusterClientStateMachine.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClientStateMachine.swift
@@ -102,8 +102,6 @@ where
             @usableFromInline
             /* private */ var circuitBreakerTimer: Timer?
 
-            var lastHealthyState: ValkeyClusterTopology?
-
             var lastError: any Error
         }
 
@@ -124,14 +122,14 @@ where
             @usableFromInline
             /* private */ var hashSlotShardMap: HashSlotShardMap
 
-            var lastHealthyState: ValkeyClusterTopology
+            var lastHealthyStateHashValue: Int
 
             var lastError: any Error
         }
 
         @usableFromInline
         struct HealthyContext {
-            var clusterTopology: ValkeyClusterTopology
+            var clusterTopologyHashValue: Int
             @usableFromInline
             /* private */ var hashSlotShardMap: HashSlotShardMap
             var consensusStart: Clock.Instant
@@ -281,18 +279,21 @@ where
             self.refreshState = .waitingForRefresh(.init(id: refreshTimerID), previousRefresh: .init(consecutiveFailures: 0))
 
             let oldCusterState = self.clusterState
-            let oldHealthyClusterTopology: ValkeyClusterTopology? =
+            let oldHealthyClusterTopologyHashValue: Int? =
                 if case .healthy(let healthyState) = self.clusterState {
-                    healthyState.clusterTopology
+                    healthyState.clusterTopologyHashValue
                 } else {
                     nil
                 }
             var result: ClusterDiscoverySucceededAction
+            let topologyHashValue = topology.hashValue
             /// Don't update cluster if description hasnt changed
-            if oldHealthyClusterTopology != topology {
+            if oldHealthyClusterTopologyHashValue != topology.hashValue {
                 var map = HashSlotShardMap()
                 map.updateCluster(topology)
-                self.clusterState = .healthy(.init(clusterTopology: topology, hashSlotShardMap: map, consensusStart: self.clock.now))
+                self.clusterState = .healthy(
+                    .init(clusterTopologyHashValue: topologyHashValue, hashSlotShardMap: map, consensusStart: self.clock.now)
+                )
 
                 let poolUpdate = self.runningClients.updateNodes(
                     topology.shards.lazy.flatMap {
@@ -373,7 +374,7 @@ where
                         pendingSuccessNotifiers: [:],
                         circuitBreakerTimer: .init(id: circuitBreakerTimerID),
                         hashSlotShardMap: healthyContext.hashSlotShardMap,
-                        lastHealthyState: healthyContext.clusterTopology,
+                        lastHealthyStateHashValue: healthyContext.clusterTopologyHashValue,
                         lastError: error
                     )
                 )
@@ -492,7 +493,6 @@ where
                     .init(
                         start: degradedContext.start,
                         pendingSuccessNotifiers: [:],
-                        lastHealthyState: degradedContext.lastHealthyState,
                         lastError: degradedContext.lastError
                     )
                 )
@@ -677,7 +677,7 @@ where
                     pendingSuccessNotifiers: [:],
                     circuitBreakerTimer: .init(id: circuitBreakerTimerID),
                     hashSlotShardMap: healthyContext.hashSlotShardMap,
-                    lastHealthyState: healthyContext.clusterTopology,
+                    lastHealthyStateHashValue: healthyContext.clusterTopologyHashValue,
                     lastError: ValkeyClusterError.clusterIsMissingMovedErrorNode
                 )
             )

--- a/Sources/Valkey/Cluster/ValkeyClusterClientStateMachine.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClientStateMachine.swift
@@ -288,7 +288,7 @@ where
             var result: ClusterDiscoverySucceededAction
             let topologyHashValue = topology.hashValue
             /// Don't update cluster if description hasnt changed
-            if oldHealthyClusterTopologyHashValue != topology.hashValue {
+            if oldHealthyClusterTopologyHashValue != topologyHashValue {
                 var map = HashSlotShardMap()
                 map.updateCluster(topology)
                 self.clusterState = .healthy(


### PR DESCRIPTION
The healthy state topology is only ever used to check if the topology has changed and if it has we update the hashSlotShardMap. This PR checks the hash value of the healthy state topology instead. This is a minor optimisation, but is also needed to remove the temptation of using the topology (which is not necessarily up to date) instead of the hashSlotShardMap.