### PR TITLE
Don't cancel other pending commands on command cancellation

### DIFF
--- a/Sources/Valkey/Connection/ValkeyChannelHandler+stateMachine.swift
+++ b/Sources/Valkey/Connection/ValkeyChannelHandler+stateMachine.swift
@@ -41,17 +41,16 @@ extension ValkeyChannelHandler {
             let context: Context
             var pendingCommands: Deque<PendingCommand>
 
-            func cancel(requestID: Int) -> (cancel: [PendingCommand], connectionClosedDueToCancellation: [PendingCommand]) {
-                var withRequestID = [PendingCommand]()
-                var withoutRequestID = [PendingCommand]()
-                for command in pendingCommands {
-                    if command.requestID == requestID {
-                        withRequestID.append(command)
-                    } else {
-                        withoutRequestID.append(command)
-                    }
+            mutating func cancel(requestID: Int) -> (cancel: [PendingCommand], stillPending: Bool) {
+                let index = pendingCommands.partition { $0.requestID == requestID }
+                let cancelled = [PendingCommand](pendingCommands[index...])
+                if index == pendingCommands.startIndex {
+                    pendingCommands.removeAll()
+                    return (cancelled, false)
+                } else {
+                    pendingCommands = .init(pendingCommands[..<index])
+                    return (cancelled, true)
                 }
-                return (withRequestID, withoutRequestID)
             }
         }
 
@@ -285,6 +284,7 @@ extension ValkeyChannelHandler {
 
         @usableFromInline
         enum CancelAction {
+            case failPendingCommands(cancel: [PendingCommand])
             case failPendingCommandsAndClose(Context, cancel: [PendingCommand], closeConnectionDueToCancel: [PendingCommand])
             case doNothing
         }
@@ -297,28 +297,38 @@ extension ValkeyChannelHandler {
                 preconditionFailure("Cannot cancel when initialized")
             case .connected:
                 preconditionFailure("Cannot cancel while in connected state")
-            case .active(let state):
-                let (cancel, closeConnectionDueToCancel) = state.cancel(requestID: requestID)
+            case .active(var state):
+                let (cancel, stillPending) = state.cancel(requestID: requestID)
                 if cancel.count > 0 {
-                    self = .closed(ValkeyClientError(.cancelled))
-                    return .failPendingCommandsAndClose(
-                        state.context,
-                        cancel: cancel,
-                        closeConnectionDueToCancel: closeConnectionDueToCancel
-                    )
+                    if stillPending {
+                        self = .closing(state)
+                        return .failPendingCommands(cancel: cancel)
+                    } else {
+                        self = .closed(ValkeyClientError(.cancelled))
+                        return .failPendingCommandsAndClose(
+                            state.context,
+                            cancel: cancel,
+                            closeConnectionDueToCancel: []
+                        )
+                    }
                 } else {
                     self = .active(state)
                     return .doNothing
                 }
-            case .closing(let state):
-                let (cancel, closeConnectionDueToCancel) = state.cancel(requestID: requestID)
+            case .closing(var state):
+                let (cancel, stillPending) = state.cancel(requestID: requestID)
                 if cancel.count > 0 {
-                    self = .closed(ValkeyClientError(.cancelled))
-                    return .failPendingCommandsAndClose(
-                        state.context,
-                        cancel: cancel,
-                        closeConnectionDueToCancel: closeConnectionDueToCancel
-                    )
+                    if stillPending {
+                        self = .closing(state)
+                        return .failPendingCommands(cancel: cancel)
+                    } else {
+                        self = .closed(ValkeyClientError(.cancelled))
+                        return .failPendingCommandsAndClose(
+                            state.context,
+                            cancel: cancel,
+                            closeConnectionDueToCancel: []
+                        )
+                    }
                 } else {
                     self = .closing(state)
                     return .doNothing

--- a/Sources/Valkey/Connection/ValkeyChannelHandler+stateMachine.swift
+++ b/Sources/Valkey/Connection/ValkeyChannelHandler+stateMachine.swift
@@ -42,14 +42,32 @@ extension ValkeyChannelHandler {
             var pendingCommands: Deque<PendingCommand>
 
             mutating func cancel(requestID: Int) -> (cancel: [PendingCommand], stillPending: Bool) {
-                let index = pendingCommands.partition { $0.requestID == requestID }
-                let cancelled = [PendingCommand](pendingCommands[index...])
-                if index == pendingCommands.startIndex {
-                    pendingCommands.removeAll()
-                    return (cancelled, false)
+                var cancelledCommands: [PendingCommand] = []
+                var lastPending: Deque<PendingCommand>.Index? = nil
+                for index in pendingCommands.indices {
+                    // record pending commands that should be cancelled and set their promise to forget
+                    // so when a response comes in it is ignored. If there are commands that shouldnt be
+                    // cancelled then record the index of the last command that shouldn't be cancelled
+                    if self.pendingCommands[index].requestID == requestID {
+                        cancelledCommands.append(self.pendingCommands[index])
+                        self.pendingCommands[index].promise = .forget
+                    } else {
+                        switch self.pendingCommands[index].promise {
+                        case .forget:
+                            break
+                        default:
+                            lastPending = index
+                        }
+                    }
+                }
+                if let lastPending {
+                    // drop any commands at the end of the list of pending commands whose results are to be ignored
+                    if lastPending != self.pendingCommands.index(before: self.pendingCommands.endIndex) {
+                        self.pendingCommands = .init(self.pendingCommands[...lastPending])
+                    }
+                    return (cancelledCommands, true)
                 } else {
-                    pendingCommands = .init(pendingCommands[..<index])
-                    return (cancelled, true)
+                    return (cancelledCommands, false)
                 }
             }
         }

--- a/Sources/Valkey/Connection/ValkeyChannelHandler+stateMachine.swift
+++ b/Sources/Valkey/Connection/ValkeyChannelHandler+stateMachine.swift
@@ -53,10 +53,10 @@ extension ValkeyChannelHandler {
                         self.pendingCommands[index].promise = .forget
                     } else {
                         switch self.pendingCommands[index].promise {
+                        case .nio, .swift:
+                            lastPending = index
                         case .forget:
                             break
-                        default:
-                            lastPending = index
                         }
                     }
                 }

--- a/Sources/Valkey/Connection/ValkeyChannelHandler.swift
+++ b/Sources/Valkey/Connection/ValkeyChannelHandler.swift
@@ -389,6 +389,10 @@ final class ValkeyChannelHandler: ChannelInboundHandler {
     func cancel(requestID: Int) {
         self.eventLoop.assertInEventLoop()
         switch self.stateMachine.cancel(requestID: requestID) {
+        case .failPendingCommands(let cancelled):
+            for command in cancelled {
+                command.promise.fail(ValkeyClientError.init(.cancelled))
+            }
         case .failPendingCommandsAndClose(let context, let cancelled, let closeConnectionDueToCancel):
             for command in cancelled {
                 command.promise.fail(ValkeyClientError.init(.cancelled))

--- a/Tests/ValkeyTests/ValkeyChannelHandlerStateMachineTests.swift
+++ b/Tests/ValkeyTests/ValkeyChannelHandlerStateMachineTests.swift
@@ -286,6 +286,31 @@ struct ValkeyChannelHandlerStateMachineTests {
         case .throwError:
             Issue.record("Invalid sendCommand action")
         }
+        switch stateMachine.cancel(requestID: 23) {
+        case .failPendingCommandsAndClose(let context, let cancel, _):
+            #expect(context == "testCancel")
+            #expect(cancel.map { $0.requestID } == [23])
+            break
+        default:
+            Issue.record("Invalid cancel action")
+        }
+        expect(stateMachine.state == .closed(ValkeyClientError(.cancelled)))
+        promise.fail(CancellationError())
+    }
+
+    @Test
+    @available(valkeySwift 1.0, *)
+    func testCancelWithPending() async throws {
+        var stateMachine = ValkeyChannelHandler.StateMachine<String>()  // set active
+        stateMachine.setConnected(context: "testCancelWithPending")
+        stateMachine.receiveHelloResponse()
+        let promise = EmbeddedEventLoop().makePromise(of: RESPToken.self)
+        switch stateMachine.sendCommand(.init(promise: .nio(promise), requestID: 23, deadline: .now())) {
+        case .sendCommand:
+            break
+        case .throwError:
+            Issue.record("Invalid sendCommand action")
+        }
         switch stateMachine.sendCommand(.init(promise: .nio(promise), requestID: 48, deadline: .now())) {
         case .sendCommand:
             break
@@ -293,10 +318,16 @@ struct ValkeyChannelHandlerStateMachineTests {
             Issue.record("Invalid sendCommand action")
         }
         switch stateMachine.cancel(requestID: 23) {
-        case .failPendingCommandsAndClose(let context, let cancel, let closeConnectionDueToCancel):
-            #expect(context == "testCancel")
+        case .failPendingCommands(let cancel):
             #expect(cancel.map { $0.requestID } == [23])
-            #expect(closeConnectionDueToCancel.map { $0.requestID } == [48])
+            break
+        default:
+            Issue.record("Invalid cancel action")
+        }
+        switch stateMachine.cancel(requestID: 48) {
+        case .failPendingCommandsAndClose(let context, let cancel, _):
+            #expect(context == "testCancelWithPending")
+            #expect(cancel.map { $0.requestID } == [48])
             break
         default:
             Issue.record("Invalid cancel action")
@@ -312,7 +343,7 @@ struct ValkeyChannelHandlerStateMachineTests {
         stateMachine.setConnected(context: "testCancel")
         stateMachine.receiveHelloResponse()
         switch stateMachine.cancel(requestID: 23) {
-        case .failPendingCommandsAndClose:
+        case .failPendingCommands, .failPendingCommandsAndClose:
             Issue.record("Invalid cancel action")
         case .doNothing:
             break

--- a/Tests/ValkeyTests/ValkeyChannelHandlerStateMachineTests.swift
+++ b/Tests/ValkeyTests/ValkeyChannelHandlerStateMachineTests.swift
@@ -324,6 +324,62 @@ struct ValkeyChannelHandlerStateMachineTests {
         default:
             Issue.record("Invalid cancel action")
         }
+        // Although we have cancelled request 23, we still receive the response
+        // This should have a forget promise and should do nothing in relation
+        // to the deadline
+        switch stateMachine.receivedResponse(token: RESPToken.ok) {
+        case .respond(let command, let deadlineAction):
+            #expect(command.requestID == 23)
+            // we cancelled this command so the promise should be forget
+            switch command.promise {
+            case .nio, .swift:
+                Issue.record()
+            case .forget:
+                break
+            }
+            #expect(deadlineAction == .doNothing)
+            break
+        default:
+            Issue.record("Invalid cancel action")
+        }
+        switch stateMachine.receivedResponse(token: RESPToken.ok) {
+        case .respondAndClose(let command, let error):
+            #expect(command.requestID == 48)
+            #expect(error == nil)
+            break
+        default:
+            Issue.record("Invalid cancel action")
+        }
+        expect(stateMachine.state == .closed(nil))
+        promise.fail(CancellationError())
+    }
+
+    @Test
+    @available(valkeySwift 1.0, *)
+    func testSecondCancelWithPending() async throws {
+        var stateMachine = ValkeyChannelHandler.StateMachine<String>()  // set active
+        stateMachine.setConnected(context: "testCancelWithPending")
+        stateMachine.receiveHelloResponse()
+        let promise = EmbeddedEventLoop().makePromise(of: RESPToken.self)
+        switch stateMachine.sendCommand(.init(promise: .nio(promise), requestID: 23, deadline: .now())) {
+        case .sendCommand:
+            break
+        case .throwError:
+            Issue.record("Invalid sendCommand action")
+        }
+        switch stateMachine.sendCommand(.init(promise: .nio(promise), requestID: 48, deadline: .now())) {
+        case .sendCommand:
+            break
+        case .throwError:
+            Issue.record("Invalid sendCommand action")
+        }
+        switch stateMachine.cancel(requestID: 23) {
+        case .failPendingCommands(let cancel):
+            #expect(cancel.map { $0.requestID } == [23])
+            break
+        default:
+            Issue.record("Invalid cancel action")
+        }
         switch stateMachine.cancel(requestID: 48) {
         case .failPendingCommandsAndClose(let context, let cancel, _):
             #expect(context == "testCancelWithPending")

--- a/Tests/ValkeyTests/ValkeyConnectionTests.swift
+++ b/Tests/ValkeyTests/ValkeyConnectionTests.swift
@@ -486,6 +486,7 @@ struct ConnectionTests {
 
     @Test
     @available(valkeySwift 1.0, *)
+    @available(iOS 26, macOS 26, tvOS 26, *)
     func testConnectionCloseDueToCancellation() async throws {
         let channel = NIOAsyncTestingChannel()
         let logger = Logger(label: "test")
@@ -493,7 +494,7 @@ struct ConnectionTests {
         try await channel.processHello()
 
         try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask {
+            group.addImmediateTask {
                 let result = try await connection.get("foo").map { String($0) }
                 #expect(result == "OK")
             }
@@ -509,6 +510,7 @@ struct ConnectionTests {
                 group.cancelAll()
             }
             try await channel.writeInbound(RESPToken(.simpleString("OK")).base)
+            try await channel.writeInbound(RESPToken(.simpleString("NOT OK")).base)
 
             await #expect(throws: ValkeyClientError(.connectionClosed)) {
                 _ = try await connection.get("foo").map { String($0) }

--- a/Tests/ValkeyTests/ValkeyConnectionTests.swift
+++ b/Tests/ValkeyTests/ValkeyConnectionTests.swift
@@ -494,10 +494,17 @@ struct ConnectionTests {
         try await channel.processHello()
 
         try await withThrowingTaskGroup(of: Void.self) { group in
+            #if compiler(>=6.2)
             group.addImmediateTask {
                 let result = try await connection.get("foo").map { String($0) }
                 #expect(result == "OK")
             }
+            #else
+            group.addTask {
+                let result = try await connection.get("foo").map { String($0) }
+                #expect(result == "OK")
+            }
+            #endif
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
                     await #expect(throws: ValkeyClientError(.cancelled)) {
@@ -510,8 +517,12 @@ struct ConnectionTests {
                 group.cancelAll()
             }
             try await channel.writeInbound(RESPToken(.simpleString("OK")).base)
+            #if compiler(>=6.2)
             try await channel.writeInbound(RESPToken(.simpleString("NOT OK")).base)
-
+            #else
+            // can't guarantee order, as we don't have addImmediateTask, so just output "OK" again
+            try await channel.writeInbound(RESPToken(.simpleString("OK")).base)
+            #endif
             await #expect(throws: ValkeyClientError(.connectionClosed)) {
                 _ = try await connection.get("foo").map { String($0) }
             }

--- a/Tests/ValkeyTests/ValkeyConnectionTests.swift
+++ b/Tests/ValkeyTests/ValkeyConnectionTests.swift
@@ -494,9 +494,8 @@ struct ConnectionTests {
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
-                await #expect(throws: ValkeyClientError(.connectionClosedDueToCancellation)) {
-                    _ = try await connection.get("foo").map { String($0) }
-                }
+                let result = try await connection.get("foo").map { String($0) }
+                #expect(result == "OK")
             }
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
@@ -508,6 +507,11 @@ struct ConnectionTests {
                 _ = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
                 _ = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
                 group.cancelAll()
+            }
+            try await channel.writeInbound(RESPToken(.simpleString("OK")).base)
+
+            await #expect(throws: ValkeyClientError(.connectionClosed)) {
+                _ = try await connection.get("foo").map { String($0) }
             }
         }
     }


### PR DESCRIPTION
This PR changes the affect of cancelling a command on the connection the command is running on.

Previously if a command was cancelled the connection the command was running on was closed and all other pending commands were failed with the error `.connectionClosedDueToCancellation`. The reasoning behind this was cancelling a command left the connection in an undefined state and we can't return a busy connection back to the connection pool.

This had one issue though. It meant that any other commands on that connection were also cancelled but without the knowledge of whether they actually occurred, which is problematic for non-idempotent commands like INCR.

This PR changes this to allow for pending commands to be processed, but also set the connection in the closing state, so once all the current pending commands have been processed the connection is closed and not returned to the connection pool. 
