### PR TITLE
Fix typo in channel handler state machine

### DIFF
--- a/Sources/Valkey/Connection/ValkeyChannelHandler+stateMachine.swift
+++ b/Sources/Valkey/Connection/ValkeyChannelHandler+stateMachine.swift
@@ -407,7 +407,7 @@ extension ValkeyChannelHandler {
                 self = .closed(nil)
                 var pendingCommands = state.pendingCommands
                 pendingCommands.prepend(state.pendingHelloCommand)
-                return .failPendingCommandsAndClose(state.context, state.pendingCommands)
+                return .failPendingCommandsAndClose(state.context, pendingCommands)
             case .active(let state):
                 self = .closed(nil)
                 return .failPendingCommandsAndClose(state.context, state.pendingCommands)

--- a/Tests/ValkeyTests/ValkeyChannelHandlerStateMachineTests.swift
+++ b/Tests/ValkeyTests/ValkeyChannelHandlerStateMachineTests.swift
@@ -37,6 +37,39 @@ struct ValkeyChannelHandlerStateMachineTests {
 
     @Test
     @available(valkeySwift 1.0, *)
+    func testCloseBeforeHello() async throws {
+        var stateMachine = ValkeyChannelHandler.StateMachine<String>()
+        stateMachine.setConnected(context: "testCloseBeforeHello")
+        let state: ValkeyChannelHandler.StateMachine<String>.ConnectedState? =
+            switch stateMachine.state {
+            case .connected(let state): state
+            default: nil
+            }
+        guard let state else {
+            Issue.record("Invalid state")
+            return
+        }
+        expect(
+            stateMachine.state
+                == .connected(.init(context: "testCloseBeforeHello", pendingHelloCommand: state.pendingHelloCommand, pendingCommands: []))
+        )
+        switch stateMachine.close() {
+        case .failPendingCommandsAndClose(let context, let commands):
+            #expect(context == "testCloseBeforeHello")
+            #expect(commands.count == 1)
+            #expect(commands.first?.requestID == 0)
+            for command in commands {
+                // Just to avoid leaking the promise
+                command.promise.fail(ValkeyClientError(.connectionClosed))
+            }
+        default:
+            Issue.record("Invalid close action")
+        }
+        expect(stateMachine.state == .closed(nil))
+    }
+
+    @Test
+    @available(valkeySwift 1.0, *)
     func testClosed() async throws {
         var stateMachine = ValkeyChannelHandler.StateMachine<String>()
         stateMachine.setConnected(context: "testClosed")

--- a/Tests/ValkeyTests/ValkeyConnectionTests.swift
+++ b/Tests/ValkeyTests/ValkeyConnectionTests.swift
@@ -70,6 +70,23 @@ struct ConnectionTests {
 
     @Test
     @available(valkeySwift 1.0, *)
+    func testConnectionCreationHelloClose() async throws {
+        let channel = NIOAsyncTestingChannel()
+        let logger = Logger(label: "test")
+        _ = try await ValkeyConnection.setupChannelAndConnect(channel, configuration: .init(), logger: logger)
+
+        var outbound = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
+        let hello3 = RESPToken(.command(["HELLO", "3"])).base
+        #expect(outbound.readSlice(length: hello3.readableBytes) == hello3)
+        // write invalid RESPToken, it should return a ValkeyClientError with id `respParsingError`
+        let error = await #expect(throws: ValkeyClientError.self) {
+            try await channel.writeInbound(ByteBuffer(string: "ERROR"))
+        }
+        #expect(error?.errorCode == .respParsingError)
+    }
+
+    @Test
+    @available(valkeySwift 1.0, *)
     func testConnectionCreationHelloAuth() async throws {
         let channel = NIOAsyncTestingChannel()
         let logger = Logger(label: "test")


### PR DESCRIPTION
- Fixes a typo in the channel handler state machine, where a copy of the deque is created, and the `HELLO` command is prepended to it, but the original deque was then mistakenly returned with the action. Now the updated copy of the deque is returned.
- Adds a test that would fail without this fix