### PR TITLE
Add support for setting the number of streams per connection.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Package.resolved
 .swift-version
 .docc-build
 /valkey
+devcontainer-lock.json

--- a/Sources/Valkey/Cluster/ValkeyClusterClient.swift
+++ b/Sources/Valkey/Cluster/ValkeyClusterClient.swift
@@ -733,7 +733,7 @@ public final class ValkeyClusterClient: Sendable {
             }
         case let error as ValkeyClientError:
             switch error.errorCode {
-            case .clientIsShutDown, .connectionClosed, .connectionClosing:
+            case .clientIsShutDown, .connectionClosed, .connectionClosing, .connectionClosedDueToCancellation:
                 return .tryAgain
             default:
                 return .dontRetry

--- a/Sources/Valkey/Node/ValkeyNodeClient.swift
+++ b/Sources/Valkey/Node/ValkeyNodeClient.swift
@@ -106,7 +106,7 @@ package final class ValkeyNodeClient: Sendable {
                 logger: logger
             )
 
-            return ConnectionAndMetadata(connection: connection, maximalStreamsOnConnection: 1)
+            return ConnectionAndMetadata(connection: connection, maximalStreamsOnConnection: connectionFactory.configuration.connectionPool.maximumNumberOfStreamsPerConnection)
         }
         self.connectionFactory = connectionFactory
         self.eventLoopGroup = eventLoopGroup

--- a/Sources/Valkey/Node/ValkeyNodeClient.swift
+++ b/Sources/Valkey/Node/ValkeyNodeClient.swift
@@ -86,6 +86,11 @@ package final class ValkeyNodeClient: Sendable {
         poolConfiguration.circuitBreakerTripAfter = connectionFactory.configuration.connectionPool.circuitBreakerTripAfter
         poolConfiguration.maximumConcurrentConnectionRequests = connectionFactory.configuration.connectionPool.maximumConcurrentConnectionRequests
 
+        precondition(
+            connectionFactory.configuration.connectionPool.maximumNumberOfStreamsPerConnection > 0,
+            "The maximum number of streams per connection must be greater than zero"
+        )
+
         self.readOnly = readOnly
         self.connectionPool = .init(
             configuration: poolConfiguration,
@@ -104,11 +109,6 @@ package final class ValkeyNodeClient: Sendable {
                 connectionID: connectionID,
                 eventLoop: eventLoopGroup.any(),
                 logger: logger
-            )
-
-            precondition(
-                connectionFactory.configuration.connectionPool.maximumNumberOfStreamsPerConnection > 0,
-                "The maximum number of streams per connection must be greater than zero"
             )
             return ConnectionAndMetadata(
                 connection: connection,

--- a/Sources/Valkey/Node/ValkeyNodeClient.swift
+++ b/Sources/Valkey/Node/ValkeyNodeClient.swift
@@ -106,7 +106,10 @@ package final class ValkeyNodeClient: Sendable {
                 logger: logger
             )
 
-            return ConnectionAndMetadata(connection: connection, maximalStreamsOnConnection: connectionFactory.configuration.connectionPool.maximumNumberOfStreamsPerConnection)
+            return ConnectionAndMetadata(
+                connection: connection,
+                maximalStreamsOnConnection: connectionFactory.configuration.connectionPool.maximumNumberOfStreamsPerConnection
+            )
         }
         self.connectionFactory = connectionFactory
         self.eventLoopGroup = eventLoopGroup

--- a/Sources/Valkey/Node/ValkeyNodeClient.swift
+++ b/Sources/Valkey/Node/ValkeyNodeClient.swift
@@ -106,6 +106,10 @@ package final class ValkeyNodeClient: Sendable {
                 logger: logger
             )
 
+            precondition(
+                connectionFactory.configuration.connectionPool.maximumNumberOfStreamsPerConnection > 0,
+                "The maximum number of streams per connection must be greater than zero"
+            )
             return ConnectionAndMetadata(
                 connection: connection,
                 maximalStreamsOnConnection: connectionFactory.configuration.connectionPool.maximumNumberOfStreamsPerConnection

--- a/Sources/Valkey/ValkeyClient.swift
+++ b/Sources/Valkey/ValkeyClient.swift
@@ -655,6 +655,8 @@ extension ValkeyClient {
                     return .dontRetry
                 }
             }
+        case .connectionClosed, .connectionClosing, .connectionClosedDueToCancellation:
+            return .tryAgain
         default:
             return .dontRetry
         }

--- a/Sources/Valkey/ValkeyClientConfiguration+SwiftConfiguration.swift
+++ b/Sources/Valkey/ValkeyClientConfiguration+SwiftConfiguration.swift
@@ -102,6 +102,7 @@ extension ValkeyClientConfiguration.ConnectionPool {
     /// - `idleTimeoutMs` (int, optional, default: 60,000): Milliseconds before idle preserved connections are closed.
     /// - `circuitBreakerTripAfterMs` (int, optional, default: 60,000): Milliseconds between first connection failure and circuit breaker activation.
     /// - `maximumConcurrentConnectionRequests` (int, optional, default: 20): Max concurrent new connection requests.
+    /// - `maximumStreamsPerConnectionCount` (int, optional, default: 1): The maximum number of leases that can use the one connection.
     public init(configReader: ConfigReader) {
         self.init()
 
@@ -127,6 +128,10 @@ extension ValkeyClientConfiguration.ConnectionPool {
 
         if let maxConcurrentRequests = configReader.int(forKey: "maximumConcurrentConnectionRequests") {
             self.maximumConcurrentConnectionRequests = maxConcurrentRequests
+        }
+
+        if let maxStreamsPerConnection = configReader.int(forKey: "maximumStreamsPerConnectionCount") {
+            self.maximumNumberOfStreamsPerConnection = UInt16(maxStreamsPerConnection)
         }
     }
 }

--- a/Sources/Valkey/ValkeyClientConfiguration.swift
+++ b/Sources/Valkey/ValkeyClientConfiguration.swift
@@ -158,6 +158,22 @@ public struct ValkeyClientConfiguration: Sendable {
         /// become idle.
         public var maximumConnectionHardLimit: Int
 
+        /// The maximum number of leases that can use the one connection. This defaults
+        /// to 1 but increasing it from 1 allows for increased throughput on the same
+        /// number of connections.
+        ///
+        /// Downsides from increasing this above 1 include
+        /// - Commands that take a long time can affect the performance of completely
+        ///   unrelated commands run elsewhere on the same connection.
+        /// - You cannot guarantee unique access to a connection. So transactions
+        ///   maybe affected by calls to `WATCH` elsewhere.
+        /// - If you are using seeing a large number of subscription push messages per second
+        ///   This could affect the performance of commands run on the same connection.
+        ///
+        /// In these situations you can start up a separate client with the maximum number of
+        /// streams set to one to run operations that are expensive or affect the state of a connection.
+        public var maximumNumberOfStreamsPerConnection: UInt16
+
         /// The time that a _preserved_ idle connection stays in the
         /// pool before it is closed.
         public var idleTimeout: Duration
@@ -199,6 +215,7 @@ public struct ValkeyClientConfiguration: Sendable {
             self.idleTimeout = idleTimeout
             self.circuitBreakerTripAfter = circuitBreakerTripAfter
             self.maximumConcurrentConnectionRequests = maximumConcurrentConnectionRequests
+            self.maximumNumberOfStreamsPerConnection = 1
         }
     }
 

--- a/Tests/IntegrationTests/ClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/ClientIntegrationTests.swift
@@ -85,7 +85,7 @@ struct ClientIntegratedTests {
                 commandEncoder.encodeArray("GET", key)
             }
         }
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "ValkeyCommand")
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
@@ -99,7 +99,7 @@ struct ClientIntegratedTests {
     @Test("Test ValkeyConnection.withConnection()")
     @available(valkeySwift 1.0, *)
     func testWithConnectionSetGet() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "WithConnectionSetGet")
         logger.logLevel = .debug
         try await ValkeyConnection.withConnection(address: .hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
@@ -115,7 +115,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testSetGet() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "SetGet")
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
@@ -131,7 +131,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testClientSetGet() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "ClientSetGet")
         logger.logLevel = .debug
         try await withValkeyClient(.hostname(valkeyHostname, port: 6379), logger: logger) { valkeyClient in
             try await valkeyClient.set("sdf", value: "Hello")
@@ -145,7 +145,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testClientShutdown() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "ClientShutdown")
         logger.logLevel = .debug
         let client = ValkeyClient(.hostname(valkeyHostname, port: 6379), configuration: .init(), logger: logger)
         try await withThrowingTaskGroup(of: Void.self) { group in
@@ -166,7 +166,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testServiceLifecycleGracefulShutdown() async throws {
-        var logger = Logger(label: "ValkeyCluster")
+        var logger = Logger(label: "ServiceLifecycleGracefulShutdown")
         logger.logLevel = .trace
 
         let client = ValkeyClient(.hostname(valkeyHostname, port: 6379), configuration: .init(), logger: logger)
@@ -184,7 +184,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testBinarySetGet() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "BinarySetGet")
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
@@ -199,7 +199,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testSPOP() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "SPOP")
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
@@ -215,7 +215,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testUnixTime() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "UnixTime")
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
@@ -232,7 +232,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testPipelinedSetGet() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "PipelinedSetGet")
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
@@ -255,7 +255,7 @@ struct ClientIntegratedTests {
             let responses = await client.execute(commands)
             try #expect(responses[1].get().decode(as: String.self) == "Pipelined Hello")
         }
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "PipelinedProtocolSetGet")
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
@@ -267,7 +267,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testPipelinedSetGetClient() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "PipelinedSetGetClient")
         logger.logLevel = .debug
         try await withValkeyClient(.hostname(valkeyHostname, port: 6379), logger: logger) { client in
             try await withKey(connection: client) { key in
@@ -283,7 +283,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testAlternativePipelinedSetGet() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "AlternativePipelinedSetGet")
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
@@ -300,7 +300,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testAlternativePipelinedSetGetClient() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "AlternativePipelinedSetGetClient")
         logger.logLevel = .debug
         try await withValkeyClient(.hostname(valkeyHostname, port: 6379), logger: logger) { client in
             try await withKey(connection: client) { key in
@@ -317,7 +317,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testTransactionSetIncrGet() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "TransactionSetIncrGet")
         logger.logLevel = .trace
         try await withValkeyClient(.hostname(valkeyHostname, port: 6379), logger: logger) { client in
             try await withKey(connection: client) { key in
@@ -334,7 +334,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testInvalidTransactionSetIncrGet() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "InvalidTransactionSetIncrGet")
         logger.logLevel = .debug
         try await withValkeyClient(.hostname(valkeyHostname, port: 6379), logger: logger) { client in
             try await withKey(connection: client) { key in
@@ -368,7 +368,7 @@ struct ClientIntegratedTests {
                 commandEncoder.encodeArray("INVALID")
             }
         }
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "InvalidTransactionExecError")
         logger.logLevel = .debug
         try await withValkeyClient(.hostname(valkeyHostname, port: 6379), logger: logger) { client in
             let transactionError = await #expect(throws: ValkeyTransactionError.self) {
@@ -405,7 +405,7 @@ struct ClientIntegratedTests {
                 commandEncoder.encodeArray("INVALID")
             }
         }
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "InvalidArrayTransactionExecError")
         logger.logLevel = .debug
         try await withValkeyClient(.hostname(valkeyHostname, port: 6379), logger: logger) { client in
             let transactionError = await #expect(throws: ValkeyTransactionError.self) {
@@ -432,7 +432,7 @@ struct ClientIntegratedTests {
     @available(valkeySwift 1.0, *)
     func testWatch() async throws {
         let logger = {
-            var logger = Logger(label: "Valkey")
+            var logger = Logger(label: "Watch")
             logger.logLevel = .trace
             return logger
         }()
@@ -469,7 +469,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testSingleElementArray() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "SingleElementArray")
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
@@ -484,7 +484,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testCommandWithMoreThan9Strings() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "CommandWithMoreThan9Strings")
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
@@ -499,7 +499,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testSort() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "Sort")
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
@@ -515,7 +515,7 @@ struct ClientIntegratedTests {
     @available(valkeySwift 1.0, *)
     @Test("Test command error is thrown")
     func testCommandError() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "CommandError")
         logger.logLevel = .trace
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withKey(connection: connection) { key in
@@ -528,7 +528,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testMultiplexing() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "Multiplexing")
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withThrowingTaskGroup(of: Void.self) { group in
@@ -549,7 +549,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testMultiplexingPipelinedRequests() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "MultiplexingPipelinedRequests")
         logger.logLevel = .debug
         try await withValkeyConnection(.hostname(valkeyHostname, port: 6379), logger: logger) { connection in
             try await withThrowingTaskGroup(of: Void.self) { group in
@@ -575,7 +575,7 @@ struct ClientIntegratedTests {
     @available(valkeySwift 1.0, *)
     func testAuthentication() async throws {
         let logger = {
-            var logger = Logger(label: "Valkey")
+            var logger = Logger(label: "Authentication")
             logger.logLevel = .debug
             return logger
         }()
@@ -598,7 +598,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testAuthenticationFailure() async throws {
-        var logger = Logger(label: "testAuthenticationFailure")
+        var logger = Logger(label: "AuthenticationFailure")
         logger.logLevel = .trace
         try await withValkeyConnection(.hostname(valkeyHostname), logger: logger) { connection in
             try await connection.aclSetuser(username: "johnsmith", rules: ["on", ">3guygsf43", "+ACL|WHOAMI"])
@@ -617,7 +617,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testLoadsOfConnections() async throws {
-        var logger = Logger(label: "testLoadsOfConnections")
+        var logger = Logger(label: "LoadsOfConnections")
         logger.logLevel = .trace
         try await withValkeyClient(.hostname(valkeyHostname, port: 6379), logger: logger) { valkeyClient in
             try await withThrowingTaskGroup(of: Void.self) { group in
@@ -648,7 +648,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testBlockingCommandTimeout() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "BlockingCommandTimeout")
         logger.logLevel = .trace
         try await withValkeyConnection(
             .hostname(valkeyHostname, port: 6379),
@@ -670,7 +670,7 @@ struct ClientIntegratedTests {
     @available(valkeySwift 1.0, *)
     @Test
     func testClientInfo() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "ClientInfo")
         logger.logLevel = .trace
         try await withValkeyClient(.hostname(valkeyHostname, port: 6379), logger: logger) { client in
             let result = try await client.clientList()
@@ -689,7 +689,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testMultipleDB() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "MultipleDB")
         logger.logLevel = .debug
         // Test all default enabled databases in range {0,15}
         for dbNum in 0...15 {
@@ -723,7 +723,7 @@ struct ClientIntegratedTests {
     @Test
     @available(valkeySwift 1.0, *)
     func testMultipleStreamsPerConnection() async throws {
-        var logger = Logger(label: "Valkey")
+        var logger = Logger(label: "MultipleStreamsPerConnection")
         logger.logLevel = .info
 
         var connectionPoolConfiguration = ValkeyClientConfiguration.ConnectionPool()

--- a/Tests/IntegrationTests/ClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/ClientIntegrationTests.swift
@@ -719,6 +719,39 @@ struct ClientIntegratedTests {
             }
         }
     }
+
+    @Test
+    @available(valkeySwift 1.0, *)
+    func testMultipleStreamsPerConnection() async throws {
+        var logger = Logger(label: "Valkey")
+        logger.logLevel = .info
+
+        var connectionPoolConfiguration = ValkeyClientConfiguration.ConnectionPool()
+        connectionPoolConfiguration.maximumNumberOfStreamsPerConnection = 4
+        try await withValkeyConnection(
+            .hostname("127.0.0.1", port: 6379),
+            configuration: .init(connectionPool: connectionPoolConfiguration),
+            logger: logger
+        ) { client in
+            try await withThrowingTaskGroup { group in
+                for i in 0..<1024 {
+                    group.addTask {
+                        let key = ValkeyKey("testMultipleStreams\(i)")
+                        let (_, _, result, _) = await client.execute(
+                            SET(key, value: "\(i)"),
+                            INCR(key),
+                            GET(key),
+                            DEL(keys: [key])
+                        )
+                        let value = try result.get().map { String($0) }
+                        #expect(value == "\(i+1)")
+                    }
+                }
+                try await group.waitForAll()
+            }
+        }
+    }
+
 }
 
 extension ValkeyClientError: Equatable {

--- a/Tests/IntegrationTests/ClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/ClientIntegrationTests.swift
@@ -727,8 +727,10 @@ struct ClientIntegratedTests {
         logger.logLevel = .info
 
         var connectionPoolConfiguration = ValkeyClientConfiguration.ConnectionPool()
-        connectionPoolConfiguration.maximumNumberOfStreamsPerConnection = 4
-        try await withValkeyConnection(
+        connectionPoolConfiguration.maximumNumberOfStreamsPerConnection = 16
+        connectionPoolConfiguration.maximumConnectionHardLimit = 5
+        connectionPoolConfiguration.maximumConnectionSoftLimit = 5
+        try await withValkeyClient(
             .hostname("127.0.0.1", port: 6379),
             configuration: .init(connectionPool: connectionPoolConfiguration),
             logger: logger

--- a/Tests/IntegrationTests/ClientIntegrationTests.swift
+++ b/Tests/IntegrationTests/ClientIntegrationTests.swift
@@ -724,14 +724,14 @@ struct ClientIntegratedTests {
     @available(valkeySwift 1.0, *)
     func testMultipleStreamsPerConnection() async throws {
         var logger = Logger(label: "MultipleStreamsPerConnection")
-        logger.logLevel = .info
+        logger.logLevel = .trace
 
         var connectionPoolConfiguration = ValkeyClientConfiguration.ConnectionPool()
         connectionPoolConfiguration.maximumNumberOfStreamsPerConnection = 16
         connectionPoolConfiguration.maximumConnectionHardLimit = 5
         connectionPoolConfiguration.maximumConnectionSoftLimit = 5
         try await withValkeyClient(
-            .hostname("127.0.0.1", port: 6379),
+            .hostname(valkeyHostname, port: 6379),
             configuration: .init(connectionPool: connectionPoolConfiguration),
             logger: logger
         ) { client in
@@ -739,14 +739,16 @@ struct ClientIntegratedTests {
                 for i in 0..<1024 {
                     group.addTask {
                         let key = ValkeyKey("testMultipleStreams\(i)")
-                        let (_, _, result, _) = await client.execute(
+                        let (_, incrResult, getResult, _) = await client.execute(
                             SET(key, value: "\(i)"),
                             INCR(key),
                             GET(key),
                             DEL(keys: [key])
                         )
-                        let value = try result.get().map { String($0) }
-                        #expect(value == "\(i+1)")
+                        let incrValue = try incrResult.get()
+                        let getValue = try getResult.get().map { String($0) }
+                        #expect(incrValue == i + 1)
+                        #expect(getValue == "\(i+1)")
                     }
                 }
                 try await group.waitForAll()

--- a/Tests/ValkeyTests/ValkeyClientTests.swift
+++ b/Tests/ValkeyTests/ValkeyClientTests.swift
@@ -200,6 +200,42 @@ struct ValkeyClientTests {
 
     @Test
     @available(valkeySwift 1.0, *)
+    func testMultipleStreamsPerConnection() async throws {
+        var logger = Logger(label: "Valkey")
+        logger.logLevel = .debug
+        let topology = await self.healthyPrimaryWithTwoReplicas
+        let mockConnections = await topology.mock(logger: logger)
+        async let _ = mockConnections.run()
+        var connectionPoolConfiguration = ValkeyClientConfiguration.ConnectionPool()
+        connectionPoolConfiguration.maximumNumberOfStreamsPerConnection = 16
+        connectionPoolConfiguration.minimumConnectionCount = 1
+        connectionPoolConfiguration.maximumConnectionHardLimit = 20
+        connectionPoolConfiguration.maximumConnectionSoftLimit = 20
+        try await withValkeyClient(
+            .hostname("127.0.0.1", port: 9000),
+            mockConnections: mockConnections,
+            configuration: .init(connectionPool: connectionPoolConfiguration),
+            logger: logger
+        ) { client in
+            // prime connection pool to ensure we have a connection
+            try await client.set("foo", value: "bar")
+            try await withThrowingTaskGroup { group in
+                // run 16 commands concurrently
+                for _ in 0..<16 {
+                    group.addTask {
+                        try await client.set("foo", value: "bar")
+                    }
+                }
+                try await group.waitForAll()
+            }
+            // check we still only have one connection
+            let connectionCount = await mockConnections.serverInstances.count
+            #expect(connectionCount == 1)
+        }
+    }
+
+    @Test
+    @available(valkeySwift 1.0, *)
     func testReadFromReplica() async throws {
         var logger = Logger(label: "Valkey")
         logger.logLevel = .debug

--- a/Tests/ValkeyTests/ValkeyClientTests.swift
+++ b/Tests/ValkeyTests/ValkeyClientTests.swift
@@ -339,4 +339,38 @@ struct ValkeyClientTests {
             try #expect(results[4].get().decode(as: String.self) == "bar")
         }
     }
+
+    @Test
+    @available(valkeySwift 1.0, *)
+    func testMultipleStreamsPerConnection() async throws {
+        var logger = Logger(label: "Valkey")
+        logger.logLevel = .info
+        let topology = await self.healthyPrimaryWithTwoReplicas
+        let mockConnections = await topology.mock(logger: logger)
+        async let _ = mockConnections.run()
+
+        var connectionPoolConfiguration = ValkeyClientConfiguration.ConnectionPool()
+        connectionPoolConfiguration.maximumNumberOfStreamsPerConnection = 4
+        try await withValkeyClient(
+            .hostname("127.0.0.1", port: 9001),
+            mockConnections: mockConnections,
+            configuration: .init(connectionPool: connectionPoolConfiguration),
+            logger: logger
+        ) { client in
+            try await withThrowingTaskGroup { group in
+                for i in 0..<1024 {
+                    group.addTask {
+                        let key = ValkeyKey("testMultipleStreams\(i)")
+                        let (_, result) = await client.execute(
+                            SET(key, value: "\(i)"),
+                            GET(key)
+                        )
+                        let value = try result.get().map { String($0) }
+                        #expect(value == "\(i)")
+                    }
+                }
+                try await group.waitForAll()
+            }
+        }
+    }
 }

--- a/Tests/ValkeyTests/ValkeyClientTests.swift
+++ b/Tests/ValkeyTests/ValkeyClientTests.swift
@@ -339,38 +339,4 @@ struct ValkeyClientTests {
             try #expect(results[4].get().decode(as: String.self) == "bar")
         }
     }
-
-    @Test
-    @available(valkeySwift 1.0, *)
-    func testMultipleStreamsPerConnection() async throws {
-        var logger = Logger(label: "Valkey")
-        logger.logLevel = .info
-        let topology = await self.healthyPrimaryWithTwoReplicas
-        let mockConnections = await topology.mock(logger: logger)
-        async let _ = mockConnections.run()
-
-        var connectionPoolConfiguration = ValkeyClientConfiguration.ConnectionPool()
-        connectionPoolConfiguration.maximumNumberOfStreamsPerConnection = 4
-        try await withValkeyClient(
-            .hostname("127.0.0.1", port: 9001),
-            mockConnections: mockConnections,
-            configuration: .init(connectionPool: connectionPoolConfiguration),
-            logger: logger
-        ) { client in
-            try await withThrowingTaskGroup { group in
-                for i in 0..<1024 {
-                    group.addTask {
-                        let key = ValkeyKey("testMultipleStreams\(i)")
-                        let (_, result) = await client.execute(
-                            SET(key, value: "\(i)"),
-                            GET(key)
-                        )
-                        let value = try result.get().map { String($0) }
-                        #expect(value == "\(i)")
-                    }
-                }
-                try await group.waitForAll()
-            }
-        }
-    }
 }


### PR DESCRIPTION
Add option `ValkeyClientConfiguration.ConnectionPool.maximumNumberOfStreamsPerConnection ` to set number of streams a connection can support. This defaults to one, but increasing this will mean multiple processes can share connections and we can run with less open connections.

As this will mean we are sharing connections across processes this comes with a number of gotchas which are documented in the adjoining comment. Also if a command fails because a connection was closed due to cancellation it will retry it with a new connection.