### PR TITLE
docs: add Pub/Sub section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,28 @@ try await valkeyClient.withConnection { connection in
 }
 ```
 
+#### Subscriptions (Pub/Sub)
+
+Subscribe to one or more channels and process messages as an async sequence. When the closure exits, the client automatically unsubscribes.
+
+```swift
+try await valkeyClient.subscribe(to: "notifications") { stream in
+    for try await message in stream {
+        print("Received: \(message.message)")
+    }
+}
+
+When you subscribe from a `ValkeyClient`, the subscription runs on a dedicated connection, kept separate from the connection pool used for every other command. Because of this, you can publish and run other commands on the *same* client while a subscription is active, the client manages the two connections for you.
+
+```swift
+// The client keeps subscribe and publish on separate connections automatically.
+try await valkeyClient.publish(channel: "notifications", message: "hello")
+```
+
+> **Note:** In Valkey (as in Redis), a connection in subscribe mode cannot issue most other commands, which traditionally means opening a second connection to publish. `ValkeyClient` handles this transparently by keeping the subscription on its own connection.
+
+
+
 ### ValkeyClusterClient
 
 For [Cluster Mode](https://valkey.io/topics/cluster-tutorial/) Valkey deployments with automatic command routing, topology discovery, and live cluster topology changes.


### PR DESCRIPTION
The README covers Commands Execution, Pipelining, Transactions, and Connection Management for `ValkeyClient`, but has no Pub/Sub section. This PR adds a section under `ValkeyClient`, with a subscribe and a publish example:

It also documents a behaviour that is not mentioned anywhere: when you subscribe from a `ValkeyClient`, the subscription runs on its own dedicated connection, separate from the pool used for other commands. This means we can subscribe and publish on the same client without opening a second connection by ourselves.

I verified in two ways:

- In the source, `subscribe` to routes through [`_withSubscriptionConnection_`](https://github.com/valkey-io/valkey-swift/blob/f4a8915f1b8dcea303c4760babf130c6f896b5af/Sources/Valkey/Subscriptions/ValkeyClient%2Bsubscribe.swift#L18), which leases a dedicated connection via `leaseSubscriptionConnection`; INCR/PUBLISH use the normal pool.
- Running `CLIENT LIST` while connected showed two separate connections, one `cmd=subscribe` and one `cmd=publish`


Please let me know if this PR make any sense, and I appreciate any feedback.


Thanks, @stockholmux, for pointing out that this was worth documenting.